### PR TITLE
Mention text editor support in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ We have a collaborative repository for type definitions of Lua libraries
 at https://github.com/teal-language/teal-types — check it out and make your
 contribution!
 
+## Text editor support
+
+Teal language support is currently available for [Vim](https://github.com/teal-language/vim-teal) and [Visual Studio Code](https://github.com/teal-language/vscode-teal).
+
 ## Community
 
 Join the chat on [Gitter](https://gitter.im/teal-language/community)!


### PR DESCRIPTION
Thanks to @euclidianAce, Teal language support for Vim is now quite good! I think we can advertise the plugin in the README.

I've also added a note about vscode support.

@mrtnpwn, you said you needed to update https://github.com/mrtnpwn/tl-nano?