### PR TITLE
Add .gitattributes file for better syntax highlighting on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.tl linguist-language=Lua


### PR DESCRIPTION
Right now, [tl.tl](https://github.com/teal-language/tl/blob/master/tl.tl) is highlighted in purple on GitHub! I assume the language is getting mixed up with [that other TL programming language](https://core.telegram.org/mtproto/TL).

With this PR, .tl files in this repo should now be highlighted as regular .lua files.