### PR TITLE
feat(lib): add gen, process_string methods

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,0 +1,5 @@
+return {
+  default = {
+    lpath = "./?.lua";
+  }
+}

--- a/spec/api/gen_spec.lua
+++ b/spec/api/gen_spec.lua
@@ -1,0 +1,43 @@
+local tl = require("tl")
+local util = require("spec.util")
+
+describe("tl.gen", function()
+   it("can process tl strings", function()
+      local input = [[
+         local movie:string = "Star Wars: Episode"
+         local episode: number = 4
+      ]]
+
+      local expected_output = [[
+         local movie = "Star Wars: Episode"
+         local episode = 4
+      ]]
+
+      local output = tl.gen(input)
+      util.assert_line_by_line(expected_output, output)
+   end)
+
+   it("returns result on type errors", function()
+      local input = [[
+         local movie:string = 1
+      ]]
+
+      local output, result = tl.gen(input)
+
+      assert.equal('local movie = 1', output)
+      assert.match("expected string", result.type_errors[1].msg, 1, true)
+      assert.is_nil(err)
+   end)
+
+   it("returns error on syntax errors", function()
+      local input = [[
+         local movie:string =
+      ]]
+
+      local output, result = tl.gen(input)
+
+      assert.is_nil(output)
+      assert.same({}, result.type_errors)
+      assert.is_not_nil(result.syntax_errors)
+   end)
+end)

--- a/spec/api/process_spec.lua
+++ b/spec/api/process_spec.lua
@@ -1,0 +1,23 @@
+local tl = require("tl")
+local util = require("spec.util")
+
+describe("tl.process", function()
+   describe("tl.process_string", function()
+      it("can process tl strings", function()
+         local tl_code = [[
+            local movie:string = "Star Wars: Episode"
+            local episode: number = 4
+         ]]
+
+         local expected_lua_code = [[
+            local movie = "Star Wars: Episode"
+            local episode = 4
+         ]]
+
+         local result = tl.process_string(tl_code)
+         local pretty_result_string = tl.pretty_print_ast(result.ast)
+
+         util.assert_line_by_line(expected_lua_code, pretty_result_string)
+      end)
+   end)
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -14,6 +14,8 @@ local TypeCheckOptions = {}
 
 local tl = {
    process = nil,
+   process_string = nil,
+   gen = nil,
    type_check = nil,
    init_env = nil,
 }
@@ -6391,6 +6393,18 @@ function tl.process(filename, env, result, preload_modules)
       is_lua = input:match("^#![^\n]*lua[^\n]*\n")
    end
 
+   result, err = tl.process_string(input, is_lua, env, result, preload_modules, filename)
+
+   if err then
+      return nil, err
+   end
+
+   return result
+end
+
+function tl.process_string(input, is_lua, env, result, preload_modules,
+filename)
+
    env = env or tl.init_env(is_lua)
    result = result or {
       syntax_errors = {},
@@ -6439,6 +6453,20 @@ function tl.process(filename, env, result, preload_modules)
    result.env = env
 
    return result
+end
+
+function tl.gen(input)
+   local result, err = tl.process_string(input, false)
+
+   if err then
+      return nil, nil
+   end
+
+   if not result.ast then
+      return nil, result
+   end
+
+   return tl.pretty_print_ast(result.ast), result
 end
 
 local function tl_package_loader(module_name)

--- a/tl.tl
+++ b/tl.tl
@@ -14,6 +14,8 @@ end
 
 local tl = {
    process: function(string, Env, Result, {string}): (Result, string) = nil,
+   process_string: function(string, boolean, Env, Result, {string}, string): (Result, string) = nil,
+   gen: function(string): string = nil,
    type_check: function(Node, TypeCheckOptions): ({Error}, {Error}, Type) = nil,
    init_env: function(boolean, boolean): Env = nil,
 }
@@ -6391,6 +6393,18 @@ function tl.process(filename: string, env: Env, result: Result, preload_modules:
       is_lua = input:match("^#![^\n]*lua[^\n]*\n") as boolean
    end
 
+   result, err = tl.process_string(input, is_lua, env, result, preload_modules, filename)
+
+   if err then
+      return nil, err
+   end
+
+   return result
+end
+
+function tl.process_string(input: string, is_lua: boolean, env: Env, result: Result, preload_modules: {string},
+                           filename: string): Result, string
+
    env = env or tl.init_env(is_lua)
    result = result or {
       syntax_errors = {},
@@ -6439,6 +6453,20 @@ function tl.process(filename: string, env: Env, result: Result, preload_modules:
    result.env = env
 
    return result
+end
+
+function tl.gen(input: string): string, Result
+   local result, err = tl.process_string(input, false)
+
+   if err then
+      return nil, nil
+   end
+
+   if not result.ast then
+      return nil, result
+   end
+
+   return tl.pretty_print_ast(result.ast), result
 end
 
 local function tl_package_loader(module_name: string): any


### PR DESCRIPTION
Adding `tl.gen` and `tl.process_string` so that `tl`'s string processing will not be limited to file io. This will be helpful in building the browser playground, and maybe more use cases?

I noticed that my local LUA_PATH did not have `./?.lua` so that tl tests were always running tests against the source from the registry. I've added a busted config so that `lpath` can use non-registry/local `tl`.

Fixes #171 