### PR TITLE
Record operator overload

### DIFF
--- a/tl.tl
+++ b/tl.tl
@@ -130,6 +130,11 @@ for _, c in ipairs({"+", "*", "/", "|", "&", "%", "^"}) do
    lex_op_start[c] = true
 end
 
+local lex_has_op: {string:boolean} = {}
+for _, c in ipairs({"+", "*", "/", "|", "&", "%", "^"}) do
+   lex_op_start[c] = true
+end
+
 local lex_space: {string:boolean} = {}
 for _, c in ipairs({" ", "\t", "\v", "\n", "\r"}) do
    lex_space[c] = true
@@ -711,6 +716,11 @@ local table_types: {TypeName:boolean} = {
    ["emptytable"] = true,
 }
 
+local HasType = record
+   ltype: Type
+   rtype: Type
+   rettype: Type
+end
 local Type = record
    {Type}
    y: number
@@ -743,6 +753,7 @@ local Type = record
    typeargs: {Type}
    fields: {string: Type}
    field_order: {string}
+   has: {string:{number:HasType}}
 
    -- array
    elements: Type
@@ -840,12 +851,14 @@ end
 
 local FactType = enum
    "is"
+   "has"
 end
 
 local Fact = record
    fact: FactType
    var: string
    typ: Type
+   op: Type
 end
 
 local KeyParsed = enum
@@ -1835,6 +1848,7 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
       local def = new_type(ps, i, "record")
       def.fields = {}
       def.field_order = {}
+      def.has = {}
       node.newtype.def = def
       i = i + 1
       if ps.tokens[i].tk == "<" then
@@ -1863,40 +1877,70 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
             if not v then
                return fail(ps, i, "expected a variable name")
             end
-            if ps.tokens[i].tk == ":" then
+            local has = false
+            if v.tk == "has" and ps.tokens[i].kind == "op" then
+               local op = ps.tokens[i].tk
+               i = verify_tk(ps, i+1, "(")
+               local ltype, rtype, rettype: Type, Type, Type
+               i, ltype = parse_type(ps, i)
+
+               i = verify_tk(ps, i, ",")
+               i, rtype = parse_type(ps, i)
+               i = verify_tk(ps, i, ")")
                i = verify_tk(ps, i, ":")
-               local t: Type
-               i, t = parse_type(ps, i)
-               if not t then
-                  return fail(ps, i, "expected a type")
+               i, rettype = parse_type(ps, i)
+               local arity = 2
+               if not def.has[op] then
+                  def.has[op] = {}
                end
-               if not def.fields[v.tk] then
-                  def.fields[v.tk] = t
-                  table.insert(def.field_order, v.tk)
-               else
-                  local prev_t = def.fields[v.tk]
-                  if t.typename == "function" and prev_t.typename == "function" then
-                     def.fields[v.tk] = new_type(ps, iv, "poly")
-                     def.fields[v.tk].types = { prev_t, t }
-                  elseif t.typename == "function" and prev_t.typename == "poly" then
-                     table.insert(prev_t.types, t)
+
+               -- print("Adding " .. op .. " to record ")
+               if def.has[op] and def.has[op][arity] then
+                  return fail(ps, i, "record already has " .. op .. " of arity " .. arity)
+               end
+               def.has[op][arity] = {
+                  ltype = ltype,
+                  rtype = rtype,
+                  rettype = rettype,
+               }
+               has = true
+            end
+            if not has then
+               if ps.tokens[i].tk == ":" then
+                  i = verify_tk(ps, i, ":")
+                  local t: Type
+                  i, t = parse_type(ps, i)
+                  if not t then
+                     return fail(ps, i, "expected a type")
+                  end
+                  if not def.fields[v.tk] then
+                     def.fields[v.tk] = t
+                     table.insert(def.field_order, v.tk)
+                  else
+                     local prev_t = def.fields[v.tk]
+                     if t.typename == "function" and prev_t.typename == "function" then
+                        def.fields[v.tk] = new_type(ps, iv, "poly")
+                        def.fields[v.tk].types = { prev_t, t }
+                     elseif t.typename == "function" and prev_t.typename == "poly" then
+                        table.insert(prev_t.types, t)
+                     else
+                        return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
+                     end
+                  end
+               elseif ps.tokens[i].tk == "=" then
+                  i = verify_tk(ps, i, "=")
+                  local nt: Node
+                  i, nt = parse_newtype(ps, i)
+                  if not nt or not nt.newtype then
+                     return fail(ps, i, "expected a type definition")
+                  end
+
+                  if not def.fields[v.tk] then
+                     def.fields[v.tk] = nt.newtype
+                     table.insert(def.field_order, v.tk)
                   else
                      return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
                   end
