### PR TITLE
support lexing luajit number literals

### DIFF
--- a/spec/lexer/literals_error_spec.lua
+++ b/spec/lexer/literals_error_spec.lua
@@ -1,0 +1,8 @@
+local tl = require("tl")
+
+describe("lexer errors", function()
+    pending("when number suffixes are invalid", function()
+        local tokens, errors = tl.lex("100llilliiu")
+        assert.same(0, #tokens)
+     end)
+end)

--- a/spec/lexer/literals_spec.lua
+++ b/spec/lexer/literals_spec.lua
@@ -69,6 +69,22 @@ describe("lexer", function()
       local syntax_errors = {}
       local tokens = tl.lex("0b1001001")
       assert.same(1, #tokens)
-      assert.same("number", tokens[2].kind)
+      assert.same("number", tokens[1].kind)
+   end)
+
+   it("lexes luajit integer number suffixes", function()
+      local syntax_errors = {}
+      local tokens = tl.lex("100ll 100lL 100UlL 100ull")
+      assert.same(4, #tokens)
+      for i = 1, 4 do
+         assert.same("number", tokens[i].kind)
+      end
+   end)
+
+   it("lexes luajit complex number suffix", function()
+      local syntax_errors = {}
+      local tokens = tl.lex("100i")
+      assert.same(1, #tokens)
+      assert.same("number", tokens[1].kind)
    end)
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -118,6 +118,15 @@ for c = string.byte("A"), string.byte("F") do
    lex_hexadecimals[string.char(c)] = true
 end
 
+local lex_number_suffixes = {}
+for _, c in ipairs({
+      "u", "U",
+      "l", "L",
+      "i", "I",
+   }) do
+   lex_number_suffixes[c] = true
+end
+
 local lex_char_symbols = {}
 for _, c in ipairs({ "[", "]", "(", ")", "{", "}", ",", "#", "`", ";" }) do
    lex_char_symbols[c] = true
@@ -134,6 +143,7 @@ for _, c in ipairs({ " ", "\t", "\v", "\n", "\r" }) do
 end
 
 local LexState = {}
+
 
 
 
@@ -463,9 +473,8 @@ function tl.lex(input)
          elseif c == "." then
             state = "decimal_float"
          else
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "hex_number" then
          if c == "." then
@@ -473,23 +482,20 @@ function tl.lex(input)
          elseif c == "p" or c == "P" then
             state = "power_sign"
          elseif not lex_hexadecimals[c] then
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "binary_number" then
          if c ~= "1" and c ~= "0" then
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "hex_float" then
          if c == "p" or c == "P" then
             state = "power_sign"
          elseif not lex_hexadecimals[c] then
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "decimal_number" then
          if c == "." then
@@ -497,17 +503,15 @@ function tl.lex(input)
          elseif c == "e" or c == "E" then
             state = "power_sign"
          elseif not lex_decimals[c] then
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "decimal_float" then
          if c == "e" or c == "E" then
             state = "power_sign"
          elseif not lex_decimals[c] then
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "power_sign" then
          if c == "-" or c == "+" then
@@ -521,6 +525,11 @@ function tl.lex(input)
          end
       elseif state == "power" then
          if not lex_decimals[c] then
+            state = "number_suffix"
+            fwd = false
+         end
+      elseif state == "number_suffix" then
+         if not lex_number_suffixes[c] then
             end_token("number", i - 1)
             fwd = false
             state = "any"
@@ -535,6 +544,7 @@ function tl.lex(input)
       ["decimal_float"] = "number",
       ["hex_number"] = "number",
       ["binary_number"] = "number",
+      ["number_suffix"] = "number",
       ["hex_float"] = "number",
       ["power"] = "number",
    }

--- a/tl.tl
+++ b/tl.tl
@@ -118,6 +118,15 @@ for c = string.byte("A"), string.byte("F") do
    lex_hexadecimals[string.char(c)] = true
 end
 
+local lex_number_suffixes: {string:boolean} = {}
+for _, c in ipairs({
+   "u", "U",
+   "l", "L",
+   "i", "I"
+}) do
+   lex_number_suffixes[c] = true
+end
+
 local lex_char_symbols: {string:boolean} = {}
 for _, c in ipairs({"[", "]", "(", ")", "{", "}", ",", "#", "`", ";"}) do
    lex_char_symbols[c] = true
@@ -149,6 +158,7 @@ local LexState = enum
    "hex_number"
    "hex_float"
    "binary_number"
+   "number_suffix"
    "lt"
    "gt"
    "colon"
@@ -463,9 +473,8 @@ function tl.lex(input: string): {Token}, {Token}
          elseif c == "." then
             state = "decimal_float"
          else
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "hex_number" then
          if c == "." then
@@ -473,23 +482,20 @@ function tl.lex(input: string): {Token}, {Token}
          elseif c == "p" or c == "P" then
             state = "power_sign"
          elseif not lex_hexadecimals[c] then
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "binary_number" then
          if c ~= "1" and c ~= "0" then
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "hex_float" then
          if c == "p" or c == "P" then
             state = "power_sign"
          elseif not lex_hexadecimals[c] then
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "decimal_number" then
          if c == "." then
@@ -497,17 +503,15 @@ function tl.lex(input: string): {Token}, {Token}
          elseif c == "e" or c == "E" then
             state = "power_sign"
          elseif not lex_decimals[c] then
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "decimal_float" then
          if c == "e" or c == "E" then
             state = "power_sign"
          elseif not lex_decimals[c] then
-            end_token("number", i - 1)
+            state = "number_suffix"
             fwd = false
-            state = "any"
          end
       elseif state == "power_sign" then
          if c == "-" or c == "+" then
@@ -521,6 +525,11 @@ function tl.lex(input: string): {Token}, {Token}
          end
       elseif state == "power" then
          if not lex_decimals[c] then
+            state = "number_suffix"
+            fwd = false
+         end
+      elseif state == "number_suffix" then
+         if not lex_number_suffixes[c] then
             end_token("number", i - 1)
             fwd = false
             state = "any"
@@ -535,6 +544,7 @@ function tl.lex(input: string): {Token}, {Token}
       ["decimal_float"] = "number",
       ["hex_number"] = "number",
       ["binary_number"] = "number",
+      ["number_suffix"] = "number",
       ["hex_float"] = "number",
       ["power"] = "number",
    }


### PR DESCRIPTION
This adds support for numbers like binary numbers `0b1010` ffi integer numbers `100ull` `100LL` (which is same as `ffi.new("int64_t", 100)` and complex numbers `1234i`

This adds some complexity to the lexer where you need to check for number suffixes when it's the end of a number. It's not even correct, as in you can type 100LILILIlLL but I'm not sure how to deal with this here.

In my own lexer I've made a tree-like structure for valid combinations that i traverse for each character, and if that fails it's a syntax error. Not sure if this is something you want to introduce or think is important enough at this time.