### PR TITLE
No backticks!

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -93,15 +93,13 @@ precedence, see below.
 
 *  basetype ::= ‘string’ | ‘boolean’ | ‘nil’ | ‘number’ |
 *      ‘{’ type ‘}’ | ‘{’ type ‘:’ type ‘}’ | ‘function’ functiontype
-*      typevar | Name [typeargs]
-
-*  typevar ::= ‘`’ Name
+*      | Name [typeargs]
 
 *  typelist ::= type {‘,’ type}
 
 *  retlist ::= ‘:’ ‘(’ [typelist] [‘...’] ‘)’ | ‘:’ typelist [‘...’]
 
-*  typeargs ::= ‘<’ typevar {‘,’ typevar} ‘>’
+*  typeargs ::= ‘<’ Name {‘,’ Name } ‘>’
 
 *  newtype ::= ‘record’ [typeargs] [‘{’ type ‘}’] {Name ‘:’ type} ‘end’ |
 *      ‘enum’ {LiteralString} ‘end’ |

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -383,12 +383,11 @@ be organized as a tree using its array part.
 Teal supports a simple form of generics that is useful enough for dealing
 collections and algorithms that operate over abstract data types.
 
-You can use type variables (annotated with a backtick) wherever a type is
-used, and you can declare them in both functions and records. Here's an
-example of a generic function:
+You can use type variables wherever a type is used, and you can declare them
+in both functions and records. Here's an example of a generic function:
 
 ```
-local function keys<`K,`V>(xs: {`K:`V}):{`K}
+local function keys<K,V>(xs: {K:V}):{K}
    local ks = {}
    for k, v in pairs(xs) do
       table.insert(ks, k)
@@ -403,9 +402,9 @@ we declare the type variables in angle brackets and use them as types. Generic
 records are declared and used like this:
 
 ```
-local Tree = record<`X>
-   {Tree<`X>}
-   item: `X
+local Tree = record<X>
+   {Tree<X>}
+   item: X
 end
 
 local t: Tree<number> = {
@@ -447,9 +446,9 @@ callbacks. This is done with using `functiontype`, and they can be generic as
 well:
 
 ```
-local Comparator = functiontype<`T>(`T, `T): boolean
+local Comparator = functiontype<T>(T, T): boolean
 
-local function mysort<`A>(arr: {`A}, cmp: Comparator<`A>)
+local function mysort<A>(arr: {A}, cmp: Comparator<A>)
    -- ...
 end
 ```

--- a/spec/call/generic_function_spec.lua
+++ b/spec/call/generic_function_spec.lua
@@ -5,7 +5,7 @@ describe("generic function", function()
    it("can declare a generic functiontype", function()
       -- pass
       local tokens = tl.lex([[
-         local ParseItem = functiontype<`T>(number): `T
+         local ParseItem = functiontype<T>(number): T
       ]])
       local _, ast = tl.parse_program(tokens)
       local errors = tl.type_check(ast)
@@ -14,9 +14,9 @@ describe("generic function", function()
    it("can declare a function using the functiontype as an argument", function()
       -- pass
       local tokens = tl.lex([[
-         local ParseItem = functiontype<`T>(number): `T
+         local ParseItem = functiontype<T>(number): T
 
-         local function parse_list<`T>(list: {`T}, parse_item: ParseItem): number, `T
+         local function parse_list<T>(list: {T}, parse_item: ParseItem): number, T
             return 0, list[1]
          end
       ]])