-               end
-            elseif ps.tokens[i].tk == "=" then
-               i = verify_tk(ps, i, "=")
-               local nt: Node
-               i, nt = parse_newtype(ps, i)
-               if not nt or not nt.newtype then
-                  return fail(ps, i, "expected a type definition")
-               end
-
-               if not def.fields[v.tk] then
-                  def.fields[v.tk] = nt.newtype
-                  table.insert(def.field_order, v.tk)
-               else
-                  return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
                end
             end
          end
@@ -6168,8 +6212,32 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
 
                a = ua
                b = ub
-               local types_op = binop_types[node.op.op]
-               node.type = types_op[a.typename] and types_op[a.typename][b.typename]
+
+               local op = node.op.op
+               if a.has and a.has[op] and a.has[op][2] then
+                  local ltype = a.has[op][2].ltype
+                  local rtype = a.has[op][2].rtype
+                  if not is_a(a, ltype) then
+                     node_error(node, "cannot use operator '" .. node.op.op:gsub("%%", "%%%%") .. "' for types %s and %s", orig_a, orig_b)
+                  elseif not is_a(b, rtype) then
+                     node_error(node, "cannot use operator '" .. node.op.op:gsub("%%", "%%%%") .. "' for types %s and %s", orig_a, orig_b)
+                  end
+                  node.type = a.has[op][2].rettype
+               elseif b.has and b.has[op] and b.has[op][2] then
+                  local ltype = b.has[op][2].ltype
+                  local rtype = b.has[op][2].rtype
+                  if not is_a(a, ltype) then
+                     node_error(node, "cannot use operator '" .. node.op.op:gsub("%%", "%%%%") .. "' for types %s and %s", orig_a, orig_b)
+                  elseif not is_a(b, rtype) then
+                     node_error(node, "cannot use operator '" .. node.op.op:gsub("%%", "%%%%") .. "' for types %s and %s", orig_a, orig_b)
+                  end
+                  node.type = b.has[op][2].rettype
+               end
+
+               if not node.type then
+                  local types_op = binop_types[node.op.op]
+                  node.type = types_op[a.typename] and types_op[a.typename][b.typename]
+               end
                if not node.type then
                   if lax and (is_unknown(a) or is_unknown(b)) then
                      node.type = UNKNOWN

--- a/tl.tl
+++ b/tl.tl
@@ -716,7 +716,7 @@ local table_types: {TypeName:boolean} = {
    ["emptytable"] = true,
 }
 
-local HasType = record
+local OpType = record
    ltype: Type
    rtype: Type
    rettype: Type
@@ -753,7 +753,7 @@ local Type = record
    typeargs: {Type}
    fields: {string: Type}
    field_order: {string}
-   has: {string:{number:HasType}}
+   has: {string:{number:OpType}}
 
    -- array
    elements: Type
@@ -1841,6 +1841,31 @@ local function parse_return(ps: ParseState, i: number): number, Node
    return i, node
 end
 
+local unary_op = {
+   ["-"] = true,
+   ["#"] = true,
+   ["~"] = true,
+}
+local bin_op = {
+   ["+"] = true,
+   ["-"] = true,
+   ["*"] = true,
+   ["%"] = true,
+   ["/"] = true,
+   ["//"] = true,
+   ["^"] = true,
+   ["&"] = true,
+   ["|"] = true,
+   ["<<"] = true,
+   [">>"] = true,
+   ["=="] = true,
+   ["~="] = true,
+   ["<="] = true,
+   [">="] = true,
+   ["<"] = true,
+   [">"] = true,
+   [".."] = true,
+}
 parse_newtype = function(ps: ParseState, i: number): number, Node
    local node: Node = new_node(ps.tokens, i, "newtype")
    node.newtype = new_type(ps, i, "typetype")
