### PR TITLE
Add option for prepending directories to the module search path

### DIFF
--- a/spec/cli/include_spec.lua
+++ b/spec/cli/include_spec.lua
@@ -1,0 +1,17 @@
+local util = require("spec.util")
+
+describe("-I --include argument", function()
+   it("adds a directory to package.path", function()
+      local name = util.write_tmp_file(finally, "foo.tl", [[
+         require("add")
+         local x: number = add(1, 2)
+
+         assert(x == 3)
+      ]])
+
+      local pd = io.popen("./tl -I spec check " .. name, "r")
+      local output = pd:read("*a")
+      util.assert_popen_close(true, "exit", 0, pd:close())
+      assert.match("0 errors detected", output, 1, true)
+   end)
+end)

--- a/spec/cli/include_spec.lua
+++ b/spec/cli/include_spec.lua
@@ -16,16 +16,13 @@ describe("-I --include argument", function()
    end)
    it("adds a directory to package.cpath", function()
       local name = util.write_tmp_file(finally, "foo.lua", [[
-         local ext = package.cpath:match("%.(%w+);")
-         local cpath_str = string.format("spec/cli/?.%s;", ext)
-
          print(package.cpath)
       ]])
-      local pd = io.popen("LUA_CPATH=\"/usr/lib/lua/?.so;\" ./tl run -I spec/cli/ " .. name, "r")
+      local pd = io.popen("LUA_CPATH=\"/usr/lib/lua/?.so\" ./tl run -I spec/cli/ " .. name, "r")
       local output = pd:read("*a")
       util.assert_popen_close(true, "exit", 0, pd:close())
       util.assert_line_by_line([[
-         spec/cli/?.so;/usr/lib/lua/?.so;
+         spec/cli/?.so;/usr/lib/lua/?.so
       ]], output)
    end)
 end)

--- a/spec/cli/include_spec.lua
+++ b/spec/cli/include_spec.lua
@@ -16,13 +16,13 @@ describe("-I --include argument", function()
    end)
    it("adds a directory to package.cpath", function()
       local name = util.write_tmp_file(finally, "foo.lua", [[
-         print(package.cpath)
+         print(package.cpath:match("spec/cli/") ~= nil)
       ]])
-      local pd = io.popen("LUA_CPATH=\"/usr/lib/lua/?.so\" ./tl run -I spec/cli/ " .. name, "r")
+      local pd = io.popen("./tl run -I spec/cli/ " .. name, "r")
       local output = pd:read("*a")
       util.assert_popen_close(true, "exit", 0, pd:close())
       util.assert_line_by_line([[
-         spec/cli/?.so;/usr/lib/lua/?.so
+         true
       ]], output)
    end)
 end)

--- a/spec/cli/include_spec.lua
+++ b/spec/cli/include_spec.lua
@@ -14,4 +14,18 @@ describe("-I --include argument", function()
       util.assert_popen_close(true, "exit", 0, pd:close())
       assert.match("0 errors detected", output, 1, true)
    end)
+   it("adds a directory to package.cpath", function()
+      local name = util.write_tmp_file(finally, "foo.lua", [[
+         local ext = package.cpath:match("%.(%w+);")
+         local cpath_str = string.format("spec/cli/?.%s;", ext)
+
+         print(package.cpath)
+      ]])
+      local pd = io.popen("LUA_CPATH=\"/usr/lib/lua/?.so;\" ./tl run -I spec/cli/ " .. name, "r")
+      local output = pd:read("*a")
+      util.assert_popen_close(true, "exit", 0, pd:close())
+      util.assert_line_by_line([[
+         spec/cli/?.so;/usr/lib/lua/?.so;
+      ]], output)
+   end)
 end)

--- a/tl
+++ b/tl
@@ -174,8 +174,6 @@ local function prepend_to_path(directory)
 
    package.path = lua_path_str .. package.path
    package.cpath = lib_path_str .. package.cpath
-
-   print(package.cpath)
 end
 
 for _, include in ipairs(tlconfig["include"]) do

--- a/tl
+++ b/tl
@@ -84,7 +84,7 @@ local function get_args_parser()
          :argname("<modulename>")
          :count("*")
 
-   parser:option("-I --include", "Prepend this directory to package.path.")
+   parser:option("-I --include", "Prepend this directory to the module search path.")
          :argname("<directory>")
          :count("*")
 
@@ -154,18 +154,28 @@ end
 
 local env = nil
 
+local function get_shared_library_ext()
+   return package.cpath:match("%.(%w+);")
+end
+
 local function prepend_to_path(directory)
    local path_separator = package.config:sub(1, 1)
 
-   local lua_path_str = directory
+   local path_str = directory
 
-   if string.sub(lua_path_str, -1) == path_separator then
-      lua_path_str = lua_path_str:sub(1, -2)
+   if string.sub(path_str, -1) == path_separator then
+      path_str = path_str:sub(1, -2)
    end
 
-   lua_path_str = lua_path_str .. path_separator .. "?.lua;"
+   path_str = path_str .. path_separator
+
+   local lib_path_str = path_str .. "?." .. get_shared_library_ext() .. ";"
+   local lua_path_str = path_str .. "?.lua;"
 
    package.path = lua_path_str .. package.path
+   package.cpath = lib_path_str .. package.cpath
+
+   print(package.cpath)
 end
 
 for _, include in ipairs(tlconfig["include"]) do

--- a/tl
+++ b/tl
@@ -19,13 +19,13 @@ local function die(msg)
 end
 
 local function find_in_sequence(seq, value)
-    for _, v in ipairs(seq) do
-        if trim(v) == trim(value) then
-            return true
-        end
-    end
+   for _, v in ipairs(seq) do
+      if trim(v) == trim(value) then
+         return true
+      end
+   end
 
