### PR TITLE
Tagged records

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -101,9 +101,15 @@ precedence, see below.
 
 *  typeargs ::= ‘<’ Name {‘,’ Name } ‘>’
 
-*  newtype ::= ‘record’ [typeargs] [‘{’ type ‘}’] {Name ‘=’ newtype} {Name ‘:’ type} ‘end’ |
+*  newtype ::= ‘record’ [typeargs] [‘is’ Name ‘with’ Name ‘=’ tagvalue]
+*                 [‘{’ type ‘}’]
+*                 {Name ‘=’ newtype}
+*                 { [‘tag’] Name ‘:’ type}
+*              ‘end’ |
 *      ‘enum’ {LiteralString} ‘end’ |
 *      ‘functiontype’ functiontype
+
+*  tagvalue ::= ‘false’ | ‘true’ | Numeral | LiteralString
 
 *  functiontype ::= [typeargs] ‘(’ partypelist ‘)’ [retlist]
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -400,6 +400,40 @@ local http = record
 end
 ```
 
+### Tagged records
+
+Teal supports a very simple form of subtyping for records: tagged records.
+You can specify a field of type number, string or boolean to act as a _tag_
+for a parent record type, and then define children record types that extend
+the parent record discriminating them based on the tag. This is how it
+works:
+
+```
+local Widget = record
+   tag widget_type: string
+
+   x: number
+   y: number
+end
+
+local Button = record is Widget with widget_type = "button"
+   text: string
+end
+
+local Field = record is Widget with widget_type = "field"
+   width: number
+   input: string
+end
+
+local function show_widget(w: Widget)
+   if w is Button then
+      draw_button(w.x, w.y, w.text)
+   elseif w is Field then
+      draw_field(w.x, w.y, w.width, w.input)
+   end
+end
+```
+
 ## Generics
 
 Teal supports a simple form of generics that is useful enough for dealing

--- a/spec/assignment/to_nominal_record_field_spec.lua
+++ b/spec/assignment/to_nominal_record_field_spec.lua
@@ -1,4 +1,5 @@
 local tl = require("tl")
+local util = require("spec.util")
 
 describe("assignment to nominal record field", function()
    it("passes", function()
@@ -32,4 +33,42 @@ describe("assignment to nominal record field", function()
       local errors = tl.type_check(ast)
       assert.match("in assignment: got number, expected Node", errors[1].msg, 1, true)
    end)
+end)
+
+describe("tagged records", function()
+   it("inherit fields from parent", util.check [[
+      local Node = record
+         tag kind: string
+         x: number
+         y: number
+      end
+
+      local EnumNode = record is Node with kind = "enum"
+         enumset: {string}
+      end
+
+      local e: EnumNode = {}
+      e.x = 12
+      e.y = 13
+      e.enumset = { "hello" }
+   ]])
+
+   it("child fields do not exist in parent", util.check_type_error([[
+      local Node = record
+         tag kind: string
+         x: number
+         y: number
+      end
+
+      local EnumNode = record is Node with kind = "enum"
+         enumset: {string}
+      end
+
+      local e: Node = {}
+      e.x = 12
+      e.y = 13
+      e.enumset = { "hello" }
+   ]], {
+      { msg = "invalid key 'enumset' in record 'e' of type Node" }
+   }))
 end)

--- a/spec/assignment/to_nominal_record_spec.lua
+++ b/spec/assignment/to_nominal_record_spec.lua
@@ -1,4 +1,5 @@
 local tl = require("tl")
+local util = require("spec.util")
 
 describe("assignment to nominal record", function()
    it("accepts empty table", function()
@@ -87,4 +88,44 @@ describe("assignment to nominal record", function()
       local errors = tl.type_check(ast)
       assert.match("in local declaration: x: got number, expected Node", errors[1].msg, 1, true)
    end)
+end)
+
+describe("tagged records", function()
+   it("child be assigned to parent", util.check [[
+      local Node = record
+         tag kind: string
+         x: number
+         y: number
+      end
+
+      local EnumNode = record is Node with kind = "enum"
+         enumset: {string}
+      end
+
+      local e: EnumNode = {}
+      e.x = 12
+      e.y = 13
+      e.enumset = { "hello" }
+      local n: Node = e
+   ]])
+
+   it("parent cannot be assigned to child", util.check_type_error([[
+      local Node = record
+         tag kind: string
+         x: number
+         y: number
+      end
+
+      local EnumNode = record is Node with kind = "enum"
+         enumset: {string}
+      end
+
+      local n: Node = {}
+      n.x = 12
+      n.y = 13
+      local e: EnumNode
+      e = n
+   ]], {
+      { msg = "in assignment: Node is not a EnumNode" }
+   }))
 end)

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -263,6 +263,46 @@ describe("tagged records", function()
       end
    ]])
 
+   it("can have enums as tags", util.check [[
+      local NodeKind = enum
+         "t1"
+         "t2"
+      end
+
+      local Node = record
+         tag kind: NodeKind
+      end
+
+      local T1Node = record is Node with kind = "t1"
+         t1data: {string}
+      end
+
+      local T2Node = record is Node with kind = "t2"
+         t2data: {string}
+      end
+   ]])
+
+   it("enums as tags must be valid", util.check_type_error([[
+      local NodeKind = enum
+         "t1"
+         "t2"
+      end
+
+      local Node = record
+         tag kind: NodeKind
+      end
+
+      local T1Node = record is Node with kind = "t1"
+         t1data: {string}
+      end
+
+      local T2Node = record is Node with kind = "t3" -- invalid!
+         t2data: {string}
+      end
+   ]], {
+      { msg = "string \"t3\" is not a member of NodeKind" }
+   }))
+
    it("subtypes must have tag declarations", util.check_syntax_error([[
       local Node = record
          tag kind: string

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -245,3 +245,114 @@ describe("records", function()
    end)
 
 end)
+
+describe("tagged records", function()
+   it("can have tags", util.check [[
+      local Node = record
+         tag kind: string
+      end
+   ]])
+
+   it("can have subtypes", util.check [[
+      local Node = record
+         tag kind: string
+      end
+
+      local EnumNode = record is Node with kind = "enum"
+         enumset: {string}
+      end
+   ]])
+
+   it("subtypes must have tag declarations", util.check_syntax_error([[
+      local Node = record
+         tag kind: string
+      end
+
+      local EnumNode = record is Node
+         enumset: {string}
+      end
+   ]], {
+      { msg = "expected 'with'" },
+   }))
+
+   it("subtype tags can be strings, numbers or booleans", util.check [[
+      local WithString = record
+         tag kind: string
+      end
+
+      local SubString = record is WithString with kind = "enum"
+         enumset: {string}
+      end
+
+      local WithNumber = record
+         tag kind: number
+      end
+
+      local SubNumber = record is WithNumber with kind = 1
+         enumset: {string}
+      end
+
+      local WithBoolean = record
+         tag kind: boolean
+      end
+
+      local SubBoolean = record is WithBoolean with kind = true
+         enumset: {string}
+      end
+   ]])
+
+   it("subtypes cannot be other literals", util.check_syntax_error([[
+      local Node = record
+         tag kind: string
+      end
+
+      local EnumNode = record is Node with kind = {}
+         enumset: {string}
+      end
+
+      local EnumNode = record is Node with kind = function() end
+         enumset: {string}
+      end
+   ]], {
+      { msg = "invalid literal for tag value" },
+      { msg = "invalid literal for tag value" },
+   }))
+
+   it("detects an unknown parent type", util.check_type_error([[
+      local Node = record
+         tag kind: string
+      end
+
+      local EnumNode = record is Bla with kind = "enum"
+         enumset: {string}
+      end
+   ]], {
+      { msg = "unknown type Bla" },
+   }))
+
+   it("detects an invalid tag", util.check_type_error([[
+      local Node = record
+         tag kind: string
+      end
+
+      local EnumNode = record is Node with typename = "enum"
+         enumset: {string}
+      end
+   ]], {
+      { msg = "invalid tag 'typename', expected 'kind'" },
+   }))
+
+   it("detects an invalid tag value", util.check_type_error([[
+      local Node = record
+         tag kind: string
+      end
+
+      local EnumNode = record is Node with kind = 123
+         enumset: {string}
+      end
+   ]], {
+      { msg = "got number, expected string" },
+   }))
+
+end)
+

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -193,6 +193,7 @@ local function gen(lax, code, expected)
       assert.same({}, syntax_errors, "Code was not expected to have syntax errors")
       local errors, unks = tl.type_check(ast, { filename = "foo.tl", lax = lax })
       assert.same({}, errors)
+
       local output_code = tl.pretty_print_ast(ast)
 
       local expected_tokens = tl.lex(expected)

--- a/tl.lua
+++ b/tl.lua
@@ -6091,7 +6091,7 @@ function tl.type_check(ast, opts)
       else
          if not typ.tag_value.type then
             if typ.tag_value.kind == "string" then
-               typ.tag_value.type = STRING
+               typ.tag_value.type = a_type({ typename = "string", tk = typ.tag_value.tk })
             elseif typ.tag_value.kind == "number" then
                typ.tag_value.type = NUMBER
             elseif typ.tag_value.kind == "boolean" then

--- a/tl.lua
+++ b/tl.lua
@@ -919,6 +919,7 @@ local Node = {}
 
 
 
+
 local function is_array_type(t)
    return t.typename == "array" or t.typename == "arrayrecord"
 end
@@ -1354,9 +1355,15 @@ local function parse_literal(ps, i)
       node.constnum = n
       return i, node
    elseif ps.tokens[i].tk == "true" then
-      return verify_kind(ps, i, "keyword", "boolean")
+      local node
+      i, node = verify_kind(ps, i, "keyword", "boolean")
+      node.constbool = true
+      return i, node
    elseif ps.tokens[i].tk == "false" then
-      return verify_kind(ps, i, "keyword", "boolean")
+      local node
+      i, node = verify_kind(ps, i, "keyword", "boolean")
+      node.constbool = false
+      return i, node
    elseif ps.tokens[i].tk == "nil" then
       return verify_kind(ps, i, "keyword", "nil")
    elseif ps.tokens[i].tk == "function" then
@@ -2793,11 +2800,23 @@ function tl.pretty_print_ast(ast, fast)
             elseif node.op.op == "as" then
                add_child(out, children[1], "", indent)
             elseif node.op.op == "is" then
-               table.insert(out, "type(")
-               add_child(out, children[1], "", indent)
-               table.insert(out, ") == \"")
-               add_child(out, children[3], "", indent)
-               table.insert(out, "\"")
+               if node.e1.type.tag_field then
+                  add_child(out, children[1], "", indent)
+                  table.insert(out, ".")
+                  table.insert(out, node.e1.type.tag_field)
+                  table.insert(out, " == ")
+                  local e2 = node.e2.casttype.resolved.tag_value
+                  local v = (e2.kind == "string" and string.format("%q", e2.conststr)) or
+                  (e2.kind == "number" and tostring(e2.constnum)) or
+                  (e2.kind == "boolean" and tostring(e2.constbool))
+                  table.insert(out, v)
+               else
+                  table.insert(out, "type(")
+                  add_child(out, children[1], "", indent)
+                  table.insert(out, ") == \"")
+                  add_child(out, children[3], "", indent)
+                  table.insert(out, "\"")
+               end
             elseif spaced_op[node.op.arity][node.op.op] or tight_op[node.op.arity][node.op.op] then
                local space = spaced_op[node.op.arity][node.op.op] and " " or ""
                if children[2] and node.op.prec > tonumber(children[2]) then
@@ -6191,12 +6210,25 @@ function tl.type_check(ast, opts)
 
                local n_table_types = 0
                local n_string_enum = 0
+               local all_tagged = true
+               local parent
                for _, t in ipairs(typ.types) do
                   t = resolve_unary(t)
+                  if t.tag_value then
+                     local pr = resolve_unary(t.parent_record)
+                     if parent and not same_type(pr, parent) then
+                        type_error(typ, "cannot discriminate a union between records with different parents")
+                        break
+                     end
+                     parent = pr
+                     typ.tag_field = parent.tag_field
+                  else
+                     all_tagged = false
+                  end
                   if table_types[t.typename] then
                      n_table_types = n_table_types + 1
-                     if n_table_types > 1 then
-                        type_error(typ, "cannot discriminate a union between multiple table types: %s", typ)
+                     if n_table_types > 1 and not all_tagged then
+                        type_error(typ, "cannot discriminate a union between untagged table types: %s", typ)
                         break
                      end
                   elseif t.typename == "string" or t.typename == "enum" then

--- a/tl.lua
+++ b/tl.lua
@@ -4250,6 +4250,12 @@ function tl.type_check(ast, opts)
       elseif t1.typename == "nominal" and t2.typename == "nominal" and #t2.names == 1 and t2.names[1] == "any" then
          return true
       elseif t1.typename == "nominal" and t2.typename == "nominal" then
+         local t1u = resolve_unary(t1)
+         local t2u = resolve_unary(t2)
+         if is_record_type(t1u) and is_record_type(t2u) and t1u.parent_record and resolve_unary(t1u.parent_record) == t2u then
+            return true
+         end
+
          if same_names(t1, t2) then
             if t1.typevals == nil and t2.typevals == nil then
                return true

--- a/tl.tl
+++ b/tl.tl
@@ -908,6 +908,7 @@ local Node = record
    e2: Node
    constnum: number
    conststr: string
+   constbool: boolean
 
    -- goto
    label: string
@@ -1354,9 +1355,15 @@ local function parse_literal(ps: ParseState, i: number): number, Node
       node.constnum = n
       return i, node
    elseif ps.tokens[i].tk == "true" then
-      return verify_kind(ps, i, "keyword", "boolean")
+      local node: Node
+      i, node = verify_kind(ps, i, "keyword", "boolean")
+      node.constbool = true
+      return i, node
    elseif ps.tokens[i].tk == "false" then
-      return verify_kind(ps, i, "keyword", "boolean")
+      local node: Node
+      i, node = verify_kind(ps, i, "keyword", "boolean")
+      node.constbool = false
+      return i, node
    elseif ps.tokens[i].tk == "nil" then
       return verify_kind(ps, i, "keyword", "nil")
    elseif ps.tokens[i].tk == "function" then
@@ -2793,11 +2800,23 @@ function tl.pretty_print_ast(ast: Node, fast: boolean): string
             elseif node.op.op == "as" then
                add_child(out, children[1], "", indent)
             elseif node.op.op == "is" then
-               table.insert(out, "type(")
-               add_child(out, children[1], "", indent)
-               table.insert(out, ") == \"")
-               add_child(out, children[3], "", indent)
-               table.insert(out, "\"")
+               if node.e1.type.tag_field then
+                  add_child(out, children[1], "", indent)
+                  table.insert(out, ".")
+                  table.insert(out, node.e1.type.tag_field)
+                  table.insert(out, " == ")
+                  local e2: Node = node.e2.casttype.resolved.tag_value
+                  local v: string = (e2.kind == "string" and string.format("%q", e2.conststr))
+                                    or (e2.kind == "number" and tostring(e2.constnum))
+                                    or (e2.kind == "boolean" and tostring(e2.constbool))
+                  table.insert(out, v)
+               else
+                  table.insert(out, "type(")
+                  add_child(out, children[1], "", indent)
+                  table.insert(out, ") == \"")
+                  add_child(out, children[3], "", indent)
+                  table.insert(out, "\"")
+               end
             elseif spaced_op[node.op.arity][node.op.op] or tight_op[node.op.arity][node.op.op] then
                local space = spaced_op[node.op.arity][node.op.op] and " " or ""
                if children[2] and node.op.prec > tonumber(children[2]) then
@@ -6191,12 +6210,25 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                -- due to codegen limitations (we only check with type() so far)
                local n_table_types = 0
                local n_string_enum = 0
+               local all_tagged = true
+               local parent: Type
                for _, t in ipairs(typ.types) do
                   t = resolve_unary(t)
+                  if t.tag_value then
+                     local pr = resolve_unary(t.parent_record)
+                     if parent and not same_type(pr, parent) then
+                        type_error(typ, "cannot discriminate a union between records with different parents")
+                        break
+                     end
+                     parent = pr
+                     typ.tag_field = parent.tag_field
+                  else
+                     all_tagged = false
+                  end
                   if table_types[t.typename] then
                      n_table_types = n_table_types + 1
-                     if n_table_types > 1 then
-                        type_error(typ, "cannot discriminate a union between multiple table types: %s", typ)
+                     if n_table_types > 1 and not all_tagged then
+                        type_error(typ, "cannot discriminate a union between untagged table types: %s", typ)
                         break
                      end
                   elseif t.typename == "string" or t.typename == "enum" then

--- a/tl.tl
+++ b/tl.tl
@@ -4250,6 +4250,12 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       elseif t1.typename == "nominal" and t2.typename == "nominal" and #t2.names == 1 and t2.names[1] == "any" then
          return true
       elseif t1.typename == "nominal" and t2.typename == "nominal" then
+         local t1u = resolve_unary(t1)
+         local t2u = resolve_unary(t2)
+         if is_record_type(t1u) and is_record_type(t2u) and t1u.parent_record and resolve_unary(t1u.parent_record) == t2u then
+            return true
+         end
+
          if same_names(t1, t2) then
             if t1.typevals == nil and t2.typevals == nil then
                return true

--- a/tl.tl
+++ b/tl.tl
@@ -710,6 +710,7 @@ local table_types: {TypeName:boolean} = {
 
 local Type = record
    {Type}
+
    y: number
    x: number
    filename: string
@@ -737,6 +738,7 @@ local Type = record
    values: Type
 
    -- records
+   tag_field: string
    typeargs: {Type}
    fields: {string: Type}
    field_order: {string}
@@ -1826,6 +1828,14 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
             def.typename = "arrayrecord"
             def.elements = t
          else
+            local is_tag = false
+            if ps.tokens[i].tk == "tag" and ps.tokens[i].kind == "identifier" then
+               if def.tag_field then
+                  return fail(ps, i, "cannot declare record tag multiple times")
+               end
+               i = i + 1
+               is_tag = true
+            end
             local v: Node
             i, v = verify_kind(ps, i, "identifier", "variable")
             local iv = i
@@ -1842,6 +1852,9 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
                if not def.fields[v.tk] then
                   def.fields[v.tk] = t
                   table.insert(def.field_order, v.tk)
+                  if is_tag then
+                     def.tag_field = v.tk
+                  end
                else
                   local prev_t = def.fields[v.tk]
                   if t.typename == "function" and prev_t.typename == "function" then
@@ -1854,6 +1867,9 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
                   end
                end
             elseif ps.tokens[i].tk == "=" then
+               if is_tag then
+                  return fail(ps, i, "cannot declare record tag on a nested type")
+               end
                i = verify_tk(ps, i, "=")
                local nt: Node
                i, nt = parse_newtype(ps, i)

--- a/tl.tl
+++ b/tl.tl
@@ -6091,7 +6091,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       else
          if not typ.tag_value.type then
             if typ.tag_value.kind == "string" then
-               typ.tag_value.type = STRING
+               typ.tag_value.type = a_type { typename = "string", tk = typ.tag_value.tk }
             elseif typ.tag_value.kind == "number" then
                typ.tag_value.type = NUMBER
             elseif typ.tag_value.kind == "boolean" then

--- a/tl.tl
+++ b/tl.tl
@@ -742,6 +742,8 @@ local Type = record
    typeargs: {Type}
    fields: {string: Type}
    field_order: {string}
+   parent_record: Type
+   tag_value: Node
 
    -- array
    elements: Type
@@ -950,9 +952,9 @@ local function fail(ps: ParseState, i: number, msg: string): number
    return math.min(#ps.tokens, i + 1)
 end
 
-local function verify_tk(ps: ParseState, i: number, tk: string): number
+local function verify_tk(ps: ParseState, i: number, tk: string): number, boolean
    if ps.tokens[i].tk == tk then
-      return i + 1
+      return i + 1, true
    end
    return fail(ps, i, "syntax error, expected '" .. tk .. "'")
 end
@@ -1799,6 +1801,36 @@ local function parse_return(ps: ParseState, i: number): number, Node
    return i, node
 end
 
+local function parse_record_tag_declaration(ps: ParseState, i: number, def: Type): number
+   local v: Node
+   i, v = verify_kind(ps, i, "identifier", "variable")
+   if not v then
+      return fail(ps, i, "expected a record type name")
+   end
+   def.parent_record = new_type(ps, i, "nominal")
+   def.parent_record.names = { v.tk }
+
+   local ok: boolean
+   i, ok = verify_tk(ps, i, "with")
+   if not ok then
+      return i - 1
+   end
+   i, v = verify_kind(ps, i, "identifier", "variable")
+   if not v then
+      return fail(ps, i, "expected a tag field name")
+   end
+   def.tag_field = v.tk
+   i = verify_tk(ps, i, "=")
+   local lit_i = i
+   i, v = parse_literal(ps, i)
+   if v.kind ~= "string" and v.kind ~= "number" and v.kind ~= "boolean" then
+      fail(ps, lit_i, "invalid literal for tag value")
+      return i
+   end
+   def.tag_value = v
+   return i
+end
+
 parse_newtype = function(ps: ParseState, i: number): number, Node
    local node: Node = new_node(ps.tokens, i, "newtype")
    node.newtype = new_type(ps, i, "typetype")
@@ -1810,6 +1842,10 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
       i = i + 1
       if ps.tokens[i].tk == "<" then
          i, def.typeargs = parse_typearg_list(ps, i)
+      end
+      if ps.tokens[i].tk == "is" then
+         i = i + 1
+         i = parse_record_tag_declaration(ps, i, def)
       end
       while not ((not ps.tokens[i]) or ps.tokens[i].tk == "end") do
          if ps.tokens[i].tk == "{" then
@@ -2124,6 +2160,9 @@ local function recurse_type<T>(ast: Type, visit: Visitor<TypeName, Type, T>): T
    end
    if ast.def then
       table.insert(xs, recurse_type(ast.def, visit))
+   end
+   if ast.parent_record then
+      table.insert(xs, recurse_type(ast.parent_record, visit))
    end
    if ast.keys then
       table.insert(xs, recurse_type(ast.keys, visit))
@@ -4364,11 +4403,11 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return false, terr(t1, "got %s, expected %s", t1, t2)
    end
 
-   local function assert_is_a(node: Node, t1: Type, t2: Type, context: string, name: string)
+   local function assert_is_a(node: Node, t1: Type, t2: Type, context: string, name: string): boolean
       t1 = resolve_tuple(t1)
       t2 = resolve_tuple(t2)
       if lax and (is_unknown(t1) or is_unknown(t2)) then
-         return
+         return true
       end
 
       if t2.typename == "unknown_emptytable_value" then
@@ -4389,6 +4428,8 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
 
       local match, match_errs = is_a(t1, t2)
       add_errs_prefixing(match_errs, errors, "in " .. context .. ": ".. (name and (name .. ": ") or ""), node)
+
+      return match
    end
 
    local function close_types(vars: {string:Variable})
@@ -6030,6 +6071,39 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
    }
 
+   local function check_parent_record(typ: Type)
+      if not typ.parent_record then
+         return
+      end
+      local pr = resolve_unary(typ.parent_record)
+      if not is_record_type(pr) then
+         type_error(typ.parent_record, "unknown type %s", typ.parent_record)
+      elseif not pr.tag_field then
+         type_error(typ, "parent record %s does not have a tag field", typ.parent_record)
+      elseif pr.tag_field ~= typ.tag_field then
+         type_error(typ, "invalid tag '" .. typ.tag_field .. "', expected '" .. pr.tag_field .. "'")
+      else
+         if not typ.tag_value.type then
+            if typ.tag_value.kind == "string" then
+               typ.tag_value.type = STRING
+            elseif typ.tag_value.kind == "number" then
+               typ.tag_value.type = NUMBER
+            elseif typ.tag_value.kind == "boolean" then
+               typ.tag_value.type = BOOLEAN
+            end
+         end
+         assert_is_a(typ as Node, typ.tag_value.type, pr.fields[typ.tag_field], "tag value")
+         for _, f in ipairs(pr.field_order) do
+            if typ.fields[f] then
+               type_error(typ, "redefining existing field '" .. f .. "' from parent record")
+            else
+               typ.fields[f] = pr.fields[f]
+               table.insert(typ.field_order, f)
+            end
+         end
+      end
+   end
+
    local visit_type: Visitor<TypeName,Type,Type> = {
       cbs = {
          ["string"] = {
@@ -6057,6 +6131,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                end
             end,
             after = function(typ: Type, children: {Type}): Type
+               check_parent_record(typ)
                end_scope()
                for name, typ in pairs(typ.fields) do
                   if typ.typename == "nestedtype" then


### PR DESCRIPTION
Played a bit with this idea this weekend. 

The one big thing missing in this PR is actually checking that table literals conform to the tagged record type. That is, the example below works, but as you can see all literals at the bottom are using casts:

```lua
local WidgetType = enum
   "button"
   "field"
end

local Widget = record
   tag widget_type: string

   x: number
   y: number
end

local Button = record is Widget with widget_type = "button"
   text: string
end

local Field = record is Widget with widget_type = "field"
   width: number
   label: string
   input: string
end

local function draw(x: number, y: number, w: number, t: string)
end

local function show_widget(w: Widget)
   if w is Button then
      draw(w.x, w.y, 10, w.text)
   elseif w is Field then
      draw(w.x, w.y, w.width, w.label)
      draw(w.x, w.y, w.width, w.input)
   else
      draw(w.x, w.y, 10)
   end
end

local widgets: {Widget} = {
   { widget_type = "field", width = 20, label = "Name:", input = "" } as Widget,
   { widget_type = "field", width = 3, label = "Age:", input = "" } as Widget,
   { widget_type = "button", text = "OK" } as Widget,
   { widget_type = "button", text = "Cancel" } as Widget,
}

```