@@ -1878,26 +1903,40 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
                return fail(ps, i, "expected a variable name")
             end
             local has = false
-            if v.tk == "has" and ps.tokens[i].kind == "op" then
+            -- FIXME: checking ps.tokens[i].kind == "op" missed #
+            if v.tk == "has" and (unary_op[ps.tokens[i].tk] or bin_op[ps.tokens[i].tk]) then
                local op = ps.tokens[i].tk
+               local op_idx = i
+               local arity: number
+               if unary_op[op] and bin_op[op] then
+                  arity = 0
+               elseif unary_op[op] then
+                  arity = 1
+               else
+                  arity = 2
+               end
                i = verify_tk(ps, i+1, "(")
                local ltype, rtype, rettype: Type, Type, Type
                i, ltype = parse_type(ps, i)
-
-               i = verify_tk(ps, i, ",")
-               i, rtype = parse_type(ps, i)
+               if ps.tokens[i].tk == "," and arity == 0 then
+                  arity = 2
+               else
+                  arity = 1
+               end
+               if def.has[op] and def.has[op][arity] then
+                  return fail(ps, op_idx, "attempt to redeclare overloaded " .. (unary_op[op] and bin_op[op] and (arity==1 and "unary " or "binary ") or "")  .. op)
+               end
+               if arity == 2 then
+                  i = verify_tk(ps, i, ",")
+                  i, rtype = parse_type(ps, i)
+               end
                i = verify_tk(ps, i, ")")
                i = verify_tk(ps, i, ":")
                i, rettype = parse_type(ps, i)
-               local arity = 2
                if not def.has[op] then
                   def.has[op] = {}
                end
 
-               -- print("Adding " .. op .. " to record ")
-               if def.has[op] and def.has[op][arity] then
-                  return fail(ps, i, "record already has " .. op .. " of arity " .. arity)
-               end
                def.has[op][arity] = {
                   ltype = ltype,
                   rtype = rtype,
@@ -6195,9 +6234,15 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                   end
                end
             elseif node.op.arity == 1 and unop_types[node.op.op] then
+               local op = node.op.op
                a = ua
-               local types_op = unop_types[node.op.op]
-               node.type = types_op[a.typename]
+               if a.has and a.has[op] and a.has[op][1] then
+                  node.type = a.has[op][1].rettype
+               end
+               if not node.type then
+                  local types_op = unop_types[op]
+                  node.type = types_op[a.typename]
+               end
                if not node.type then
                   if lax and is_unknown(a) then
                      node.type = UNKNOWN


### PR DESCRIPTION
Should close #190, I've written some basic tests for this, but generics are still a problem and I'm not 100% sold on the syntax. Additionally, unary operators shouldn't need their input's specified because they can't be called without the type being the argument. (binary ops need it because order and operations with other types will care)

So just a review of the issue I opened:
- syntax:
```
local Vector = record
   {number}

   has +(Vector, Vector): Vector
   has -(Vector, Vector): Vector
   has -(Vector): Vector
end

local a: Vector = {}
local b: Vector = a + a -- doesn't error! :D (at least at compile time)
```

still some opportunity for a 'has' operator, but I don't see much of a use case for it
```
if a has + then
   local b = a + a
end
```

But I do think this opens up some opportunity to do some refactors of how binary and unary operations are handled.

Additionally, the errors generated by overloading one operator multiple times are considered syntax errors which at first seemed wrong, but I guess makes sense.

Anywho, I'd like your thoughts on this. The syntax is easy to change and the logic was actually not too hard to implement (hopefully it actually works correctly).

(also generics are a little broken something like `has +(Vector<T>, T): Vector<T>` doesn't work due to the single `T` and I'm not exactly sure how those get resolved yet, furthermore stuff like `has +<T>(Vector, T): T should probably be allowed`)