-    return false
+   return false
 end
 
 -- FIXME
@@ -155,21 +155,21 @@ end
 local env = nil
 
 local function prepend_to_path(directory)
-    local path_separator = package.config:sub(1, 1)
+   local path_separator = package.config:sub(1, 1)
 
-    local lua_path_str = directory
+   local lua_path_str = directory
 
-    if string.sub(lua_path_str, -1) == path_separator then
-        lua_path_str = lua_path_str:sub(1, -2)
-    end
+   if string.sub(lua_path_str, -1) == path_separator then
+      lua_path_str = lua_path_str:sub(1, -2)
+   end
 
-    lua_path_str = lua_path_str .. path_separator .. "?.lua;"
+   lua_path_str = lua_path_str .. path_separator .. "?.lua;"
 
-    package.path = lua_path_str .. package.path
+   package.path = lua_path_str .. package.path
 end
 
 for _, include in ipairs(tlconfig["include"]) do
-    prepend_to_path(include)
+   prepend_to_path(include)
 end
 
 for i, filename in ipairs(args["script"]) do

--- a/tl
+++ b/tl
@@ -155,7 +155,7 @@ end
 local env = nil
 
 local function get_shared_library_ext()
-   return package.cpath:match("%.(%w+);")
+   return package.cpath:match("%.(%w+)$")
 end
 
 local function prepend_to_path(directory)

--- a/tl
+++ b/tl
@@ -155,7 +155,7 @@ end
 local env = nil
 
 local function get_shared_library_ext()
-   return package.cpath:match("%.(%w+)$")
+   return package.cpath:match("%.(%w+)%s*$")
 end
 
 local function prepend_to_path(directory)

--- a/tl
+++ b/tl
@@ -18,6 +18,10 @@ local function die(msg)
    os.exit(1)
 end
 
+local function is_null_or_whitespace(str)
+   return str == nil or trim(str) == ""
+end
+
 local function find_in_sequence(seq, value)
    for _, v in ipairs(seq) do
       if trim(v) == trim(value) then
@@ -155,6 +159,10 @@ end
 local env = nil
 
 local function get_shared_library_ext()
+   if is_null_or_whitespace(package.cpath) then
+      return "so" -- FIXME
+   end
+
    return package.cpath:match("%.(%w+)%s*$")
 end
 

--- a/tl
+++ b/tl
@@ -18,10 +18,21 @@ local function die(msg)
    os.exit(1)
 end
 
+local function find_in_sequence(seq, value)
+    for _, v in ipairs(seq) do
+        if trim(v) == trim(value) then
+            return true
+        end
+    end
+
+    return false
+end
+
 -- FIXME
 local function validate_config(config)
    local valid_keys = {
-      preload_modules = true
+      preload_modules = true,
+      include = true
    }
 
    for k, _ in pairs(config) do
@@ -37,7 +48,8 @@ end
 
 local function get_config()
    local config = {
-      preload_modules = {}
+      preload_modules = {},
+      include = {}
    }
 
    local status, user_config = pcall(require, "tlconfig")
@@ -72,6 +84,10 @@ local function get_args_parser()
          :argname("<modulename>")
          :count("*")
 
+   parser:option("-I --include", "Prepend this directory to package.path.")
+         :argname("<directory>")
+         :count("*")
+
    parser:flag("--skip-compat53", "Skip compat53 insertions.")
 
    parser:command_target("command")
@@ -100,17 +116,14 @@ local tlconfig = get_config()
 local cmd = args["command"]
 
 for _, preload_module_cli in ipairs(args["preload"]) do
-   local found_in_config = false
-
-   for _, preload_module_config in ipairs(tlconfig.preload_modules) do
-      if trim(preload_module_cli) == trim(preload_module_config) then
-         found_in_config = true
-         break
-      end
-   end
-
-   if not found_in_config then
+   if not find_in_sequence(tlconfig.preload_modules, preload_module_cli) then
       table.insert(tlconfig.preload_modules, preload_module_cli)
+   end
+end
+
+for _, include_dir_cli in ipairs(args["include"]) do
+   if not find_in_sequence(tlconfig.include, include_dir_cli) then
+      table.insert(tlconfig.include, include_dir_cli)
    end
 end
 
@@ -140,6 +153,24 @@ local function report_type_errors(result)
 end
 
 local env = nil
+
+local function prepend_to_path(directory)
+    local path_separator = package.config:sub(1, 1)
+
+    local lua_path_str = directory
+
+    if string.sub(lua_path_str, -1) == path_separator then
+        lua_path_str = lua_path_str:sub(1, -2)
+    end
+
+    lua_path_str = lua_path_str .. path_separator .. "?.lua;"
+
+    package.path = lua_path_str .. package.path
+end
+
+for _, include in ipairs(tlconfig["include"]) do
+    prepend_to_path(include)
+end
 
 for i, filename in ipairs(args["script"]) do
    local modules = i == 1 and tlconfig.preload_modules

--- a/tl
+++ b/tl
@@ -18,7 +18,7 @@ local function die(msg)
    os.exit(1)
 end
 
-local function is_null_or_whitespace(str)
+local function is_nil_or_whitespace(str)
    return str == nil or trim(str) == ""
 end
 
@@ -159,7 +159,7 @@ end
 local env = nil
 
 local function get_shared_library_ext()
-   if is_null_or_whitespace(package.cpath) then
+   if is_nil_or_whitespace(package.cpath) then
       return "so" -- FIXME
    end
 


### PR DESCRIPTION
Initial work on https://github.com/teal-language/tl/issues/92.

This PR adds the `-I --include` option for prepending directories to `package.path`. It also adds an `include` key in `tlconfig.lua`.