@@ -27,10 +27,10 @@ describe("generic function", function()
    it("can use the typevar in the function body", function()
       -- pass
       local tokens = tl.lex([[
-         local ParseItem = functiontype<`T>(number): `T
+         local ParseItem = functiontype<T>(number): T
 
-         local function parse_list<`T>(list: {`T}, parse_item: ParseItem): number, {`T}
-            local ret: {`T} = {}
+         local function parse_list<T>(list: {T}, parse_item: ParseItem): number, {T}
+            local ret: {T} = {}
             local n = 0
             return n, ret
          end
@@ -42,13 +42,13 @@ describe("generic function", function()
    it("can use the function along with a typevar", function()
       -- pass
       local tokens = tl.lex([[
-         local Id = functiontype<`a>(`a): `a
+         local Id = functiontype<a>(a): a
 
          local function string_id(a: string): string
             return a
          end
 
-         local function use_id<`T>(v: `T, id: Id<`T>): `T
+         local function use_id<T>(v: T, id: Id<T>): T
             return id(v)
          end
 
@@ -61,9 +61,9 @@ describe("generic function", function()
    it("does not mix up typevars with the same name in different scopes", function()
       -- pass
       local tokens = tl.lex([[
-         local Convert = functiontype<`a, `b>(`a): `b
+         local Convert = functiontype<a, b>(a): b
 
-         local function id<`a>(x: `a): `a
+         local function id<a>(x: a): a
             return x
          end
 
@@ -71,7 +71,7 @@ describe("generic function", function()
             return tostring(n)
          end
 
-         local function use_conv<`X, `Y>(x: `X, cvt: Convert<`X, `Y>): `Y
+         local function use_conv<X, Y>(x: X, cvt: Convert<X, Y>): Y
             return id(cvt(x))
          end
 
@@ -86,7 +86,7 @@ describe("generic function", function()
    it("catches incorrect typevars, does not mix up multiple uses", function()
       -- fail
       local tokens = tl.lex([[
-         local Convert = functiontype<`a, `b>(`a): `b
+         local Convert = functiontype<a, b>(a): b
 
          local function convert_num_str(n: number): string
             return tostring(n)
@@ -96,7 +96,7 @@ describe("generic function", function()
             return tonumber(s)
          end
 
-         local function use_conv<`X,`Y>(x: `X, cvt: Convert<`X, `Y>, tvc: Convert<`X, `Y>): `Y -- tvc is not flipped!
+         local function use_conv<X,Y>(x: X, cvt: Convert<X, Y>, tvc: Convert<X, Y>): Y -- tvc is not flipped!
             return cvt(tvc(cvt(x)))
          end
 
@@ -115,13 +115,13 @@ describe("generic function", function()
    it("will catch if resolved typevar does not match", function()
       -- pass
       local tokens = tl.lex([[
-         local Id = functiontype<`a>(`a): `a
+         local Id = functiontype<a>(a): a
 
          local function string_id(a: string): string
             return a
          end
 
-         local function use_id<`T>(v: `T, id: Id<`T>): `T
+         local function use_id<T>(v: T, id: Id<T>): T
             return id(v)
          end
 
@@ -136,13 +136,13 @@ describe("generic function", function()
    it("can use the function along with an indirect typevar", function()
       -- pass
       local tokens = tl.lex([[
-         local Id = functiontype<`a>(`a): `a
+         local Id = functiontype<a>(a): a
 
          local function string_id(a: string): string
             return a
          end
 
-         local function use_id<`T>(v: {`T}, id: Id<`T>): `T
+         local function use_id<T>(v: {T}, id: Id<T>): T
             return id(v[1])
          end
 
@@ -155,13 +155,13 @@ describe("generic function", function()
    it("will catch if resolved indirect typevar does not match", function()
       -- pass
       local tokens = tl.lex([[
-         local Id = functiontype<`a>(`a): `a
+         local Id = functiontype<a>(a): a
 
          local function string_id(a: string): string
             return a
          end
 
-         local function use_id<`T>(v: {`T}, id: Id<`T>): `T
+         local function use_id<T>(v: {T}, id: Id<T>): T
             return id(v[1])
          end
 
@@ -177,10 +177,10 @@ describe("generic function", function()
    it("can use the function along with an indirect typevar", function()
       -- pass
       local tokens = tl.lex([[
-         local ParseItem = functiontype<`X>(number): `X
+         local ParseItem = functiontype<X>(number): X
 
-         local function parse_list<`T>(list: {`T}, parse_item: ParseItem<`T>): number, {`T}
-            local ret: {`T} = {}
+         local function parse_list<T>(list: {T}, parse_item: ParseItem<T>): number, {T}
+            local ret: {T} = {}
             local n = 0
             for i, t in ipairs(list) do
                n = i
@@ -208,7 +208,7 @@ describe("generic function", function()
    it("can use a typevar from an argument as the function return type", function()
       -- ok
       local tokens = tl.lex([[
-         local function parse_list<`T>(list: {`T}): `T
+         local function parse_list<T>(list: {T}): T
             return list[1]
          end
       ]])
@@ -219,20 +219,20 @@ describe("generic function", function()
    it("will catch if typevar is unbound", function()
       -- fail
       local tokens = tl.lex([[
-         local function parse_list<`T>(list: {`T}): `T
+         local function parse_list<T>(list: {T}): T
             return true
          end
       ]])
       local _, ast = tl.parse_program(tokens)
       local errors = tl.type_check(ast)
       assert.same(1, #errors)
-      assert.match("got boolean, expected `T", errors[1].msg, 1, true)
+      assert.match("got boolean, expected T", errors[1].msg, 1, true)
    end)
    it("will accept if typevar is bound at a higher level", function()
       -- fail
       local tokens = tl.lex([[
-         local function fun<`T>()
-            local function parse_list<`T>(list: {`T}): `T
+         local function fun<T>()
+            local function parse_list<T>(list: {T}): T
                return list[1]
             end
          end
@@ -244,14 +244,14 @@ describe("generic function", function()
    it("will catch if return value does not match the typevar", function()
       -- fail
       local tokens = tl.lex([[
-         local function parse_list<`T>(list: {`T}): `T
+         local function parse_list<T>(list: {T}): T
             return true
          end
       ]])
       local _, ast = tl.parse_program(tokens)
       local errors = tl.type_check(ast)
       assert.same(1, #errors)
-      assert.match("got boolean, expected `T", errors[1].msg, 1, true)
+      assert.match("got boolean, expected T", errors[1].msg, 1, true)
    end)
    it("will catch if argument value does not match the typevar", function()
       -- fail
@@ -261,7 +261,7 @@ describe("generic function", function()
             x: number
          end
 
-         local function insert<`a>(list: {`a}, item: `a)
+         local function insert<a>(list: {a}, item: a)
             table.insert(list, item)
          end
 
@@ -277,10 +277,10 @@ describe("generic function", function()
    it("will catch if resolved typevar does not match", function()
       -- fail
       local tokens = tl.lex([[
-         local ParseItem = functiontype<`V>(number): `V
+         local ParseItem = functiontype<V>(number): V
 
-         local function parse_list<`T>(list: {`T}, parse_item: ParseItem<`T>): number, {`T}
-            local ret: {`T} = {}
+         local function parse_list<T>(list: {T}, parse_item: ParseItem<T>): number, {T}
+            local ret: {T} = {}
             local n = 0
             for i, t in ipairs(list) do
                n = i
@@ -313,10 +313,10 @@ describe("generic function", function()
    it("can map one typevar to another", function()
       -- pass
       local tokens = tl.lex([[
-         local ParseItem = functiontype<`V>(number): `V
+         local ParseItem = functiontype<V>(number): V
 
-         local function parse_list<`T>(list: {`T}, parse_item: ParseItem<`T>): number, {`T}
-            local ret: {`T} = {}
+         local function parse_list<T>(list: {T}, parse_item: ParseItem<T>): number, {T}
+            local ret: {T} = {}
             local n = 0
             for i, t in ipairs(list) do
                n = i
@@ -345,10 +345,10 @@ describe("generic function", function()
       local Node = record
       end
 
-      local VisitorCallbacks = record<`X, `Y>
+      local VisitorCallbacks = record<X, Y>
       end
 
-      local function recurse_node<`T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>}): `T
+      local function recurse_node<T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, T>}, visit_type: {string:VisitorCallbacks<Type, T>}): T
       end
 
       local function pretty_print_ast(ast: Node): string
@@ -357,7 +357,7 @@ describe("generic function", function()
          return recurse_node(ast, visit_node, visit_type)
       end
    ]], {
-      { msg = "unknown type Type", x = 136 },
+      { msg = "unknown type Type", x = 134 },
       { msg = "unknown type Type", x = 53 }
    }))
    it("propagates resolved typevar in return type", function()
@@ -368,10 +368,10 @@ describe("generic function", function()
          local Type = record
          end
 
-         local VisitorCallbacks = record<`N, `X>
+         local VisitorCallbacks = record<N, X>
          end
 
-         local function recurse_node<`T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>}): `T
+         local function recurse_node<T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, T>}, visit_type: {string:VisitorCallbacks<Type, T>}): T
          end
 
          local function pretty_print_ast(ast: Node): string
@@ -393,10 +393,10 @@ describe("generic function", function()
          local Type = record
          end
 
-         local VisitorCallbacks = record<`X, `Y>
+         local VisitorCallbacks = record<X, Y>
          end
 
-         local function recurse_node<`T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>}): `T
+         local function recurse_node<T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, T>}, visit_type: {string:VisitorCallbacks<Type, T>}): T
          end
 
          local function pretty_print_ast(ast: Node): string
@@ -416,10 +416,10 @@ describe("generic function", function()
          local Type = record
          end
 
-         local VisitorCallbacks = record<`X, `Y>
+         local VisitorCallbacks = record<X, Y>
          end
 
-         local function recurse_node<`T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, `T>}, visit_type: {string:VisitorCallbacks<Type, `T>})
+         local function recurse_node<T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, T>}, visit_type: {string:VisitorCallbacks<Type, T>})
          end
 
          local function pretty_print_ast(ast: Node): string
@@ -431,7 +431,7 @@ describe("generic function", function()
       local _, ast = tl.parse_program(tokens)
       local errors = tl.type_check(ast)
       assert.same(1, #errors)
-      assert.match("argument 3: type parameter <`T>: got number, expected string", errors[1].msg, 1, true)
+      assert.match("argument 3: type parameter <T>: got number, expected string", errors[1].msg, 1, true)
       assert.same(43, errors[1].x)
    end)
    it("inference trickles down to function arguments", function()
@@ -472,7 +472,7 @@ describe("generic function", function()
    end)
    it("does not leak an unresolved generic type", function()
       local tokens = tl.lex([[
-         function mypairs<`a, `b>(map: {`a:`b}): (`a, `b)
+         function mypairs<a, b>(map: {a:b}): (a, b)
          end
 
          local _, resolved   = mypairs({["hello"] = true})
@@ -489,9 +489,9 @@ describe("generic function", function()
       assert.same("unknown", ast[3].exps[1].type[2].typename)
    end)
    it("does not produce a recursive type", util.lax_check([[
-      function mypairs<`a, `b>(map: {`a:`b}): (`a, `b)
+      function mypairs<a, b>(map: {a:b}): (a, b)
       end
-      function myipairs<`a>(array: {`a}): (`a)
+      function myipairs<a>(array: {a}): (a)
       end
 
       local _, xs = mypairs(xss)
@@ -510,7 +510,7 @@ describe("generic function", function()
    }))
 
    pending("check that 'any' matches any type variable", util.check [[
-      local function map<`X, `Y>(xs: {`X}, f: function(`X):`Y): {`Y}
+      local function map<X, Y>(xs: {X}, f: function(X):Y): {Y}
          local rs = {}
          for i, v in ipairs(xs) do
             rs[i] = f(v)

--- a/spec/declaration/global_function_spec.lua
+++ b/spec/declaration/global_function_spec.lua
@@ -18,7 +18,7 @@ describe("global function", function()
 
       it("can have type variables", function()
          local tokens = tl.lex([[
-            global f: function<`a, `b, `c>(`a, `b): `c
+            global f: function<a, b, c>(a, b): c
 
             f = function(a: number, b: string): boolean
                return #b == a
@@ -89,7 +89,7 @@ describe("global function", function()
 
          it("declaration with type variables", function()
             local tokens = tl.lex([[
-               ]] .. decl .. [[ f<`a, `b>(a1: `a, a2: `a, b1: `b, b2: `b): `b
+               ]] .. decl .. [[ f<a, b>(a1: a, a2: a, b1: b, b2: b): b
                   if a1 == a2 then
                      return b1
                   else
@@ -155,7 +155,7 @@ describe("global function", function()
          describe("with function arguments", function()
             it("has ambiguity without parentheses in function type return", function()
                local tokens = tl.lex([[
-                  ]] .. decl .. [[ map<`a, `b>(f: function(`a):`b, xs: {`a}): {`b}
+                  ]] .. decl .. [[ map<a, b>(f: function(a):b, xs: {a}): {b}
                      local r = {}
                      for i, x in ipairs(xs) do
                         r[i] = f(x)
@@ -171,12 +171,12 @@ describe("global function", function()
                local syntax_errors = {}
                tl.parse_program(tokens, syntax_errors)
                assert.same(1, syntax_errors[1].y)
-               assert.same(54 + #decl, syntax_errors[1].x)
+               assert.same(50 + #decl, syntax_errors[1].x)
             end)
 
             it("has no ambiguity with parentheses in function type return", function()
                local tokens = tl.lex([[
-                  ]] .. decl .. [[ map<`a,`b>(f: function(`a):(`b), xs: {`a}): {`b}
+                  ]] .. decl .. [[ map<a,b>(f: function(a):(b), xs: {a}): {b}
                      local r = {}
                      for i, x in ipairs(xs) do
                         r[i] = f(x)

--- a/spec/declaration/local_function_spec.lua
+++ b/spec/declaration/local_function_spec.lua
@@ -19,7 +19,7 @@ describe("local function", function()
 
       it("can have type variables", function()
          local tokens = tl.lex([[
-            local f: function<`a, `b, `c>(`a, `b): `c
+            local f: function<a, b, c>(a, b): c
 
             f = function(a: number, b: string): boolean
                return #b == a
@@ -99,7 +99,7 @@ describe("local function", function()
 
    it("declaration with type variables", function()
       local tokens = tl.lex([[
-         local function f<`a, `b>(a1: `a, a2: `a, b1: `b, b2: `b): `b
+         local function f<a, b>(a1: a, a2: a, b1: b, b2: b): b
             if a1 == a2 then
                return b1
             else
@@ -165,7 +165,7 @@ describe("local function", function()
    describe("with function arguments", function()
       it("has ambiguity without parentheses in function type return", function()
          local tokens = tl.lex([[
-            local function map(f: function(`a):`b, xs: {`a}): {`b}
+            local function map(f: function(a):b, xs: {a}): {b}
                local r = {}
                for i, x in ipairs(xs) do
                   r[i] = f(x)
@@ -181,12 +181,12 @@ describe("local function", function()
          local syntax_errors = {}
          tl.parse_program(tokens, syntax_errors)
          assert.same(1, syntax_errors[1].y)
-         assert.same(54, syntax_errors[1].x)
+         assert.same(52, syntax_errors[1].x)
       end)
 
       it("has no ambiguity with parentheses in function type return", function()
          local tokens = tl.lex([[
-            local function map<`a,`b>(f: function(`a):(`b), xs: {`a}): {`b}
+            local function map<a,b>(f: function(a):(b), xs: {a}): {b}
                local r = {}
                for i, x in ipairs(xs) do
                   r[i] = f(x)

--- a/spec/declaration/record_method_spec.lua
+++ b/spec/declaration/record_method_spec.lua
@@ -28,7 +28,7 @@ describe("record method", function()
             x = 2,
             b = true,
          }
-         function r:f<`T>(a: number, b: string, xs: {`T}): boolean, `T
+         function r:f<T>(a: number, b: string, xs: {T}): boolean, T
             if self.b then
                return #b == 3, xs[1]
             else

--- a/tl.lua
+++ b/tl.lua
@@ -2177,7 +2177,7 @@ visit_type)
          if cbs.before_e2 then
             cbs.before_e2(ast, xs)
          end
-         if ast.op.op == "is" then
+         if ast.op.op == "is" or ast.op.op == "as" then
             xs[3] = recurse_type(ast.e2.casttype, visit_type)
          else
             xs[3] = recurse_node(ast.e2, visit_node, visit_type)

--- a/tl.lua
+++ b/tl.lua
@@ -2765,12 +2765,12 @@ local VARARG_ANY = a_type({ ["typename"] = "any", ["is_va"] = true, })
 local VARARG_STRING = a_type({ ["typename"] = "string", ["is_va"] = true, })
 local VARARG_NUMBER = a_type({ ["typename"] = "number", ["is_va"] = true, })
 local VARARG_UNKNOWN = a_type({ ["typename"] = "unknown", ["is_va"] = true, })
+local VARARG_ALPHA = a_type({ ["typename"] = "typevar", ["typevar"] = "@a", ["is_va"] = true, })
 local BOOLEAN = a_type({ ["typename"] = "boolean", })
-local ARG_ALPHA = a_type({ ["typename"] = "typearg", ["typearg"] = "`a", })
-local ARG_BETA = a_type({ ["typename"] = "typearg", ["typearg"] = "`b", })
-local ALPHA = a_type({ ["typename"] = "typevar", ["typevar"] = "`a", })
-local BETA = a_type({ ["typename"] = "typevar", ["typevar"] = "`b", })
-local ARRAY_OF_ANY = a_type({ ["typename"] = "array", ["elements"] = ANY, })
+local ARG_ALPHA = a_type({ ["typename"] = "typearg", ["typearg"] = "@a", })
+local ARG_BETA = a_type({ ["typename"] = "typearg", ["typearg"] = "@b", })
+local ALPHA = a_type({ ["typename"] = "typevar", ["typevar"] = "@a", })
+local BETA = a_type({ ["typename"] = "typevar", ["typevar"] = "@b", })
 local ARRAY_OF_STRING = a_type({ ["typename"] = "array", ["elements"] = STRING, })
 local ARRAY_OF_ALPHA = a_type({ ["typename"] = "array", ["elements"] = ALPHA, })
 local MAP_OF_ALPHA_TO_BETA = a_type({ ["typename"] = "map", ["keys"] = ALPHA, ["values"] = BETA, })
@@ -3284,8 +3284,8 @@ local standard_library = {
             ["needs_compat53"] = true,
             ["typeargs"] = { [1] = ARG_ALPHA, },
             ["args"] = { [1] = ARRAY_OF_ALPHA, [2] = NUMBER, [3] = NUMBER, },
-            ["rets"] = { [1] = a_type({ ["typename"] = "typevar", ["typevar"] = "`a", ["is_va"] = true, }),
-            }, }),
+            ["rets"] = { [1] = VARARG_ALPHA, },
+         }),
          ["move"] = a_type({
             ["typename"] = "poly",
             ["types"] = {

--- a/tl.lua
+++ b/tl.lua
@@ -1075,13 +1075,17 @@ local function parse_trying_list(tokens, i, errs, list, parse_item)
 end
 
 local function parse_typearg_type(tokens, i, errs)
-   i = verify_tk(tokens, i, errs, "`")
+   local backtick = false
+   if tokens[i].tk == "`" then
+      i = verify_tk(tokens, i, errs, "`")
+      backtick = true
+   end
    i = verify_kind(tokens, i, errs, "identifier")
    return i, a_type({
       ["y"] = tokens[i - 2].y,
       ["x"] = tokens[i - 2].x,
       ["typename"] = "typearg",
-      ["typearg"] = "`" .. tokens[i - 1].tk,
+      ["typearg"] = (backtick and "`" or "") .. tokens[i - 1].tk,
    })
 end
 

--- a/tl.lua
+++ b/tl.lua
@@ -2009,6 +2009,12 @@ local function recurse_type(ast, visit)
    visit_before(ast, ast.typename, visit)
    local xs = {}
 
+   if ast.typeargs then
+      for _, child in ipairs(ast.typeargs) do
+         table.insert(xs, recurse_type(child, visit))
+      end
+   end
+
    for i, child in ipairs(ast) do
       xs[i] = recurse_type(child, visit)
    end
@@ -2026,11 +2032,6 @@ local function recurse_type(ast, visit)
    end
    if ast.values then
       table.insert(xs, recurse_type(ast.values, visit))
-   end
-   if ast.typeargs then
-      for _, child in ipairs(ast.typeargs) do
-         table.insert(xs, recurse_type(child, visit))
-      end
    end
    if ast.elements then
       table.insert(xs, recurse_type(ast.elements, visit))
@@ -3582,7 +3583,7 @@ function tl.type_check(ast, opts)
       return copy
    end
 
-   local function find_type(names)
+   local function find_type(names, accept_typearg)
       local typ = find_var(names[1])
       if not typ then
          return nil
@@ -3597,10 +3598,15 @@ function tl.type_check(ast, opts)
             break
          end
       end
-      if typ and typ.typename ~= "typetype" then
-         return nil
+      if typ then
+         if accept_typearg and typ.typename == "typearg" then
+            return typ
+         end
+         if typ.typename == "typetype" then
+            return typ
+         end
       end
-      return typ
+      return nil
    end
 
    local function infer_var(emptytable, t, node)
@@ -5665,11 +5671,35 @@ function tl.type_check(ast, opts)
                return typ
             end,
          },
+         ["function"] = {
+            ["before"] = function(typ, children)
+               begin_scope()
+            end,
+            ["after"] = function(typ, children)
+               end_scope()
+               return typ
+            end,
+         },
+         ["typearg"] = {
+            ["after"] = function(typ, children)
+               add_var(nil, typ.typearg, a_type({
+                  ["y"] = typ.y,
+                  ["x"] = typ.x,
+                  ["typename"] = "typearg",
+                  ["typearg"] = typ.typearg,
+               }))
+               return typ
+            end,
+         },
          ["nominal"] = {
             ["after"] = function(typ, children)
-               if not find_type(typ.names) then
+               local t = find_type(typ.names, true)
+               if t and t.typename == "typearg" then
 
- end
+                  typ.names = nil
+                  typ.typename = "typevar"
+                  typ.typevar = t.typearg
+               end
                return typ
             end,
          },
@@ -5707,14 +5737,14 @@ function tl.type_check(ast, opts)
          end,
       },
    }
+
+   visit_type.cbs["record"] = visit_type.cbs["function"]
+
    visit_type.cbs["typetype"] = visit_type.cbs["string"]
    visit_type.cbs["typevar"] = visit_type.cbs["string"]
-   visit_type.cbs["typearg"] = visit_type.cbs["string"]
-   visit_type.cbs["function"] = visit_type.cbs["string"]
    visit_type.cbs["array"] = visit_type.cbs["string"]
    visit_type.cbs["map"] = visit_type.cbs["string"]
    visit_type.cbs["arrayrecord"] = visit_type.cbs["string"]
-   visit_type.cbs["record"] = visit_type.cbs["string"]
    visit_type.cbs["enum"] = visit_type.cbs["string"]
    visit_type.cbs["boolean"] = visit_type.cbs["string"]
    visit_type.cbs["nil"] = visit_type.cbs["string"]

--- a/tl.tl
+++ b/tl.tl
@@ -1013,21 +1013,21 @@ local function parse_table_item(tokens: {Token}, i: number, errs: {ParseError}, 
    return i, node, n + 1
 end
 
-local ParseItem = functiontype<`T>({Token}, number, {ParseError}, number): number, `T, number
+local ParseItem = functiontype<T>({Token}, number, {ParseError}, number): number, T, number
 
 local SeparatorMode = enum
    "sep"
    "term"
 end
 
-local function parse_list<`T>(tokens: {Token}, i: number, errs: {ParseError}, list: {`T}, close: {string:boolean}, sep: SeparatorMode, parse_item: ParseItem<`T>): number, {`T}
+local function parse_list<T>(tokens: {Token}, i: number, errs: {ParseError}, list: {T}, close: {string:boolean}, sep: SeparatorMode, parse_item: ParseItem<T>): number, {T}
    local n = 1
    while tokens[i].kind ~= "$EOF$" do
       if close[tokens[i].tk] then
          (list as Node).yend = tokens[i].y
          break
       end
-      local item: `T
+      local item: T
       i, item, n = parse_item(tokens, i, errs, n)
       table.insert(list, item)
       if tokens[i].tk == "," then
@@ -1041,7 +1041,7 @@ local function parse_list<`T>(tokens: {Token}, i: number, errs: {ParseError}, li
    return i, list
 end
 
-local function parse_bracket_list<`T>(tokens: {Token}, i: number, errs: {ParseError}, list: {`T}, open: string, close: string, sep: SeparatorMode, parse_item: ParseItem<`T>): number, {`T}
+local function parse_bracket_list<T>(tokens: {Token}, i: number, errs: {ParseError}, list: {T}, open: string, close: string, sep: SeparatorMode, parse_item: ParseItem<T>): number, {T}
    i = verify_tk(tokens, i, errs, open)
    i = parse_list(tokens, i, errs, list, { [close] = true }, sep, parse_item)
    i = verify_tk(tokens, i, errs, close)
@@ -1053,7 +1053,7 @@ local function parse_table_literal(tokens: {Token}, i: number, errs: {ParseError
    return parse_bracket_list(tokens, i, errs, node, "{", "}", "term", parse_table_item)
 end
 
-local function parse_trying_list<`T>(tokens: {Token}, i: number, errs: {ParseError}, list: {`T}, parse_item: ParseItem<`T>): number, {`T}
+local function parse_trying_list<T>(tokens: {Token}, i: number, errs: {ParseError}, list: {T}, parse_item: ParseItem<T>): number, {T}
    local tryerrs: {ParseError} = {}
    local tryi, item = parse_item(tokens, i, tryerrs)
    if not item then
@@ -1972,30 +1972,30 @@ end
 -- AST traversal
 --------------------------------------------------------------------------------
 
-local VisitorCallbacks = record<`N, `T>
-   before: function(`N, {`T})
-   before_statements: function({`N}, {`T})
-   before_e2: function({`N}, {`T})
-   after: function(`N, {`T}, `T): `T
+local VisitorCallbacks = record<N, T>
+   before: function(N, {T})
+   before_statements: function({N}, {T})
+   before_e2: function({N}, {T})
+   after: function(N, {T}, T): T
 end
 
-local Visitor = record<`K, `N, `T>
-   cbs: {`K:VisitorCallbacks<`N, `T>}
-   after: VisitorCallbacks<`N, `T>
+local Visitor = record<K, N, T>
+   cbs: {K:VisitorCallbacks<N, T>}
+   after: VisitorCallbacks<N, T>
 end
 
-local function visit_before<`K,`N,`T>(ast: `N, kind: `K, visit: Visitor<`K,`N,`T>): `T
+local function visit_before<K,N,T>(ast: N, kind: K, visit: Visitor<K,N,T>): T
    assert(visit.cbs[kind], "no visitor for " .. (kind as string))
    if visit.cbs[kind].before then
       visit.cbs[kind].before(ast)
    end
 end
 
-local function visit_after<`K,`N,`T>(ast: `N, kind: `K, visit: Visitor<`K, `N,`T>, xs: {`T}): `T
+local function visit_after<K,N,T>(ast: N, kind: K, visit: Visitor<K, N,T>, xs: {T}): T
    if visit.after and visit.after.before then
       visit.after.before(ast, xs)
    end
-   local ret: `T
+   local ret: T
    if visit.cbs[kind].after then
       ret = visit.cbs[kind].after(ast, xs)
    end
@@ -2005,9 +2005,9 @@ local function visit_after<`K,`N,`T>(ast: `N, kind: `K, visit: Visitor<`K, `N,`T
    return ret
 end
 
-local function recurse_type<`T>(ast: Type, visit: Visitor<TypeName, Type, `T>): `T
+local function recurse_type<T>(ast: Type, visit: Visitor<TypeName, Type, T>): T
    visit_before(ast, ast.typename, visit)
-   local xs: {`T} = {}
+   local xs: {T} = {}
 
    if ast.typeargs then
       for _, child in ipairs(ast.typeargs) do
@@ -2066,15 +2066,15 @@ local function recurse_type<`T>(ast: Type, visit: Visitor<TypeName, Type, `T>): 
    return visit_after(ast, ast.typename, visit, xs)
 end
 
-local function recurse_node<`T>(ast: Node,
-                                visit_node: Visitor<NodeKind, Node, `T>,
-                                visit_type: Visitor<TypeName, Type, `T>): `T
+local function recurse_node<T>(ast: Node,
+                                visit_node: Visitor<NodeKind, Node, T>,
+                                visit_type: Visitor<TypeName, Type, T>): T
    if not ast then
       -- parse error
       return
    end
    visit_before(ast, ast.kind, visit_node)
-   local xs: {`T} = {}
+   local xs: {T} = {}
    local cbs = visit_node.cbs[ast.kind]
    if ast.kind == "statements"
       or ast.kind == "variables"
@@ -2172,7 +2172,7 @@ local function recurse_node<`T>(ast: Node,
       if ast.op.op == ":" and ast.e1.kind == "string" then
          p1 = -999
       end
-      xs[2] = p1 as `T
+      xs[2] = p1 as T
       if ast.op.arity == 2 then
          if cbs.before_e2 then
             cbs.before_e2(ast, xs)
@@ -2182,7 +2182,7 @@ local function recurse_node<`T>(ast: Node,
          else
             xs[3] = recurse_node(ast.e2, visit_node, visit_type)
          end
-         xs[4] = (ast.e2.op and ast.e2.op.prec) as `T
+         xs[4] = (ast.e2.op and ast.e2.op.prec) as T
       end
    elseif ast.kind == "newtype" then
       xs[1] = recurse_type(ast.newtype, visit_type)
@@ -2765,12 +2765,12 @@ local VARARG_ANY = a_type { typename = "any", is_va = true }
 local VARARG_STRING = a_type { typename = "string", is_va = true }
 local VARARG_NUMBER = a_type { typename = "number", is_va = true }
 local VARARG_UNKNOWN = a_type { typename = "unknown", is_va = true }
+local VARARG_ALPHA = a_type { typename = "typevar", typevar = "@a", is_va = true }
 local BOOLEAN = a_type { typename = "boolean" }
-local ARG_ALPHA = a_type { typename = "typearg", typearg = "`a" }
-local ARG_BETA = a_type { typename = "typearg", typearg = "`b" }
-local ALPHA = a_type { typename = "typevar", typevar = "`a" }
-local BETA = a_type { typename = "typevar", typevar = "`b" }
-local ARRAY_OF_ANY = a_type { typename = "array", elements = ANY }
+local ARG_ALPHA = a_type { typename = "typearg", typearg = "@a" }
+local ARG_BETA = a_type { typename = "typearg", typearg = "@b" }
+local ALPHA = a_type { typename = "typevar", typevar = "@a" }
+local BETA = a_type { typename = "typevar", typevar = "@b" }
 local ARRAY_OF_STRING = a_type { typename = "array", elements = STRING }
 local ARRAY_OF_ALPHA = a_type { typename = "array", elements = ALPHA }
 local MAP_OF_ALPHA_TO_BETA = a_type { typename = "map", keys = ALPHA, values = BETA }
@@ -3284,8 +3284,8 @@ local standard_library: {string:Type} = {
             needs_compat53 = true,
             typeargs = { ARG_ALPHA },
             args = { ARRAY_OF_ALPHA, NUMBER, NUMBER },
-            rets = { a_type { typename = "typevar", typevar = "`a", is_va = true }
-         } },
+            rets = { VARARG_ALPHA },
+         },
          ["move"] = a_type {
             typename = "poly",
             types = {
@@ -4748,7 +4748,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          return vars
       end
 
-      local function intersect<`T>(xs: {`T}, ys: {`T}, same: function(`T, `T): boolean): {`T}
+      local function intersect<T>(xs: {T}, ys: {T}, same: function(T, T): boolean): {T}
          local rs = {}
          for i = #xs, 1, -1 do
             local x = xs[i]

--- a/tl.tl
+++ b/tl.tl
@@ -2177,7 +2177,7 @@ local function recurse_node<`T>(ast: Node,
          if cbs.before_e2 then
             cbs.before_e2(ast, xs)
          end
-         if ast.op.op == "is" then
+         if ast.op.op == "is" or ast.op.op == "as" then
             xs[3] = recurse_type(ast.e2.casttype, visit_type)
          else
             xs[3] = recurse_node(ast.e2, visit_node, visit_type)

--- a/tl.tl
+++ b/tl.tl
@@ -1075,13 +1075,17 @@ local function parse_trying_list<`T>(tokens: {Token}, i: number, errs: {ParseErr
 end
 
 local function parse_typearg_type(tokens: {Token}, i: number, errs: {ParseError}): number, Type, number
-   i = verify_tk(tokens, i, errs, "`")
+   local backtick = false
+   if tokens[i].tk == "`" then
+      i = verify_tk(tokens, i, errs, "`")
+      backtick = true
+   end
    i = verify_kind(tokens, i, errs, "identifier")
    return i, a_type {
       y = tokens[i - 2].y,
       x = tokens[i - 2].x,
       typename = "typearg",
-      typearg = "`" .. tokens[i-1].tk,
+      typearg = (backtick and "`" or "") .. tokens[i-1].tk,
    }
 end
 

--- a/tl.tl
+++ b/tl.tl
@@ -2009,6 +2009,12 @@ local function recurse_type<`T>(ast: Type, visit: Visitor<TypeName, Type, `T>): 
    visit_before(ast, ast.typename, visit)
    local xs: {`T} = {}
 
+   if ast.typeargs then
+      for _, child in ipairs(ast.typeargs) do
+         table.insert(xs, recurse_type(child, visit))
+      end
+   end
+
    for i, child in ipairs(ast) do
       xs[i] = recurse_type(child, visit)
    end
@@ -2026,11 +2032,6 @@ local function recurse_type<`T>(ast: Type, visit: Visitor<TypeName, Type, `T>): 
    end
    if ast.values then
       table.insert(xs, recurse_type(ast.values, visit))
-   end
-   if ast.typeargs then
-      for _, child in ipairs(ast.typeargs) do
-         table.insert(xs, recurse_type(child, visit))
-      end
    end
    if ast.elements then
       table.insert(xs, recurse_type(ast.elements, visit))
@@ -3582,7 +3583,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return copy
    end
 
-   local function find_type(names: {string}): Type
+   local function find_type(names: {string}, accept_typearg: boolean): Type
       local typ = find_var(names[1])
       if not typ then
          return nil
@@ -3597,10 +3598,15 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             break
          end
       end
-      if typ and typ.typename ~= "typetype" then
-         return nil
+      if typ then
+         if accept_typearg and typ.typename == "typearg" then
+            return typ
+         end
+         if typ.typename == "typetype" then
+            return typ
+         end
       end
-      return typ
+      return nil
    end
 
    local function infer_var(emptytable: Type, t: Type, node: Node)
@@ -5665,10 +5671,34 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                return typ,
             end,
          },
+         ["function"] = {
+            before = function(typ: Type, children: {Type})
+               begin_scope()
+            end,
+            after = function(typ: Type, children: {Type}): Type
+               end_scope()
+               return typ
+            end,
+         },
+         ["typearg"] = {
+            after = function(typ: Type, children: {Type}): Type
+               add_var(nil, typ.typearg, a_type {
+                  y = typ.y,
+                  x = typ.x,
+                  typename = "typearg",
+                  typearg = typ.typearg,
+               })
+               return typ
+            end,
+         },
          ["nominal"] = {
             after = function(typ: Type, children: {Type}): Type
-               if not find_type(typ.names) then
-                  --type_error(typ, "unknown type %s", typ)
+               local t = find_type(typ.names, true)
+               if t and t.typename == "typearg" then
+                  -- convert nominal into a typevar
+                  typ.names = nil
+                  typ.typename = "typevar"
+                  typ.typevar = t.typearg
                end
                return typ
             end,
@@ -5707,14 +5737,14 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          end
       }
    }
+
+   visit_type.cbs["record"] = visit_type.cbs["function"]
+
    visit_type.cbs["typetype"] = visit_type.cbs["string"]
    visit_type.cbs["typevar"] = visit_type.cbs["string"]
-   visit_type.cbs["typearg"] = visit_type.cbs["string"]
-   visit_type.cbs["function"] = visit_type.cbs["string"]
    visit_type.cbs["array"] = visit_type.cbs["string"]
    visit_type.cbs["map"] = visit_type.cbs["string"]
    visit_type.cbs["arrayrecord"] = visit_type.cbs["string"]
-   visit_type.cbs["record"] = visit_type.cbs["string"]
    visit_type.cbs["enum"] = visit_type.cbs["string"]
    visit_type.cbs["boolean"] = visit_type.cbs["string"]
    visit_type.cbs["nil"] = visit_type.cbs["string"]


### PR DESCRIPTION
The compiler no longer require backticks in type variables! 

This version still _supports_ backticks, for a smoother transition, but the compiler does not use them anymore. Another PR in the near future will remove support for backticks.

Closes #76.