### PR TITLE
tl run: support CLI arguments passed to the script

### DIFF
--- a/spec/cli/run_spec.lua
+++ b/spec/cli/run_spec.lua
@@ -138,4 +138,143 @@ describe("tl run", function()
          assert.same("", output)
       end)
    end)
+
+   describe("with arguments", function()
+      it("passes arguments as arg", function()
+         local name = util.write_tmp_file(finally, "hello.tl", [[
+            for i = -10, 10 do
+               print(i .. " " .. tostring(arg[i]))
+            end
+         ]])
+         local pd = io.popen("./tl run " .. name .. " hello world", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(true, "exit", 0, pd:close())
+         util.assert_line_by_line([[
+            -10 nil
+            -9 nil
+            -8 nil
+            -7 nil
+            -6 nil
+            -5 nil
+            -4 nil
+            -3 lua
+            -2 ./tl
+            -1 run
+            0 ]] .. name .. "\n" .. [[
+            1 hello
+            2 world
+            3 nil
+            4 nil
+            5 nil
+            6 nil
+            7 nil
+            8 nil
+            9 nil
+            10 nil
+         ]], output)
+      end)
+
+      it("allows -- to stop argument parsing after script name", function()
+         local name = util.write_tmp_file(finally, "hello.tl", [[
+            for i = -10, 10 do
+               print(i .. " " .. tostring(arg[i]))
+            end
+         ]])
+         local pd = io.popen("./tl run " .. name .. " -- --skip-compat53 hello world", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(true, "exit", 0, pd:close())
+         util.assert_line_by_line([[
+            -10 nil
+            -9 nil
+            -8 nil
+            -7 nil
+            -6 nil
+            -5 nil
+            -4 lua
+            -3 ./tl
+            -2 run
+            -1 --
+            0 ]] .. name .. "\n" .. [[
+            1 --skip-compat53
+            2 hello
+            3 world
+            4 nil
+            5 nil
+            6 nil
+            7 nil
+            8 nil
+            9 nil
+            10 nil
+         ]], output)
+      end)
+
+      it("allows -- to stop argument parsing before script name", function()
+         local name = util.write_tmp_file(finally, "hello.tl", [[
+            for i = -10, 10 do
+               print(i .. " " .. tostring(arg[i]))
+            end
+         ]])
+         local pd = io.popen("./tl run -- " .. name .. " --skip-compat53 hello world", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(true, "exit", 0, pd:close())
+         util.assert_line_by_line([[
+            -10 nil
+            -9 nil
+            -8 nil
+            -7 nil
+            -6 nil
+            -5 nil
+            -4 lua
+            -3 ./tl
+            -2 run
+            -1 --
+            0 ]] .. name .. "\n" .. [[
+            1 --skip-compat53
+            2 hello
+            3 world
+            4 nil
+            5 nil
+            6 nil
+            7 nil
+            8 nil
+            9 nil
+            10 nil
+         ]], output)
+      end)
+
+      it("does not get arguments and non-arguments confused when they look the same", function()
+         local name = util.write_tmp_file(finally, "hello.tl", [[
+            for i = -10, 10 do
+               print(i .. " " .. tostring(arg[i]))
+            end
+         ]])
+         local pd = io.popen("./tl run -I . -- " .. name .. " -I . hello world", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(true, "exit", 0, pd:close())
+         util.assert_line_by_line([[
+            -10 nil
+            -9 nil
+            -8 nil
+            -7 nil
+            -6 lua
+            -5 ./tl
+            -4 run
+            -3 -I
+            -2 .
+            -1 --
+            0 ]] .. name .. "\n" .. [[
+            1 -I
+            2 .
+            3 hello
+            4 world
+            5 nil
+            6 nil
+            7 nil
+            8 nil
+            9 nil
+            10 nil
+         ]], output)
+      end)
+   end)
+
 end)

--- a/tl
+++ b/tl
@@ -103,11 +103,7 @@ local function get_args_parser()
    gen_command:argument("script", "The tl script."):args("+")
 
    local run_command = parser:command("run", "Run a tl script.")
-   run_command:argument("script", "The tl script."):args(1)
-      :convert(function(arg)
-         assert(type(arg) == "string")
-         return { arg }
-   end)
+   run_command:argument("script", "The tl script."):args("+")
 
    return parser
 end
@@ -229,19 +225,42 @@ for i, filename in ipairs(args["script"]) do
       if filename:match("%.tl$") then
          local ok = report_type_errors(result)
          if not ok then
-            exit = 1
-            break
+            os.exit(1)
          end
       end
 
       local chunk = (loadstring or load)(tl.pretty_print_ast(result.ast), "@" .. filename)
 
-      local narg = #arg
-      for i = -5, narg do
-         arg[i - 2] = arg[i]
+      -- collect all non-arguments including negative arg values
+      local neg_arg = {}
+      local nargs = #args["script"]
+      local j = #arg
+      local p = nargs
+      local n = 1
+      while arg[j] do
+         if arg[j] == args["script"][p] then
+            p = p - 1
+         else
+            neg_arg[n] = arg[j]
+            n = n + 1
+         end
+         j = j - 1
       end
-      arg[narg] = nil
-      arg[narg - 1] = nil
+
+      -- shift back all non-arguments to negative positions
+      for p, a in ipairs(neg_arg) do
+         arg[-p] = a
+      end
+      -- put script in arg[0] and arguments in positive positions
+      for p, a in ipairs(args["script"]) do
+         arg[p - 1] = a
+      end
+      -- cleanup the rest
+      n = nargs
+      while arg[n] do
+         arg[n] = nil
+         n = n + 1
+      end
 
       tl.loader()
 


### PR DESCRIPTION
`tl run hello.tl foo bar` did not pass `foo` and `bar` as arguments to `hello.tl` — this PR intends to fix that. :)

If my memory serves me right, Lua and LuaJIT have somewhat different behavior in their handling of `arg`. The invariants I kept here are:
* `arg[0]` is always the script name
* positive `arg` entries are the script arguments
* anything else (Lua interpreter, `tl` arguments) is in negative `arg` entries.

Our behavior is a little different from PUC Lua though, in that once `lua` sees a non-flag, it stops argument parsing immediately. argparse does not do that, it needs a `--` to stop interpreting arguments. I do some juggling of the arguments to preserve the invariants above.