### PR TITLE
Add command-line flag to disable compat53 insertions

### DIFF
--- a/spec/cli/gen_spec.lua
+++ b/spec/cli/gen_spec.lua
@@ -77,8 +77,7 @@ describe("tl gen", function()
       end)
    end)
 
-   describe("with/without --skip-compat53", function()
-
+   describe("with --skip-compat53", function()
       it("does not add compat53 insertions", function()
          local name = util.write_tmp_file(finally, "test.tl", [[
             local t = {1, 2, 3, 4}
@@ -94,8 +93,9 @@ describe("tl gen", function()
             print(table.unpack(t))
          ]], util.read_file(lua_name))
       end)
+   end)
 
-
+   describe("without --skip-compat53", function()
       it("adds compat53 insertions by default", function()
          local name = util.write_tmp_file(finally, "test.tl", [[
             local t = {1, 2, 3, 4}
@@ -111,6 +111,6 @@ describe("tl gen", function()
             print(_tl_table_unpack(t))
          ]], util.read_file(lua_name))
       end)
-
    end)
+
 end)

--- a/tl
+++ b/tl
@@ -72,6 +72,8 @@ local function get_args_parser()
          :argname("<modulename>")
          :count("*")
 
+   parser:flag("--skip-compat53", "Skip compat53 insertions.")
+
    parser:command_target("command")
 
    local check_command = parser:command("check", "Type-check one or more tl script.")
@@ -141,6 +143,27 @@ local env = nil
 
 for i, filename in ipairs(args["script"]) do
    local modules = i == 1 and tlconfig.preload_modules
+
+   if not env then
+      local basename, extension = filename:match("(.*)%.([a-z]+)$")
+      extension = extension and extension:lower()
+
+      local lax_mode
+      if extension == "tl" then
+         lax_mode = false
+      elseif extension == "lua" then
+         lax_mode = true
+      else
+         -- if we can't decide based on the file extension, default to strict
+         -- mode
+         lax_mode = false
+      end
+
+      local skip_compat53 = args["skip_compat53"]
+
+      env = tl.init_env(lax_mode, skip_compat53)
+   end
+
    local result, err = tl.process(filename, env, nil, modules)
    if err then
       die(err)

--- a/tl.lua
+++ b/tl.lua
@@ -3,6 +3,7 @@ local assert = require('compat53.module').assert or assert; local io = require('
 
 
 
+
 local TypeCheckOptions = {}
 
 
@@ -14,6 +15,7 @@ local TypeCheckOptions = {}
 local tl = {
    ["process"] = nil,
    ["type_check"] = nil,
+   ["init_env"] = nil,
 }
 
 
@@ -3441,16 +3443,17 @@ local function init_globals(lax)
    return globals
 end
 
-local function init_env(lax)
+function tl.init_env(lax, skip_compat53)
    return {
       ["modules"] = {},
       ["globals"] = init_globals(lax),
+      ["skip_compat53"] = skip_compat53,
    }
 end
 
 function tl.type_check(ast, opts)
    opts = opts or {}
-   opts.env = opts.env or init_env(opts.lax)
+   opts.env = opts.env or tl.init_env(opts.lax, opts.skip_compat53)
    local lax = opts.lax
    local filename = opts.filename
    local result = opts.result or {
@@ -5708,7 +5711,7 @@ function tl.process(filename, env, result, preload_modules)
       is_lua = input:match("^#![^\n]*lua[^\n]*\n")
    end
 
-   env = env or init_env(is_lua)
+   env = env or tl.init_env(is_lua)
    result = result or {
       ["syntax_errors"] = {},
       ["type_errors"] = {},
@@ -5748,6 +5751,7 @@ function tl.process(filename, env, result, preload_modules)
       ["filename"] = filename,
       ["env"] = env,
       ["result"] = result,
+      ["skip_compat53"] = env.skip_compat53,
    }
    error, unknown, result.type = tl.type_check(program, opts)
 

--- a/tl.tl
+++ b/tl.tl
@@ -1,6 +1,7 @@
 local Env = record
    globals: {string:Variable}
    modules: {string:Type}
+   skip_compat53: boolean
 end
 
 local TypeCheckOptions = record
@@ -14,6 +15,7 @@ end
 local tl = {
    process: function(string, Env, Result, {string}): (Result, string) = nil,
    type_check: function(Node, TypeCheckOptions): ({Error}, {Error}, Type) = nil,
+   init_env: function(boolean, boolean): Env = nil,
 }
 
 --------------------------------------------------------------------------------
@@ -3441,16 +3443,17 @@ local function init_globals(lax: boolean): {string:Variable}
    return globals
 end
 
-local function init_env(lax: boolean): Env
+function tl.init_env(lax: boolean, skip_compat53: boolean): Env
    return {
       modules = {},
       globals = init_globals(lax),
+      skip_compat53 = skip_compat53,
    }
 end
 
 function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Type
    opts = opts or {}
-   opts.env = opts.env or init_env(opts.lax)
+   opts.env = opts.env or tl.init_env(opts.lax, opts.skip_compat53)
    local lax = opts.lax
    local filename = opts.filename
    local result = opts.result or {
@@ -5708,7 +5711,7 @@ function tl.process(filename: string, env: Env, result: Result, preload_modules:
       is_lua = input:match("^#![^\n]*lua[^\n]*\n") as boolean
    end
 
-   env = env or init_env(is_lua)
+   env = env or tl.init_env(is_lua)
    result = result or {
       syntax_errors = {},
       type_errors = {},
@@ -5748,6 +5751,7 @@ function tl.process(filename: string, env: Env, result: Result, preload_modules:
       filename = filename,
       env = env,
       result = result,
+      skip_compat53 = env.skip_compat53,
    }
    error, unknown, result.type = tl.type_check(program, opts)
 


### PR DESCRIPTION
This PR adds a command-line flag to skip compat53 insertions.

The flag `skip_compat53`, that is already used in `TypeCheckOptions`, is now exposed as a command-line option. The flag can be set with `--skip-compat53` from the command line, and is then passed to `tl.process` in `env`.

Example:

```shell
% # This file uses table.unpack, which would usually trigger the compat53 inserts.
% cat test.tl
local t = {1, 2, 3, 4}
print(table.unpack(t))

% # When passing --skip-compat53, compat53 inserts are not added
% tl --skip-compat53 gen test.tl
Wrote: test.lua

% cat test.lua
local t = { [1] = 1, [2] = 2, [3] = 3, [4] = 4, }
print(table.unpack(t))

% # Without the flag, compat53 inserts are added
% tl gen test.tl
Wrote: test.lua

% cat test.lua
local table = require('compat53.module').table or table; local _tl_table_unpack = unpack or table.unpack; local t = { [1] = 1, [2] = 2, [3] = 3, [4] = 4, }
print(_tl_table_unpack(t))

```

I'm open to any form of feedback or suggestions :)

So far there's no option to set this flag from the tl loader, but as far as I can tell the compat53 insertions are never added with the loader.

Resolves #78 