### PR TITLE
rockspec: install both tl.lua and tl.tl

### DIFF
--- a/tl-dev-1.rockspec
+++ b/tl-dev-1.rockspec
@@ -25,6 +25,9 @@ build = {
    install = {
       bin = {
          "tl"
+      },
+      lua = {
+         "tl.tl"
       }
    },
 }


### PR DESCRIPTION
By default, tl.tl was not installed, so we couldn't `require('tl')` inside external Teal code.

Does this tweak look right? My initial attempt was 
```lua
   modules = {
      tl = { "tl.lua", "tl.tl" },
   },
```
...but then, LuaRocks would try to compile these files with GCC.