### PR TITLE
accept both 'function' and 'global function' for global functions

### DIFF
--- a/spec/declaration/global_function_spec.lua
+++ b/spec/declaration/global_function_spec.lua
@@ -1,0 +1,199 @@
+local tl = require("tl")
+
+describe("global function", function()
+   describe("type", function()
+      it("can have anonymous arguments", function()
+         local tokens = tl.lex([[
+            global f: function(number, string): boolean
+
+            f = function(a: number, b: string): boolean
+               return #b == a
+            end
+            local ok = f(3, "abc")
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors = tl.type_check(ast)
+         assert.same({}, errors)
+      end)
+
+      it("can have type variables", function()
+         local tokens = tl.lex([[
+            global f: function<`a, `b, `c>(`a, `b): `c
+
+            f = function(a: number, b: string): boolean
+               return #b == a
+            end
+            local ok = f(3, "abc")
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors = tl.type_check(ast)
+         assert.same({}, errors)
+      end)
+
+      it("can take names in arguments but names are ignored", function()
+         local tokens = tl.lex([[
+            global f: function(x: number, y: string): boolean
+
+            f = function(a: number, b: string): boolean
+               return #b == a
+            end
+            local ok = f(3, "abc")
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors = tl.type_check(ast)
+         assert.same({}, errors)
+      end)
+
+      it("can take typed vararg in arguments", function()
+         local tokens = tl.lex([[
+            global f: function(x: number, ...: string): boolean
+
+            f = function(a: number, ...: string): boolean
+               return #select(1, ...) == a
+            end
+            local ok = f(3, "abc")
+         ]])
+         local _, ast = tl.parse_program(tokens)
+         local errors = tl.type_check(ast)
+         assert.same({}, errors)
+      end)
+
+      it("cannot take untyped vararg", function()
+         local tokens = tl.lex([[
+            global f: function(number, ...): boolean
+
+            f = function(a: number, ...: string): boolean
+               return #select(1, ...) == a
+            end
+            local ok = f(3, "abc")
+         ]])
+         local syntax_errors = {}
+         local _ = tl.parse_program(tokens, syntax_errors)
+         assert.same("cannot have untyped '...' when declaring the type of an argument", syntax_errors[1].msg)
+      end)
+   end)
+
+   for _, decl in ipairs({ "function", "global function" }) do
+      describe("'" .. decl .. "'", function()
+         it("declaration", function()
+            local tokens = tl.lex([[
+               ]] .. decl .. [[ f(a: number, b: string): boolean
+                  return #b == a
+               end
+               local ok = f(3, "abc")
+            ]])
+            local _, ast = tl.parse_program(tokens)
+            local errors = tl.type_check(ast)
+            assert.same({}, errors)
+         end)
+
+         it("declaration with type variables", function()
+            local tokens = tl.lex([[
+               ]] .. decl .. [[ f<`a, `b>(a1: `a, a2: `a, b1: `b, b2: `b): `b
+                  if a1 == a2 then
+                     return b1
+                  else
+                     return b2
+                  end
+               end
+               local ok = f(10, 20, "hello", "world")
+            ]])
+            local _, ast = tl.parse_program(tokens)
+            local errors = tl.type_check(ast)
+            assert.same({}, errors)
+         end)
+
+         it("declaration with nil as return", function()
+            local tokens = tl.lex([[
+               ]] .. decl .. [[ f(a: number, b: string): nil
+                  return
+               end
+               local ok = f(3, "abc")
+            ]])
+            local _, ast = tl.parse_program(tokens)
+            local errors = tl.type_check(ast)
+            assert.same({}, errors)
+         end)
+
+         it("declaration with no return", function()
+            local tokens = tl.lex([[
+               ]] .. decl .. [[ f(a: number, b: string): ()
+                  return
+               end
+               f(3, "abc")
+            ]])
+            local _, ast = tl.parse_program(tokens)
+            local errors = tl.type_check(ast)
+            assert.same({}, errors)
+         end)
+
+         it("declaration with no return cannot be used in assignment", function()
+            local tokens = tl.lex([[
+               ]] .. decl .. [[ f(a: number, b: string): ()
+                  return
+               end
+               local x = f(3, "abc")
+            ]])
+            local _, ast = tl.parse_program(tokens)
+            local errors = tl.type_check(ast)
+            assert.same(1, #errors)
+            assert.same("assignment in declaration did not produce an initial value for variable 'x'", errors[1].msg)
+         end)
+
+         it("declaration with return nil can be used in assignment", function()
+            local tokens = tl.lex([[
+               ]] .. decl .. [[ f(a: number, b: string): nil
+                  return
+               end
+               local x = f(3, "abc")
+            ]])
+            local _, ast = tl.parse_program(tokens)
+            local errors = tl.type_check(ast)
+            assert.same(0, #errors)
+         end)
+
+         describe("with function arguments", function()
+            it("has ambiguity without parentheses in function type return", function()
+               local tokens = tl.lex([[
+                  ]] .. decl .. [[ map<`a, `b>(f: function(`a):`b, xs: {`a}): {`b}
+                     local r = {}
+                     for i, x in ipairs(xs) do
+                        r[i] = f(x)
+                     end
+                     return r
+                  end
+                  local function quoted(s: string): string
+                     return "'" .. s .. "'"
+                  end
+
+                  print(table.concat(map(quoted, {"red", "green", "blue"}), ", "))
+               ]])
+               local syntax_errors = {}
+               tl.parse_program(tokens, syntax_errors)
+               assert.same(1, syntax_errors[1].y)
+               assert.same(54 + #decl, syntax_errors[1].x)
+            end)
+
+            it("has no ambiguity with parentheses in function type return", function()
+               local tokens = tl.lex([[
+                  ]] .. decl .. [[ map<`a,`b>(f: function(`a):(`b), xs: {`a}): {`b}
+                     local r = {}
+                     for i, x in ipairs(xs) do
+                        r[i] = f(x)
+                     end
+                     return r
+                  end
+                  local function quoted(s: string): string
+                     return "'" .. s .. "'"
+                  end
+
+                  print(table.concat(map(quoted, {"red", "green", "blue"}), ", "))
+               ]])
+               local _, ast = tl.parse_program(tokens)
+               local errors = tl.type_check(ast)
+               assert.same({}, errors)
+            end)
+         end)
+      end)
+   end
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -1914,6 +1914,9 @@ local function parse_statement(tokens, i, errs)
       end
    elseif tokens[i].tk == "global" then
       i = i + 1
+      if tokens[i].tk == "function" then
+         return parse_function(tokens, i, errs)
+      end
       return parse_variable_declarations(tokens, i, errs, "global_declaration")
    elseif tokens[i].tk == "function" then
       return parse_function(tokens, i, errs)

--- a/tl.tl
+++ b/tl.tl
@@ -1914,6 +1914,9 @@ local function parse_statement(tokens: {Token}, i: number, errs: {ParseError}): 
       end
    elseif tokens[i].tk == "global" then
       i = i + 1
+      if tokens[i].tk == "function" then
+         return parse_function(tokens, i, errs)
+      end
       return parse_variable_declarations(tokens, i, errs, "global_declaration")
    elseif tokens[i].tk == "function" then
       return parse_function(tokens, i, errs)


### PR DESCRIPTION
Since `global` is accepted for variables in the same places where
`local` is, I suppose `global function` should be accepted as well
for consistency.

(Eventually the bare `function` syntax could produce a warning
in .tl files, but for now we accept both forms...)

Closes #72 