### PR TITLE
Type declaration changes

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -28,13 +28,17 @@ precedence, see below.
        ‘for’ Name ‘=’ exp ‘,’ exp [‘,’ exp] ‘do’ block ‘end’ |
        ‘for’ namelist ‘in’ explist ‘do’ block ‘end’ |
        ‘function’ funcname funcbody |
-       ‘local’ ‘function’ Name funcbody |
 +      ‘local’ attnamelist [‘:’ typelist] [‘=’ explist] |
-+      ‘local’ Name ‘=’ newtype |
+       ‘local’ ‘function’ Name funcbody |
+*      ‘local’ ‘record’ Name recordbody |
+*      ‘local’ ‘enum’ Name enumbody |
+*      ‘local’ ‘type’ Name ‘=’ newtype |
+*      ‘global’ attnamelist ‘:’ typelist [‘=’ explist] |
+*      ‘global’ attnamelist ‘=’ explist |
 *      ‘global’ ‘function’ Name funcbody |
-*      ‘global’ attnamelist ‘:’ typelist |
-*      ‘global’ attnamelist [‘:’ typelist] ‘=’ explist
-*      ‘global’ Name ‘=’ newtype
+*      ‘global’ ‘record’ Name recordbody |
+*      ‘global’ ‘enum’ Name enumbody |
+*      ‘global’ ‘type’ Name ‘=’ newtype
 
    attnamelist ::=  Name [attrib] {‘,’ Name [attrib]}
 
@@ -76,7 +80,9 @@ precedence, see below.
 
    field ::= ‘[’ exp ‘]’ ‘=’ exp |
 +     Name [‘:’ type] ‘=’ exp |
-*     Name ‘=’ newtype |
+*     ‘record’ Name recordbody |
+*     ‘enum’ Name enumbody |
+*     ‘type’ Name ‘=’ newtype |
       exp
 
    fieldsep ::= ‘,’ | ‘;’
@@ -91,7 +97,7 @@ precedence, see below.
 *  type ::= ‘(’ type ‘)’ | basetype {‘|’ basetype}
 
 *  basetype ::= ‘string’ | ‘boolean’ | ‘nil’ | ‘number’ |
-*      ‘{’ type ‘}’ | ‘{’ type ‘:’ type ‘}’ | ‘function’ functiontype
+*      ‘{’ type ‘}’ | ‘{’ type ‘:’ type ‘}’ | functiontype
 *      | Name {{‘.’ Name }} [typeargs]
 
 *  typelist ::= type {‘,’ type}
@@ -100,11 +106,13 @@ precedence, see below.
 
 *  typeargs ::= ‘<’ Name {‘,’ Name } ‘>’
 
-*  newtype ::= ‘record’ [typeargs] [‘{’ type ‘}’] {Name ‘=’ newtype} {Name ‘:’ type} ‘end’ |
-*      ‘enum’ {LiteralString} ‘end’ |
-*      ‘functiontype’ functiontype
+*  newtype ::= ‘record’ recordbody | ‘enum’ enumbody | type
 
-*  functiontype ::= [typeargs] ‘(’ partypelist ‘)’ [‘:’ retlist]
+*  recordbody ::= [typeargs] [‘{’ type ‘}’] {Name ‘=’ newtype} {Name ‘:’ type} ‘end’
+
+*  enumbody ::= {LiteralString} ‘end’
+
+*  functiontype ::= ‘function’ [typeargs] ‘(’ partypelist ‘)’ [‘:’ retlist]
 
 *  partypelist ::= partype {‘,’ partype}
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -300,12 +300,27 @@ different value type. Records (named as such in honor of the Algol/Pascal
 tradition from which Lua gets much of the feel of its syntax) can be used
 to represent objects, "structs", etc.
 
-To declare a record variable you need to refer by name to a record type, which
-describes the set of valid fields (keys of type string and their values of
-specific types) this record can take.
+To declare a record variable, you need to create a record type first.
+The type describes the set of valid fields (keys of type string and their values of
+specific types) this record can take. You can declare types using `local type`
+and global types using `global type`.
 
 ```
-local Point = record
+local type Point = record
+   x: number
+   y: number
+end
+```
+
+Types are constant: you cannot reassign them, and they must be initialized
+with a type on declaration.
+
+Just like with functions in Lua, which can be declared either with `local f =
+function()` or with `local function f()`, there is also a shorthand syntax
+available for the declaration of record types:
+
+```
+local record Point
    x: number
    y: number
 end
@@ -364,7 +379,7 @@ callback to be defined by users of a module you are creating), you can declare
 the type of the function field in the record and fill it later from anywhere:
 
 ```
-local Obj = record
+local record Obj
    location: Point
    draw: function(Obj)
 end
@@ -375,7 +390,7 @@ following is an arrayrecord. You can use it both as a record, accessing its
 fields by name, and as an array, accessing its entries by number.
 
 ```
-local Node = record
+local record Node
    {Node}
    weight: number
    name: string
@@ -390,9 +405,9 @@ when exporting a module as a record, so that the types created in the module
 can be used by the client code which requires the module.
 
 ```
-local http = record
+local record http
 
-   Response = record
+   record Response
       status_code: number
    end
 
@@ -434,7 +449,7 @@ we declare the type variables in angle brackets and use them as types. Generic
 records are declared and used like this:
 
 ```
-local Tree = record<X>
+local type Tree = record<X>
    {Tree<X>}
    item: X
 end
@@ -455,7 +470,18 @@ enumeration of possible values.
 You describe an enum like this:
 
 ```
-local Direction = enum
+local type Direction = enum
+   "north"
+   "south"
+   "east"
+   "west"
+end
+```
+
+or like this:
+
+```
+local enum Direction
    "north"
    "south"
    "east"
@@ -474,11 +500,11 @@ various examples.
 
 You can declare nominal function types, like we do for records, to avoid
 longwinded type declarations, especially when declaring functions that take
-callbacks. This is done with using `functiontype`, and they can be generic as
+callbacks. This is done with using `function` types, and they can be generic as
 well:
 
 ```
-local Comparator = functiontype<T>(T, T): boolean
+local type Comparator = function<T>(T, T): boolean
 
 local function mysort<A>(arr: {A}, cmp: Comparator<A>)
    -- ...
@@ -688,7 +714,7 @@ as their definition has been previously required:
 -- mymod.tl
 local mymod = {}
 
-global MyPoint = record
+global type MyPoint = record
    x: number
    y: number
 end

--- a/spec/api/gen_spec.lua
+++ b/spec/api/gen_spec.lua
@@ -41,7 +41,7 @@ describe("tl.gen", function()
 
    it("does not crash on inference errors due to a lack of a filename", function()
       local input = [[
-          local Point = record
+          local type Point = record
              x: number
              y: number
           end

--- a/spec/arguments/array_spec.lua
+++ b/spec/arguments/array_spec.lua
@@ -16,7 +16,7 @@ describe("array argument", function()
    }))
 
    it("constructs type of complex array correctly (#111)", util.check_type_error([[
-      local MyRecord = record
+      local type MyRecord = record
          func: function<K, V>(t: {{K:V}}): {V}
       end
 

--- a/spec/arguments/boolean_spec.lua
+++ b/spec/arguments/boolean_spec.lua
@@ -29,7 +29,7 @@ describe("boolean argument", function()
          end
       end
 
-      local R = record
+      local type R = record
          b: boolean
       end
       local r: R = {}

--- a/spec/arguments/enum_spec.lua
+++ b/spec/arguments/enum_spec.lua
@@ -2,7 +2,7 @@ local util = require("spec.util")
 
 describe("enum argument", function()
    it("accepts a valid string", util.check [[
-      local Direction = enum
+      local type Direction = enum
          "north"
          "south"
          "east"
@@ -17,7 +17,7 @@ describe("enum argument", function()
    ]])
 
    it("rejects an invalid string", util.check_type_error([[
-      local Direction = enum
+      local type Direction = enum
          "north"
          "south"
          "east"

--- a/spec/arguments/record_spec.lua
+++ b/spec/arguments/record_spec.lua
@@ -2,7 +2,7 @@ local util = require("spec.util")
 
 describe("record argument", function()
    it("catches error passing map when record is expected", util.check_type_error([[
-      local node_t = record
+      local type node_t = record
          node: {string: node_t}
       end
 

--- a/spec/assignment/to_enum_spec.lua
+++ b/spec/assignment/to_enum_spec.lua
@@ -2,7 +2,7 @@ local util = require("spec.util")
 
 describe("assignment to enum", function()
    it("accepts a valid string", util.check [[
-      local Direction = enum
+      local type Direction = enum
          "north"
          "south"
          "east"
@@ -15,7 +15,7 @@ describe("assignment to enum", function()
    ]])
 
    it("rejects an invalid string", util.check_type_error([[
-      local Direction = enum
+      local type Direction = enum
          "north"
          "south"
          "east"

--- a/spec/assignment/to_map_spec.lua
+++ b/spec/assignment/to_map_spec.lua
@@ -9,7 +9,7 @@ describe("assignment to maps", function()
    ]])
 
    it("resolves strings to enum", util.check [[
-      local Direction = enum
+      local type Direction = enum
          "north"
          "south"
          "east"

--- a/spec/assignment/to_multiple_variables_spec.lua
+++ b/spec/assignment/to_multiple_variables_spec.lua
@@ -17,7 +17,7 @@ describe("assignment to multiple variables", function()
    }))
 
    it("reports unsufficient rvalues as an error, tricky", util.check_type_error([[
-      local T = record
+      local type T = record
          x: number
          y: number
       end

--- a/spec/assignment/to_nominal_arrayrecord_spec.lua
+++ b/spec/assignment/to_nominal_arrayrecord_spec.lua
@@ -2,7 +2,7 @@ local util = require("spec.util")
 
 describe("assignment to nominal arrayrecord", function()
    it("accepts empty table", util.check [[
-      local Node = record
+      local type Node = record
          {Node}
          foo: boolean
       end
@@ -10,7 +10,7 @@ describe("assignment to nominal arrayrecord", function()
    ]])
 
    it("accepts complete fields without array entries", util.check [[
-      local Node = record
+      local type Node = record
          {Node}
          foo: boolean
       end
@@ -20,7 +20,7 @@ describe("assignment to nominal arrayrecord", function()
    ]])
 
    it("accepts complete fields with array entries", util.check [[
-      local Node = record
+      local type Node = record
          {Node}
          foo: boolean
       end
@@ -34,7 +34,7 @@ describe("assignment to nominal arrayrecord", function()
    ]])
 
    it("accepts incomplete fields without array entries", util.check [[
-      local Node = record
+      local type Node = record
          {Node}
          foo: boolean
          bar: number
@@ -45,7 +45,7 @@ describe("assignment to nominal arrayrecord", function()
    ]])
 
    it("accepts complete fields with array entries", util.check [[
-      local Node = record
+      local type Node = record
          {Node}
          foo: boolean
          bar: number
@@ -60,7 +60,7 @@ describe("assignment to nominal arrayrecord", function()
    ]])
 
    it("fails if table has extra fields", util.check_type_error([[
-      local Node = record
+      local type Node = record
          {Node}
          foo: boolean
          bar: number
@@ -74,7 +74,7 @@ describe("assignment to nominal arrayrecord", function()
    }))
 
    it("fails if mismatch", util.check_type_error([[
-      local Node = record
+      local type Node = record
          {Node}
          foo: boolean
       end

--- a/spec/assignment/to_nominal_record_field_spec.lua
+++ b/spec/assignment/to_nominal_record_field_spec.lua
@@ -2,10 +2,10 @@ local util = require("spec.util")
 
 describe("assignment to nominal record field", function()
    it("passes", util.check [[
-      local Node = record
+      local type Node = record
          foo: boolean
       end
-      local Type = record
+      local type Type = record
          node: Node
       end
       local t: Type = {}
@@ -13,10 +13,10 @@ describe("assignment to nominal record field", function()
    ]])
 
    it("fails if mismatch", util.check_type_error([[
-      local Node = record
+      local type Node = record
          foo: boolean
       end
-      local Type = record
+      local type Type = record
          node: Node
       end
       local t: Type = {}

--- a/spec/assignment/to_nominal_record_field_spec.lua
+++ b/spec/assignment/to_nominal_record_field_spec.lua
@@ -26,7 +26,7 @@ describe("assignment to nominal record field", function()
    }))
 
    it("fails with incorrect literal index", util.check_type_error([[
-      local Node = record
+      local type Node = record
           f: string
       end
 
@@ -37,7 +37,7 @@ describe("assignment to nominal record field", function()
    }))
 
    it("fails with variable index with arbitrary string", util.check_type_error([[
-      local Node = record
+      local type Node = record
           f: string
       end
 
@@ -49,12 +49,12 @@ describe("assignment to nominal record field", function()
    }))
 
    it("succeeds with variable index with enum", util.check [[
-      local Node = record
+      local type Node = record
           f: string
           g: string
       end
 
-      local Keys = enum
+      local type Keys = enum
          "f"
          "g"
       end

--- a/spec/assignment/to_nominal_record_spec.lua
+++ b/spec/assignment/to_nominal_record_spec.lua
@@ -2,21 +2,21 @@ local util = require("spec.util")
 
 describe("assignment to nominal record", function()
    it("accepts empty table", util.check [[
-      local Node = record
+      local type Node = record
          b: boolean
       end
       local x: Node = {}
    ]])
 
    it("accepts complete table", util.check [[
-      local R = record
+      local type R = record
          foo: string
       end
-      local AR = record
+      local type AR = record
          {Node}
          bar: string
       end
-      local Node = record
+      local type Node = record
          b: boolean
          n: number
          m: {number: string}
@@ -35,7 +35,7 @@ describe("assignment to nominal record", function()
    ]])
 
    it("accepts incomplete table", util.check [[
-      local Node = record
+      local type Node = record
          b: boolean
          n: number
       end
@@ -45,7 +45,7 @@ describe("assignment to nominal record", function()
    ]])
 
    it("fails if table has extra fields", util.check_type_error([[
-      local Node = record
+      local type Node = record
          b: boolean
          n: number
       end
@@ -58,7 +58,7 @@ describe("assignment to nominal record", function()
    }))
 
    it("fails if mismatch", util.check_type_error([[
-      local Node = record
+      local type Node = record
          b: boolean
       end
       local x: Node = 123
@@ -67,11 +67,11 @@ describe("assignment to nominal record", function()
    }))
 
    it("type system is nominal: fails if different records with compatible structure", util.check_type_error([[
-      local Node1 = record
+      local type Node1 = record
          b: boolean
       end
 
-      local Node2 = record
+      local type Node2 = record
          b: boolean
       end
 
@@ -83,7 +83,7 @@ describe("assignment to nominal record", function()
    }))
 
    it("identical generic instances resolve to the same type", util.check [[
-      local R = record<T>
+      local type R = record<T>
          x: T
       end
 

--- a/spec/assignment/to_self_record_field_spec.lua
+++ b/spec/assignment/to_self_record_field_spec.lua
@@ -2,7 +2,7 @@ local util = require("spec.util")
 
 describe("assignment to self record field", function()
    it("passes", util.check [[
-      local Node = record
+      local type Node = record
          foo: boolean
       end
       function Node:method()
@@ -11,7 +11,7 @@ describe("assignment to self record field", function()
    ]])
 
    it("fails if mismatch", util.check_type_error([[
-      local Node = record
+      local type Node = record
          foo: string
       end
       function Node:method()

--- a/spec/assignment/to_union_spec.lua
+++ b/spec/assignment/to_union_spec.lua
@@ -62,7 +62,7 @@ describe("assignment to union", function()
    ]])
 
    it("resolves arrays of unions", util.check [[
-      local Item = record
+      local type Item = record
          name: string
       end
 

--- a/spec/call/generic_function_spec.lua
+++ b/spec/call/generic_function_spec.lua
@@ -141,7 +141,7 @@ describe("generic function", function()
          return n, ret
       end
 
-      local Node = record
+      local type Node = record
          foo: number
       end
 
@@ -185,7 +185,7 @@ describe("generic function", function()
    }))
 
    it("will catch if argument value does not match the typevar", util.check_type_error([[
-      local Output = record
+      local type Output = record
          {string}
          x: number
       end
@@ -214,11 +214,11 @@ describe("generic function", function()
          return n, ret
       end
 
-      local Node = record
+      local type Node = record
          foo: number
       end
 
-      local Other = record
+      local type Other = record
          bar: string
       end
 
@@ -246,7 +246,7 @@ describe("generic function", function()
          return n, ret
       end
 
-      local Node = record
+      local type Node = record
          foo: number
       end
 
@@ -260,10 +260,10 @@ describe("generic function", function()
    ]])
 
    it("checks that missing typevars are caught", util.check_type_error([[
-      local Node = record
+      local type Node = record
       end
 
-      local VisitorCallbacks = record<X, Y>
+      local type VisitorCallbacks = record<X, Y>
       end
 
       local function recurse_node<T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, T>}, visit_type: {string:VisitorCallbacks<Type, T>}): T
@@ -280,13 +280,13 @@ describe("generic function", function()
    }))
 
    it("propagates resolved typevar in return type", util.check [[
-      local Node = record
+      local type Node = record
       end
 
-      local Type = record
+      local type Type = record
       end
 
-      local VisitorCallbacks = record<N, X>
+      local type VisitorCallbacks = record<N, X>
       end
 
       local function recurse_node<T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, T>}, visit_type: {string:VisitorCallbacks<Type, T>}): T
@@ -300,13 +300,13 @@ describe("generic function", function()
    ]])
 
    it("checks that typevars that appear in multiple arguments must match, pass", util.check [[
-      local Node = record
+      local type Node = record
       end
 
-      local Type = record
+      local type Type = record
       end
 
-      local VisitorCallbacks = record<X, Y>
+      local type VisitorCallbacks = record<X, Y>
       end
 
       local function recurse_node<T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, T>}, visit_type: {string:VisitorCallbacks<Type, T>}): T
@@ -320,13 +320,13 @@ describe("generic function", function()
    ]])
 
    it("checks that typevars that appear in multiple arguments must match, fail", util.check_type_error([[
-      local Node = record
+      local type Node = record
       end
 
-      local Type = record
+      local type Type = record
       end
 
-      local VisitorCallbacks = record<X, Y>
+      local type VisitorCallbacks = record<X, Y>
       end
 
       local function recurse_node<T>(ast: Node, visit_node: {string:VisitorCallbacks<Node, T>}, visit_type: {string:VisitorCallbacks<Type, T>})
@@ -342,7 +342,7 @@ describe("generic function", function()
    }))
 
    it("inference trickles down to function arguments, pass", util.check [[
-      local R = record
+      local type R = record
          arch: string
       end
       local data: {R} = {
@@ -353,10 +353,10 @@ describe("generic function", function()
    ]])
 
    it("inference trickles down to function arguments, pass", util.check_type_error([[
-      local R = record
+      local type R = record
          arch: string
       end
-      local S = record
+      local type S = record
          different: string
       end
       local data: {R} = {

--- a/spec/call/generic_function_spec.lua
+++ b/spec/call/generic_function_spec.lua
@@ -2,12 +2,12 @@ local tl = require("tl")
 local util = require("spec.util")
 
 describe("generic function", function()
-   it("can declare a generic functiontype", util.check [[
-      local ParseItem = functiontype<T>(number): T
+   it("can declare a generic function type", util.check [[
+      local type ParseItem = function<T>(number): T
    ]])
 
-   it("can declare a function using the functiontype as an argument", util.check [[
-      local ParseItem = functiontype<T>(number): T
+   it("can declare a function using the function type as an argument", util.check [[
+      local type ParseItem = function<T>(number): T
 
       local function parse_list<T>(list: {T}, parse_item: ParseItem): number, T
          return 0, list[1]
@@ -15,7 +15,7 @@ describe("generic function", function()
    ]])
 
    it("can use the typevar in the function body", util.check [[
-      local ParseItem = functiontype<T>(number): T
+      local type ParseItem = function<T>(number): T
 
       local function parse_list<T>(list: {T}, parse_item: ParseItem): number, {T}
          local ret: {T} = {}
@@ -25,7 +25,7 @@ describe("generic function", function()
    ]])
 
    it("can use the function along with a typevar", util.check [[
-      local Id = functiontype<a>(a): a
+      local type Id = function<a>(a): a
 
       local function string_id(a: string): string
          return a
@@ -39,7 +39,7 @@ describe("generic function", function()
    ]])
 
    it("does not mix up typevars with the same name in different scopes", util.check [[
-      local Convert = functiontype<a, b>(a): b
+      local type Convert = function<a, b>(a): b
 
       local function id<a>(x: a): a
          return x
@@ -63,7 +63,7 @@ describe("generic function", function()
    ]])
 
    it("catches incorrect typevars, does not mix up multiple uses", util.check_type_error([[
-      local Convert = functiontype<a, b>(a): b
+      local type Convert = function<a, b>(a): b
 
       local function convert_num_str(n: number): string
          return tostring(n)
@@ -83,7 +83,7 @@ describe("generic function", function()
    }))
 
    it("will catch if resolved typevar does not match", util.check_type_error([[
-      local Id = functiontype<a>(a): a
+      local type Id = function<a>(a): a
 
       local function string_id(a: string): string
          return a
@@ -99,7 +99,7 @@ describe("generic function", function()
    }))
 
    it("can use the function along with an indirect typevar", util.check [[
-      local Id = functiontype<a>(a): a
+      local type Id = function<a>(a): a
 
       local function string_id(a: string): string
          return a
@@ -113,7 +113,7 @@ describe("generic function", function()
    ]])
 
    it("will catch if resolved indirect typevar does not match", util.check_type_error([[
-      local Id = functiontype<a>(a): a
+      local type Id = function<a>(a): a
 
       local function string_id(a: string): string
          return a
@@ -129,7 +129,7 @@ describe("generic function", function()
    }))
 
    it("can use the function along with an indirect typevar", util.check [[
-      local ParseItem = functiontype<X>(number): X
+      local type ParseItem = function<X>(number): X
 
       local function parse_list<T>(list: {T}, parse_item: ParseItem<T>): number, {T}
          local ret: {T} = {}
@@ -202,7 +202,7 @@ describe("generic function", function()
    }))
 
    it("will catch if resolved typevar does not match", util.check_type_error([[
-      local ParseItem = functiontype<V>(number): V
+      local type ParseItem = function<V>(number): V
 
       local function parse_list<T>(list: {T}, parse_item: ParseItem<T>): number, {T}
          local ret: {T} = {}
@@ -234,7 +234,7 @@ describe("generic function", function()
    }))
 
    it("can map one typevar to another", util.check [[
-      local ParseItem = functiontype<V>(number): V
+      local type ParseItem = function<V>(number): V
 
       local function parse_list<T>(list: {T}, parse_item: ParseItem<T>): number, {T}
          local ret: {T} = {}

--- a/spec/cli/gen_spec.lua
+++ b/spec/cli/gen_spec.lua
@@ -4,7 +4,7 @@ local util = require("spec.util")
 local input_file = [[
 global type1 = 2
 
-local type_2 = record
+local type type_2 = record
 end
 
 local function bla()

--- a/spec/declaration/array_spec.lua
+++ b/spec/declaration/array_spec.lua
@@ -14,6 +14,13 @@ describe("array declarations", function()
       print(x[10])
    ]])
 
+   it("can be declared as a nominal type", util.check [[
+      local type Booleans = {boolean}
+      local bs: Booleans = {
+         true, false, [12] = true,
+      }
+   ]])
+
    it("can be indirect", util.check [[
       local RED = 1
       local BLUE = 2

--- a/spec/declaration/enum_spec.lua
+++ b/spec/declaration/enum_spec.lua
@@ -1,0 +1,99 @@
+local util = require("spec.util")
+
+describe("enum declaration", function()
+   it("declares a enum with local type", util.check [[
+      local type t = enum
+         "left"
+         "right"
+      end
+
+      local func = function(b: boolean): t
+         if b then
+            return "left"
+         else
+            return "right"
+         end
+      end
+   ]])
+
+   it("declares a enum with local enum", util.check [[
+      local enum t
+         "left"
+         "right"
+      end
+
+      local func = function(b: boolean): t
+         if b then
+            return "left"
+         else
+            return "right"
+         end
+      end
+   ]])
+
+   it("declares a enum with global type", util.check [[
+      global type t = enum
+         "left"
+         "right"
+      end
+
+      global func = function(b: boolean): t
+         if b then
+            return "left"
+         else
+            return "right"
+         end
+      end
+   ]])
+
+   it("declares a enum with global enum", util.check [[
+      global enum t
+         "left"
+         "right"
+      end
+
+      global func = function(b: boolean): t
+         if b then
+            return "left"
+         else
+            return "right"
+         end
+      end
+   ]])
+
+   it("produces a nice error when local declared with the old syntax", util.check_syntax_error([[
+      local t = enum
+         "left"
+         "right"
+      end
+
+      local func = function(b: boolean): t
+         if b then
+            return "left"
+         else
+            return "right"
+         end
+      end
+   ]], {
+      { y = 1, msg = "syntax error: this syntax is no longer valid; use 'local enum t'" },
+      { msg = "syntax error" },
+   }))
+
+   it("produces a nice error when global declared with the old syntax", util.check_syntax_error([[
+      global t = enum
+         "left"
+         "right"
+      end
+
+      local func = function(b: boolean): t
+         if b then
+            return "left"
+         else
+            return "right"
+         end
+      end
+   ]], {
+      { y = 1, msg = "syntax error: this syntax is no longer valid; use 'global enum t'" },
+      { msg = "syntax error" },
+   }))
+end)

--- a/spec/declaration/functiontype_spec.lua
+++ b/spec/declaration/functiontype_spec.lua
@@ -2,7 +2,7 @@ local util = require("spec.util")
 
 describe("functiontype declaration", function()
    it("declares a functiontype", util.check [[
-      local t = functiontype(number, number): string
+      local type t = function(number, number): string
 
       local func = function(a: number, b: number): string
          return tostring(a + b)
@@ -10,7 +10,7 @@ describe("functiontype declaration", function()
    ]])
 
    it("functiontype can return a union including itself (#135)", util.check [[
-      local F = functiontype(): F | number
+      local type F = function(): F | number
 
       local i = 5
       local func: F

--- a/spec/declaration/functiontype_spec.lua
+++ b/spec/declaration/functiontype_spec.lua
@@ -9,6 +9,16 @@ describe("functiontype declaration", function()
       end
    ]])
 
+   it("produces a nice error when declared with the old syntax", util.check_syntax_error([[
+      local t = functiontype(number, number): string
+
+      local func = function(a: number, b: number): string
+         return tostring(a + b)
+      end
+   ]], {
+      { y = 1, msg = "syntax error: this syntax is no longer valid; use 'local type t = function('..." },
+   }))
+
    it("functiontype can return a union including itself (#135)", util.check [[
       local type F = function(): F | number
 

--- a/spec/declaration/local_spec.lua
+++ b/spec/declaration/local_spec.lua
@@ -95,5 +95,13 @@ describe("local", function()
       ]], {
          { msg = "b" },
       }))
+
+      it("'type', 'record' and 'enum' are not reserved keywords", util.check [[
+         local type = type
+         local record: string = "hello"
+         local enum: number = 123
+         print(record)
+         print(enum + 123)
+      ]])
    end)
 end)

--- a/spec/declaration/local_spec.lua
+++ b/spec/declaration/local_spec.lua
@@ -63,7 +63,7 @@ describe("local", function()
       end)
 
       it("reports unset and untyped values as errors in tl mode", util.check_type_error([[
-         local T = record
+         local type T = record
             x: number
             y: number
          end
@@ -80,7 +80,7 @@ describe("local", function()
       }))
 
       it("reports unset values as unknown in Lua mode", util.lax_check([[
-         local T = record
+         local type T = record
             x: number
             y: number
          end

--- a/spec/declaration/record_method_spec.lua
+++ b/spec/declaration/record_method_spec.lua
@@ -158,7 +158,7 @@ describe("record method", function()
    it("allows colon notation in methods", function()
       util.mock_io(finally, {
          ["foo.tl"] = [[
-            local Point = record
+            local type Point = record
                x: number
                y: number
                __index: Point
@@ -229,7 +229,7 @@ describe("record method", function()
    it("allows functions declared on method tables (#27)", function()
       util.mock_io(finally, {
          ["foo.tl"] = [[
-            local Point = record
+            local type Point = record
                x: number
                y: number
             end

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -23,6 +23,20 @@ describe("records", function()
       p.y = 12
    ]])
 
+   it("produces a nice error when declared with bare 'local'", util.check_syntax_error([[
+      local Point = record
+         x: number
+         y: number
+      end
+
+      local p: Point = {}
+      p.x = 12
+      p.y = 12
+   ]], {
+      { y = 1, msg = "syntax error: this syntax is no longer valid; use 'local record Point'" },
+      { msg = "syntax error" },
+   }))
+
    it("can be declared with 'global type'", util.check [[
       global type Point = record
          x: number

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -2,7 +2,7 @@ local util = require("spec.util")
 
 describe("records", function()
    it("can have self-references", util.check [[
-      local SLAXML = record
+      local type SLAXML = record
           parse: function(self: SLAXML, xml: string, anotherself: SLAXML)
        end
 
@@ -11,11 +11,11 @@ describe("records", function()
    ]])
 
    it("can have circular type dependencies", util.check [[
-      local R = record
+      local type R = record
          foo: S
       end
 
-      local S = record
+      local type S = record
          foo: R
       end
 
@@ -25,16 +25,16 @@ describe("records", function()
    ]])
 
    it("can have circular type dependencies on nested types", util.check [[
-      local R = record
-         R2 = record
+      local type R = record
+         type R2 = record
             foo: S.S2
          end
 
          foo: S
       end
 
-      local S = record
-         S2 = record
+      local type S = record
+         type S2 = record
             foo: R.R2
          end
 
@@ -47,16 +47,16 @@ describe("records", function()
    ]])
 
    it("can detect errors in type dependencies on nested types", util.check_type_error([[
-      local R = record
-         R2 = record
+      local type R = record
+         type R2 = record
             foo: S.S3
          end
 
          foo: S
       end
 
-      local S = record
-         S2 = record
+      local type S = record
+         type S2 = record
             foo: R.R2
          end
 
@@ -71,12 +71,12 @@ describe("records", function()
    }))
 
    it("can overload functions", util.check [[
-      global love_graphics = record
+      global type love_graphics = record
          print: function(text: string, x: number, y: number, r: number, sx: number, sy: number, ox: number, oy: number, kx: number, ky:number)
          print: function(coloredtext: {any}, x: number, y: number, r: number, sx: number, sy: number, ox: number, oy: number, kx: number, ky:number)
       end
 
-      global love = record
+      global type love = record
          graphics: love_graphics
       end
 
@@ -86,7 +86,7 @@ describe("records", function()
    ]])
 
    it("cannot overload other things", util.check_syntax_error([[
-      global love_graphics = record
+      global type love_graphics = record
          print: number
          print: string
       end
@@ -96,7 +96,7 @@ describe("records", function()
 
    it("can report an error on unknown types in polymorphic definitions", util.check_type_error([[
       -- this reports an error
-      local R = record
+      local type R = record
          u: function(): UnknownType
          u: function(): string
       end
@@ -110,7 +110,7 @@ describe("records", function()
 
    it("can report an error on unknown types in polymorphic definitions in any order", util.check_type_error([[
       -- this reports an error
-      local R = record
+      local type R = record
          u: function(): string
          u: function(): UnknownType
       end
@@ -123,14 +123,14 @@ describe("records", function()
    }))
 
    it("can produce an intersection type for polymorphic functions", util.check [[
-      local requests = record
+      local type requests = record
 
-         RequestOpts = record
+         type RequestOpts = record
             {string}
             url: string
          end
 
-         Response = record
+         type Response = record
             status_code: number
          end
 
@@ -144,14 +144,14 @@ describe("records", function()
    ]])
 
    it("can check the arity of polymorphic functions", util.check_type_error([[
-      local requests = record
+      local type requests = record
 
-         RequestOpts = record
+         type RequestOpts = record
             {string}
             url: string
          end
 
-         Response = record
+         type Response = record
             status_code: number
          end
 
@@ -169,14 +169,14 @@ describe("records", function()
    it("can be nested", function()
       util.mock_io(finally, {
          ["req.d.tl"] = [[
-            local requests = record
+            local type requests = record
 
-               RequestOpts = record
+               type RequestOpts = record
                   {string}
                   url: string
                end
 
-               Response = record
+               type Response = record
                   status_code: number
                end
 
@@ -200,8 +200,8 @@ describe("records", function()
    end)
 
    it("can have nested generic records", util.check [[
-      local foo = record
-         bar = record<T>
+      local type foo = record
+         type bar = record<T>
             x: T
          end
          example: bar<string>
@@ -213,8 +213,8 @@ describe("records", function()
    ]])
 
    it("can extend generic functions", util.check [[
-      local foo = record
-         bar = function<T>(T)
+      local type foo = record
+         type bar = function<T>(T)
          example: bar<string>
       end
 
@@ -224,8 +224,8 @@ describe("records", function()
    ]])
 
    it("does not produce an esoteric type error (#167)", util.check_type_error([[
-      local foo = record
-         bar = function<T>(T)
+      local type foo = record
+         type bar = function<T>(T)
          example: bar<string>
       end
 
@@ -238,8 +238,8 @@ describe("records", function()
    }))
 
    it("can cast generic member using full path of type name", util.check [[
-      local foo = record
-         bar = function<T>(T)
+      local type foo = record
+         type bar = function<T>(T)
          example: bar<string>
       end
 
@@ -253,12 +253,12 @@ describe("records", function()
          ["req.d.tl"] = [[
             local requests = record
 
-               RequestOpts = record
+               type RequestOpts = record
                   {string}
                   url: string
                end
 
-               Response = record
+               type Response = record
                   status_code: number
                end
 

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -214,7 +214,7 @@ describe("records", function()
 
    it("can extend generic functions", util.check [[
       local foo = record
-         bar = functiontype<T>(T)
+         bar = function<T>(T)
          example: bar<string>
       end
 
@@ -225,7 +225,7 @@ describe("records", function()
 
    it("does not produce an esoteric type error (#167)", util.check_type_error([[
       local foo = record
-         bar = functiontype<T>(T)
+         bar = function<T>(T)
          example: bar<string>
       end
 
@@ -239,7 +239,7 @@ describe("records", function()
 
    it("can cast generic member using full path of type name", util.check [[
       local foo = record
-         bar = functiontype<T>(T)
+         bar = function<T>(T)
          example: bar<string>
       end
 

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -230,6 +230,18 @@ describe("records", function()
       })
    end)
 
+   it("record and enum and not reserved words", util.check [[
+      local type foo = record
+         record: string
+         enum: number
+      end
+
+      local f: foo = {}
+
+      foo.record = "hello"
+      foo.enum = 123
+   ]])
+
    it("can have nested generic records", util.check [[
       local type foo = record
          type bar = record<T>
@@ -241,6 +253,24 @@ describe("records", function()
       local f: foo = {}
 
       foo.example = { x = "hello" }
+   ]])
+
+   it("can have nested enums", util.check [[
+      local type foo = record
+         enum Direction
+            "north"
+            "south"
+            "east"
+            "west"
+         end
+
+         d: Direction
+      end
+
+      local f: foo = {}
+
+      local dir: foo.Direction = "north"
+      foo.d = dir
    ]])
 
    it("can have nested generic records with shorthand syntax", util.check [[

--- a/spec/declaration/union_spec.lua
+++ b/spec/declaration/union_spec.lua
@@ -48,8 +48,8 @@ describe("union declaration", function()
    }))
 
    it("cannot declare a union between multiple function types", util.check_type_error([[
-      local F1 = functiontype(): number
-      local F2 = functiontype(): string
+      local type F1 = function(): number
+      local type F2 = function(): string
       local t: F1|F2
    ]], {
       { msg = "cannot discriminate a union between multiple function types" },

--- a/spec/declaration/union_spec.lua
+++ b/spec/declaration/union_spec.lua
@@ -23,6 +23,20 @@ describe("union declaration", function()
       params3 = { key1 = 'val2', key2 = {'val2', 'val3'}}
    ]])
 
+   it("unions can be declared nominally", util.check [[
+      -- with parentheses
+      local type P1 = (string | {string})
+      local params1: {string:P1} = { key1 = 'val2', key2 = {'val2', 'val3'}}
+
+      -- without parentheses
+      local type P2 = string | {string}
+      local params2: {string:P2} = { key1 = 'val2', key2 = {'val2', 'val3'}}
+
+      -- with extra parentheses
+      local type P3 = ((((string | {string}))))
+      local params3: {string:P3} = { key1 = 'val2', key2 = {'val2', 'val3'}}
+   ]])
+
    it("cannot declare a union between multiple table types", util.check_type_error([[
       local t: number | {number} | {string:boolean}
    ]], {
@@ -30,10 +44,10 @@ describe("union declaration", function()
    }))
 
    it("cannot declare a union between multiple records", util.check_type_error([[
-      local R1 = record
+      local type R1 = record
          f: string
       end
-      local R2 = record
+      local type R2 = record
          g: string
       end
       local t: R1 | R2

--- a/spec/error_reporting/syntax_error_spec.lua
+++ b/spec/error_reporting/syntax_error_spec.lua
@@ -9,7 +9,7 @@ describe("syntax errors", function()
    }))
 
    it("in enum", util.check_syntax_error([[
-      local Direction = enum
+      local type Direction = enum
          "north",
          "south",
          "east",

--- a/spec/operator/as_spec.lua
+++ b/spec/operator/as_spec.lua
@@ -2,7 +2,7 @@ local util = require("spec.util")
 
 describe("cast", function()
    it("can be used inside table literals", util.check [[
-      local Foo = record
+      local type Foo = record
          x: string
       end
 
@@ -25,7 +25,7 @@ describe("cast", function()
    ]])
 
    it("can cast to enum", util.check [[
-      local Direction = enum
+      local type Direction = enum
          "north"
          "south"
          "east"

--- a/spec/operator/eq_spec.lua
+++ b/spec/operator/eq_spec.lua
@@ -18,7 +18,7 @@ describe("==", function()
    }))
 
    it("fails comparing enum to invalid literal string", util.check_type_error([[
-      local MyEnum = enum
+      local type MyEnum = enum
          "foo"
          "bar"
       end

--- a/spec/operator/index_spec.lua
+++ b/spec/operator/index_spec.lua
@@ -25,7 +25,7 @@ describe("[]", function()
       }))
 
       it("ok without declaration if key is enum and all keys map to the same type", util.check [[
-         local Keys = enum
+         local type Keys = enum
             "foo"
             "bar"
          end
@@ -35,7 +35,7 @@ describe("[]", function()
       ]])
 
       it("fail if key is enum and not all keys map to the same type", util.check_type_error([[
-         local Keys = enum
+         local type Keys = enum
             "foo"
             "bar"
          end
@@ -47,7 +47,7 @@ describe("[]", function()
       }))
 
       it("fail if key is enum and not all keys are covered", util.check_type_error([[
-         local Keys = enum
+         local type Keys = enum
             "foo"
             "bar"
             "oops"

--- a/spec/operator/index_spec.lua
+++ b/spec/operator/index_spec.lua
@@ -88,7 +88,7 @@ describe("[]", function()
    end)
    describe("on enums", function()
       it("works with relevant stdlib string functions", util.check [[
-         local foo = enum
+         local type foo = enum
             "bar"
          end
          local s: foo

--- a/spec/operator/is_spec.lua
+++ b/spec/operator/is_spec.lua
@@ -201,10 +201,10 @@ describe("flow analysis with is", function()
          }))
 
          it("cannot discriminate a union between records", util.check_type_error([[
-            local R1 = record
+            local type R1 = record
                foo: string
             end
-            local R2 = record
+            local type R2 = record
                foo: string
             end
             local t: R1 | R2
@@ -213,7 +213,7 @@ describe("flow analysis with is", function()
          }))
 
          it("cannot discriminate a union between multiple string/enum types", util.check_type_error([[
-            local Enum = enum
+            local type Enum = enum
                "hello"
                "world"
             end

--- a/spec/operator/or_spec.lua
+++ b/spec/operator/or_spec.lua
@@ -2,7 +2,7 @@ local util = require("spec.util")
 
 describe("or", function()
    it("map or record matching map", util.check [[
-      local Ty = record
+      local type Ty = record
          name: string
          foo: number
       end
@@ -12,7 +12,7 @@ describe("or", function()
    ]])
 
    it("string or enum matches enum", util.check [[
-      local Dir = enum
+      local type Dir = enum
          "left"
          "right"
       end
@@ -23,7 +23,7 @@ describe("or", function()
    ]])
 
    it("invalid string or enum matches string", util.check_type_error([[
-      local Dir = enum
+      local type Dir = enum
          "left"
          "right"
       end

--- a/spec/preload/preload_spec.lua
+++ b/spec/preload/preload_spec.lua
@@ -6,11 +6,11 @@ describe("preload", function()
       -- ok
       util.mock_io(finally, {
          ["love.d.tl"] = [[
-            global love_graphics = record
+            global type love_graphics = record
                print: function(text: string)
             end
 
-            global love = record
+            global type love = record
                draw: function()
                graphics: love_graphics
             end
@@ -33,21 +33,21 @@ describe("preload", function()
       -- ok
       util.mock_io(finally, {
          ["love.d.tl"] = [[
-            global love_graphics = record
+            global type love_graphics = record
                print: function(text: string)
             end
 
-            global love = record
+            global type love = record
                draw: function()
                graphics: love_graphics
             end
          ]],
          ["hate.d.tl"] = [[
-            global hate_graphics = record
+            global type hate_graphics = record
                print: function(text: string)
             end
 
-            global hate = record
+            global type hate = record
                draw: function()
                graphics: hate_graphics
             end

--- a/spec/statement/repeat_spec.lua
+++ b/spec/statement/repeat_spec.lua
@@ -3,7 +3,7 @@ local util = require("spec.util")
 describe("repeat", function()
    it("only closes scope after until", util.check [[
       repeat
-         local R = record
+         local type R = record
             a: string
          end
          local r = { a = "hello" }
@@ -11,7 +11,7 @@ describe("repeat", function()
    ]])
    it("closes scope on exit", util.check_type_error([[
       repeat
-         local R = record
+         local type R = record
             a: string
          end
          local r = { a = "hello" }

--- a/spec/stdlib/require_spec.lua
+++ b/spec/stdlib/require_spec.lua
@@ -423,7 +423,7 @@ describe("require", function()
             local someds = record
                Event = record
                end
-               Callback = functiontype(Event)
+               Callback = function(Event)
                subscribe: function(callback: Callback)
             end
 
@@ -454,7 +454,7 @@ describe("require", function()
                Event = record<T>
                   x: T
                end
-               Callback = functiontype(Event<string>)
+               Callback = function(Event<string>)
                subscribe: function(callback: Callback)
             end
 

--- a/spec/stdlib/require_spec.lua
+++ b/spec/stdlib/require_spec.lua
@@ -65,7 +65,7 @@ describe("require", function()
       -- ok
       util.mock_io(finally, {
          ["point.tl"] = [[
-            local Point = record
+            local type Point = record
                x: number
                y: number
             end
@@ -101,8 +101,7 @@ describe("require", function()
          ["box.tl"] = [[
             local box = {}
 
-            -- local type
-            local Box = record
+            local type Box = record
                x: number
                y: number
                w: number
@@ -137,7 +136,7 @@ describe("require", function()
       -- ok
       util.mock_io(finally, {
          ["point.tl"] = [[
-            local Point = record
+            local type Point = record
                x: number
                y: number
             end
@@ -201,7 +200,7 @@ describe("require", function()
       -- ok
       util.mock_io(finally, {
          ["point.tl"] = [[
-            local Point = record
+            local type Point = record
                x: number
                y: number
             end
@@ -220,7 +219,7 @@ describe("require", function()
          ["bar.tl"] = [[
             local mypoint = require "point"
 
-            local rec = record
+            local type rec = record
                xx: number
                yy: number
             end
@@ -260,7 +259,7 @@ describe("require", function()
       -- ok
       util.mock_io(finally, {
          ["point.tl"] = [[
-            local Point = record
+            local type Point = record
                x: number
                y: number
             end
@@ -290,7 +289,7 @@ describe("require", function()
       -- ok
       util.mock_io(finally, {
          ["point.tl"] = [[
-            local Point = record
+            local type Point = record
                x: number
                y: number
             end
@@ -308,7 +307,7 @@ describe("require", function()
          ["foo.tl"] = [[
             local point1 = require "point"
 
-            local Point = record
+            local type Point = record
                foo: string
             end
 
@@ -358,7 +357,7 @@ describe("require", function()
             local box = {}
 
             -- global type
-            global Box = record
+            global type Box = record
                x: number
                y: number
                w: number
@@ -420,10 +419,10 @@ describe("require", function()
       -- ok
       util.mock_io(finally, {
          ["someds.d.tl"] = [[
-            local someds = record
-               Event = record
+            local type someds = record
+               type Event = record
                end
-               Callback = function(Event)
+               type Callback = function(Event)
                subscribe: function(callback: Callback)
             end
 
@@ -450,11 +449,11 @@ describe("require", function()
       -- ok
       util.mock_io(finally, {
          ["someds.d.tl"] = [[
-            local someds = record
-               Event = record<T>
+            local type someds = record
+               type Event = record<T>
                   x: T
                end
-               Callback = function(Event<string>)
+               type Callback = function(Event<string>)
                subscribe: function(callback: Callback)
             end
 
@@ -480,11 +479,11 @@ describe("require", function()
    it("cannot extend a record object with unknown types outside of scope", function ()
       util.mock_io(finally, {
          ["love.d.tl"] = [[
-            global LoveGraphics = record
+            global type LoveGraphics = record
                print: function(text: string)
             end
 
-            global Love = record
+            global type Love = record
                draw: function()
                graphics: LoveGraphics
             end
@@ -513,11 +512,11 @@ describe("require", function()
    it("cannot extend a record type with unknown types outside of scope", function ()
       util.mock_io(finally, {
          ["love.d.tl"] = [[
-            global love_graphics = record
+            global type love_graphics = record
                print: function(text: string)
             end
 
-            global love = record
+            global type love = record
                draw: function()
                graphics: love_graphics
             end
@@ -545,7 +544,7 @@ describe("require", function()
    it("cannot extend a record type outside of scope", function ()
       util.mock_io(finally, {
          ["widget.tl"] = [[
-            local Widget = record
+            local type Widget = record
                 draw: function(self: Widget)
             end
 
@@ -572,7 +571,7 @@ describe("require", function()
    it("can redeclare a function that was previously declared outside of scope", function ()
       util.mock_io(finally, {
          ["widget.tl"] = [[
-            local Widget = record
+            local type Widget = record
                 draw: function(self: Widget)
             end
 
@@ -598,16 +597,16 @@ describe("require", function()
    it("can extend a global defined in scope", function ()
       util.mock_io(finally, {
          ["luaunit.d.tl"] = [[
-            global luaunit_runner_t = record
+            global type luaunit_runner_t = record
                setOutputType: function(luaunit_runner_t, string)
                runSuite: function(luaunit_runner_t, any): number
             end
 
-            global luaunit_t = record
+            global type luaunit_t = record
                new: function(): luaunit_runner_t
             end
 
-            local luaunit = record
+            local type luaunit = record
                LuaUnit: luaunit_t
                assertIsTrue: function(any)
             end

--- a/tl.lua
+++ b/tl.lua
@@ -1013,7 +1013,6 @@ end
 local is_newtype = {
    ["enum"] = true,
    ["record"] = true,
-   ["functiontype"] = true,
 }
 
 local function parse_table_value(ps, i)
@@ -1930,7 +1929,7 @@ parse_newtype = function(ps, i)
       node.yend = ps.tokens[i].y
       i = verify_tk(ps, i, "end")
       return i, node
-   elseif ps.tokens[i].tk == "functiontype" or ps.tokens[i].tk == "function" then
+   elseif ps.tokens[i].tk == "function" then
       i, node.newtype.def = parse_function_type(ps, i)
       return i, node
    end

--- a/tl.lua
+++ b/tl.lua
@@ -2047,6 +2047,17 @@ local function parse_variable_declarations(ps, i, node_name)
    i, asgn.decltype = parse_type_list(ps, i, "decltype")
 
    if ps.tokens[i].tk == "=" then
+
+      if ps.tokens[i + 1].tk == "record" or
+         ps.tokens[i + 1].tk == "enum" then
+
+         local scope = node_name == "local_declaration" and "local" or "global"
+         fail(ps, i, "syntax error: this syntax is no longer valid; use '" .. scope .. " " .. ps.tokens[i + 1].tk .. " " .. asgn.vars[1].tk .. "'")
+      elseif ps.tokens[i + 1].tk == "functiontype" then
+         local scope = node_name == "local_declaration" and "local" or "global"
+         fail(ps, i, "syntax error: this syntax is no longer valid; use '" .. scope .. " type " .. asgn.vars[1].tk .. " = function('...")
+      end
+
       asgn.exps = new_node(ps.tokens, i, "values")
       local v = 1
       repeat

--- a/tl.lua
+++ b/tl.lua
@@ -1930,7 +1930,7 @@ parse_newtype = function(ps, i)
       node.yend = ps.tokens[i].y
       i = verify_tk(ps, i, "end")
       return i, node
-   elseif ps.tokens[i].tk == "functiontype" then
+   elseif ps.tokens[i].tk == "functiontype" or ps.tokens[i].tk == "function" then
       i, node.newtype.def = parse_function_type(ps, i)
       return i, node
    end

--- a/tl.lua
+++ b/tl.lua
@@ -1837,6 +1837,15 @@ local function parse_return(ps, i)
    return i, node
 end
 
+local function store_field_in_record(name, def, nt)
+   if def.fields[name] then
+      return false
+   end
+   def.fields[name] = nt.newtype
+   table.insert(def.field_order, name)
+   return true
+end
+
 parse_newtype = function(ps, i)
    local node = new_node(ps.tokens, i, "newtype")
    node.newtype = new_type(ps, i, "typetype")
@@ -1865,6 +1874,24 @@ parse_newtype = function(ps, i)
             end
             def.typename = "arrayrecord"
             def.elements = t
+         elseif ps.tokens[i].tk == "type" and ps.tokens[i + 1].tk ~= ":" then
+            i = i + 1
+            local v
+            i, v = verify_kind(ps, i, "identifier", "variable")
+            if not v then
+               return fail(ps, i, "expected a variable name")
+            end
+            i = verify_tk(ps, i, "=")
+            local nt
+            i, nt = parse_newtype(ps, i)
+            if not nt or not nt.newtype then
+               return fail(ps, i, "expected a type definition")
+            end
+
+            local ok = store_field_in_record(v.tk, def, nt)
+            if not ok then
+               return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
+            end
          else
             local v
             i, v = verify_kind(ps, i, "identifier", "variable")
@@ -1894,18 +1921,11 @@ parse_newtype = function(ps, i)
                   end
                end
             elseif ps.tokens[i].tk == "=" then
-               i = verify_tk(ps, i, "=")
-               local nt
-               i, nt = parse_newtype(ps, i)
-               if not nt or not nt.newtype then
-                  return fail(ps, i, "expected a type definition")
-               end
-
-               if not def.fields[v.tk] then
-                  def.fields[v.tk] = nt.newtype
-                  table.insert(def.field_order, v.tk)
+               local next_word = ps.tokens[i + 1].tk
+               if next_word == "functiontype" then
+                  return fail(ps, i, "syntax error: this syntax is no longer valid; use 'type " .. v.tk .. " = function('...")
                else
-                  return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
+                  return fail(ps, i, "syntax error: this syntax is no longer valid; use 'type " .. v.tk .. " = '...")
                end
             end
          end
@@ -1929,8 +1949,8 @@ parse_newtype = function(ps, i)
       node.yend = ps.tokens[i].y
       i = verify_tk(ps, i, "end")
       return i, node
-   elseif ps.tokens[i].tk == "function" then
-      i, node.newtype.def = parse_function_type(ps, i)
+   else
+      i, node.newtype.def = parse_type(ps, i)
       return i, node
    end
    return fail(ps, i)
@@ -1989,19 +2009,7 @@ local function parse_variable_declarations(ps, i, node_name)
       repeat
          i = i + 1
          local val
-         if is_newtype[ps.tokens[i].tk] then
-            if #asgn.vars > 1 then
-               return fail(ps, i, "cannot perform multiple assignment of type definitions")
-            end
-            i, val = parse_newtype(ps, i)
-            if val then
-               val.newtype.def.names = { asgn.vars[v].tk }
-            else
-               return i, val
-            end
-         else
-            i, val = parse_expression(ps, i)
-         end
+         i, val = parse_expression(ps, i)
          table.insert(asgn.exps, val)
          v = v + 1
       until ps.tokens[i].tk ~= ","

--- a/tl.lua
+++ b/tl.lua
@@ -5691,14 +5691,6 @@ function tl.type_check(ast, opts)
       return UNKNOWN
    end
 
-   local function put_newtype_name_in_scope(node)
-      if node.exps and node.exps[1] and node.exps[1].kind == "newtype" then
-         local t = node.exps[1].newtype.def
-         local var = node.vars[1]
-         add_var(var, var.tk, node.exps[1].newtype, var.is_const)
-      end
-   end
-
    local visit_node = {}
 
    visit_node.cbs = {
@@ -5751,9 +5743,6 @@ function tl.type_check(ast, opts)
          end,
       },
       ["local_declaration"] = {
-         before = function(node)
-            put_newtype_name_in_scope(node)
-         end,
          after = function(node, children)
             local vals = get_assignment_values(children[2], #node.vars)
             for i, var in ipairs(node.vars) do
@@ -5788,9 +5777,6 @@ function tl.type_check(ast, opts)
          end,
       },
       ["global_declaration"] = {
-         before = function(node)
-            put_newtype_name_in_scope(node)
-         end,
          after = function(node, children)
             local vals = get_assignment_values(children[2], #node.vars)
             for i, var in ipairs(node.vars) do

--- a/tl.lua
+++ b/tl.lua
@@ -846,6 +846,8 @@ local NodeKind = {}
 
 
 
+
+
 local FactType = {}
 
 
@@ -2008,20 +2010,45 @@ local function parse_variable_declarations(ps, i, node_name)
    return i, asgn
 end
 
+local function parse_type_declaration(ps, i, node_name)
+   i = i + 2
+
+   local asgn = new_node(ps.tokens, i, node_name)
+   i, asgn.var = parse_variable_name(ps, i)
+   if not asgn.var then
+      return fail(ps, i, "expected a type name")
+   end
+   i = verify_tk(ps, i, "=")
+   i, asgn.value = parse_newtype(ps, i)
+   if asgn.value then
+      asgn.value.newtype.def.names = { asgn.var.tk }
+   else
+      return i
+   end
+
+   return i, asgn
+end
+
 local function parse_statement(ps, i)
    if ps.tokens[i].tk == "local" then
-      if ps.tokens[i + 1].tk == "function" then
+      if ps.tokens[i + 1].tk == "type" and ps.tokens[i + 2].kind == "identifier" then
+         return parse_type_declaration(ps, i, "local_type")
+      elseif ps.tokens[i + 1].tk == "function" then
          return parse_local_function(ps, i)
       else
          i = i + 1
          return parse_variable_declarations(ps, i, "local_declaration")
       end
    elseif ps.tokens[i].tk == "global" then
-      i = i + 1
-      if ps.tokens[i].tk == "function" then
+      if ps.tokens[i + 1].tk == "type" and ps.tokens[i + 2].kind == "identifier" then
+         return parse_type_declaration(ps, i, "global_type")
+      elseif ps.tokens[i + 1].tk == "function" then
+         i = i + 1
          return parse_function(ps, i)
+      else
+         i = i + 1
+         return parse_variable_declarations(ps, i, "global_declaration")
       end
-      return parse_variable_declarations(ps, i, "global_declaration")
    elseif ps.tokens[i].tk == "function" then
       return parse_function(ps, i)
    elseif ps.tokens[i].tk == "if" then
@@ -2218,6 +2245,10 @@ visit_type)
       if ast.decltype then
          xs[3] = recurse_type(ast.decltype, visit_type)
       end
+   elseif ast.kind == "local_type" or
+      ast.kind == "global_type" then
+      xs[1] = recurse_node(ast.var, visit_node, visit_type)
+      xs[2] = recurse_node(ast.value, visit_node, visit_type)
    elseif ast.kind == "table_item" then
       xs[1] = recurse_node(ast.key, visit_node, visit_type)
       xs[2] = recurse_node(ast.value, visit_node, visit_type)
@@ -2479,6 +2510,25 @@ function tl.pretty_print_ast(ast, fast)
                table.insert(out, " =")
                add_child(out, children[2], " ")
             end
+            return out
+         end,
+      },
+      ["local_type"] = {
+         after = function(node, children)
+            local out = { y = node.y, h = 0 }
+            table.insert(out, "local")
+            add_child(out, children[1], " ")
+            table.insert(out, " =")
+            add_child(out, children[2], " ")
+            return out
+         end,
+      },
+      ["global_type"] = {
+         after = function(node, children)
+            local out = { y = node.y, h = 0 }
+            add_child(out, children[1], " ")
+            table.insert(out, " =")
+            add_child(out, children[2], " ")
             return out
          end,
       },
@@ -5586,6 +5636,37 @@ function tl.type_check(ast, opts)
                end_scope()
             end
 
+            node.type = NONE
+         end,
+      },
+      ["local_type"] = {
+         before = function(node)
+            add_var(node.var, node.var.tk, node.value.newtype, node.var.is_const)
+         end,
+         after = function(node, children)
+            dismiss_unresolved(node.var.tk)
+            node.type = NONE
+         end,
+      },
+      ["global_type"] = {
+         before = function(node)
+            add_global(node.var, node.var.tk, node.value.newtype, node.var.is_const)
+         end,
+         after = function(node, children)
+            local existing, existing_is_const = find_global(node.var.tk)
+            local var = node.var
+            if existing then
+               if existing_is_const == true and not var.is_const then
+                  node_error(var, "global was previously declared as <const>: " .. var.tk)
+               end
+               if existing_is_const == false and var.is_const then
+                  node_error(var, "global was previously declared as not <const>: " .. var.tk)
+               end
+               if not same_type(existing, node.value.newtype) then
+                  node_error(var, "cannot redeclare global with a different type: previous type of " .. var.tk .. " is %s", existing)
+               end
+            end
+            dismiss_unresolved(var.tk)
             node.type = NONE
          end,
       },

--- a/tl.tl
+++ b/tl.tl
@@ -17,7 +17,7 @@ local LoadMode = enum
    "t"
    "bt"
 end
-local type LoadFunction = functiontype(...:any): any...
+local type LoadFunction = function(...:any): any...
 
 local tl = {
    load: function(string, string, LoadMode, {any:any}): LoadFunction, string = nil,
@@ -1083,7 +1083,7 @@ local function parse_table_item(ps: ParseState, i: number, n: number): number, N
    return i, node, n + 1
 end
 
-local type ParseItem = functiontype<T>(ParseState, number, number): number, T, number
+local type ParseItem = function<T>(ParseState, number, number): number, T, number
 
 local type SeparatorMode = enum
    "sep"
@@ -4167,7 +4167,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
    end
 
-   local type CompareTypes = functiontype(Type, Type, boolean): boolean, {Error}
+   local type CompareTypes = function(Type, Type, boolean): boolean, {Error}
 
    local function compare_typevars(t1: Type, t2: Type, comp: CompareTypes): boolean, {Error}
       local tv1 = find_var(t1.typevar)
@@ -4218,7 +4218,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
 
    local is_a: function(Type, Type, boolean): boolean, {Error}
 
-   local type TypeGetter = functiontype(string): Type
+   local type TypeGetter = function(string): Type
 
    local function match_record_fields(t1: Type, t2: TypeGetter, cmp: CompareTypes): boolean, {Error}
       cmp = cmp or is_a

--- a/tl.tl
+++ b/tl.tl
@@ -1837,6 +1837,15 @@ local function parse_return(ps: ParseState, i: number): number, Node
    return i, node
 end
 
+local function store_field_in_record(name: string, def: Type, nt: Node): boolean
+   if def.fields[name] then
+      return false
+   end
+   def.fields[name] = nt.newtype
+   table.insert(def.field_order, name)
+   return true
+end
+
 parse_newtype = function(ps: ParseState, i: number): number, Node
    local node: Node = new_node(ps.tokens, i, "newtype")
    node.newtype = new_type(ps, i, "typetype")
@@ -1865,6 +1874,24 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
             end
             def.typename = "arrayrecord"
             def.elements = t
+         elseif ps.tokens[i].tk == "type" and ps.tokens[i + 1].tk ~= ":" then
+            i = i + 1
+            local v: Node
+            i, v = verify_kind(ps, i, "identifier", "variable")
+            if not v then
+               return fail(ps, i, "expected a variable name")
+            end
+            i = verify_tk(ps, i, "=")
+            local nt: Node
+            i, nt = parse_newtype(ps, i)
+            if not nt or not nt.newtype then
+               return fail(ps, i, "expected a type definition")
+            end
+
+            local ok = store_field_in_record(v.tk, def, nt)
+            if not ok then
+               return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
+            end
          else
             local v: Node
             i, v = verify_kind(ps, i, "identifier", "variable")
@@ -1894,18 +1921,11 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
                   end
                end
             elseif ps.tokens[i].tk == "=" then
-               i = verify_tk(ps, i, "=")
-               local nt: Node
-               i, nt = parse_newtype(ps, i)
-               if not nt or not nt.newtype then
-                  return fail(ps, i, "expected a type definition")
-               end
-
-               if not def.fields[v.tk] then
-                  def.fields[v.tk] = nt.newtype
-                  table.insert(def.field_order, v.tk)
+               local next_word = ps.tokens[i + 1].tk
+               if next_word == "functiontype" then
+                  return fail(ps, i, "syntax error: this syntax is no longer valid; use 'type " .. v.tk .. " = function('...")
                else
-                  return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
+                  return fail(ps, i, "syntax error: this syntax is no longer valid; use 'type " .. v.tk .. " = '...")
                end
             end
          end
@@ -1929,8 +1949,8 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
       node.yend = ps.tokens[i].y
       i = verify_tk(ps, i, "end")
       return i, node
-   elseif ps.tokens[i].tk == "function" then
-      i, node.newtype.def = parse_function_type(ps, i)
+   else
+      i, node.newtype.def = parse_type(ps, i)
       return i, node
    end
    return fail(ps, i)
@@ -1989,19 +2009,7 @@ local function parse_variable_declarations(ps: ParseState, i: number, node_name:
       repeat
          i = i + 1
          local val: Node
-         if is_newtype[ps.tokens[i].tk] then
-            if #asgn.vars > 1 then
-               return fail(ps, i, "cannot perform multiple assignment of type definitions")
-            end
-            i, val = parse_newtype(ps, i)
-            if val then
-               val.newtype.def.names = { asgn.vars[v].tk }
-            else
-               return i, val
-            end
-         else
-            i, val = parse_expression(ps, i)
-         end
+         i, val = parse_expression(ps, i)
          table.insert(asgn.exps, val)
          v = v + 1
       until ps.tokens[i].tk ~= ","

--- a/tl.tl
+++ b/tl.tl
@@ -12,7 +12,7 @@ local record TypeCheckOptions
    result: Result
 end
 
-local type LoadMode = enum
+local enum LoadMode
    "b"
    "t"
    "bt"
@@ -65,7 +65,7 @@ local keywords: {string:boolean} = {
 --   ["global"] = true,
 }
 
-local type TokenKind = enum
+local enum TokenKind
    "keyword"
    "op"
    "string"
@@ -143,7 +143,7 @@ for _, c in ipairs({" ", "\t", "\v", "\n", "\r"}) do
    lex_space[c] = true
 end
 
-local type LexState = enum
+local enum LexState
    "start"
    "any"
    "identifier"
@@ -680,7 +680,7 @@ local record ParseError
    filename: string
 end
 
-local type TypeName = enum
+local enum TypeName
    "typetype"
    "nestedtype"
    "typevar"
@@ -804,7 +804,7 @@ local record Operator
    prec: number
 end
 
-local type NodeKind = enum
+local enum NodeKind
    "op"
    "nil"
    "string"
@@ -848,7 +848,7 @@ local type NodeKind = enum
    "paren"
 end
 
-local type FactType = enum
+local enum FactType
    "is"
 end
 
@@ -858,7 +858,7 @@ local record Fact
    typ: Type
 end
 
-local type KeyParsed = enum
+local enum KeyParsed
    "short"
    "long"
    "implicit"
@@ -950,7 +950,7 @@ local record ParseState
    filename: string
 end
 
-local type ParseTypeListMode = enum
+local enum ParseTypeListMode
    "rets"
    "decltype"
    "casttype"
@@ -1084,7 +1084,7 @@ end
 
 local type ParseItem = function<T>(ParseState, number, number): number, T, number
 
-local type SeparatorMode = enum
+local enum SeparatorMode
    "sep"
    "term"
 end

--- a/tl.tl
+++ b/tl.tl
@@ -1,10 +1,10 @@
-local type Env = record
+local record Env
    globals: {string:Variable}
    modules: {string:Type}
    skip_compat53: boolean
 end
 
-local type TypeCheckOptions = record
+local record TypeCheckOptions
    lax: boolean
    filename: string
    skip_compat53: boolean
@@ -78,7 +78,7 @@ local type TokenKind = enum
    "$EOF$"
 end
 
-local type Token = record
+local record Token
    x: number
    y: number
    i: number
@@ -673,7 +673,7 @@ local function new_typeid(): number
    return last_typeid
 end
 
-local type ParseError = record
+local record ParseError
    y: number
    x: number
    msg: string
@@ -719,7 +719,7 @@ local table_types: {TypeName:boolean} = {
    ["emptytable"] = true,
 }
 
-local type Type = record
+local record Type
    {Type}
    y: number
    x: number
@@ -796,7 +796,7 @@ local type Type = record
    nominals: {string:{Type}}
 end
 
-local type Operator = record
+local record Operator
    y: number
    x: number
    arity: number
@@ -852,7 +852,7 @@ local type FactType = enum
    "is"
 end
 
-local type Fact = record
+local record Fact
    fact: FactType
    var: string
    typ: Type
@@ -864,7 +864,7 @@ local type KeyParsed = enum
    "implicit"
 end
 
-local type Node = record
+local record Node
    {Node}
    y: number
    x: number
@@ -944,7 +944,7 @@ local function is_type(t:Type): boolean
    return t.typename == "typetype" or t.typename == "nestedtype"
 end
 
-local type ParseState = record
+local record ParseState
    tokens: {Token}
    errs: {ParseError}
    filename: string
@@ -1846,92 +1846,128 @@ local function store_field_in_record(name: string, def: Type, nt: Node): boolean
    return true
 end
 
+local type ParseBody = function(ps: ParseState, i: number, def: Type, node: Node): number, Node
+
+local function parse_nested_type(ps: ParseState, i: number, def: Type, typename: TypeName, parse_body: ParseBody): number, boolean
+   i = i + 1 -- skip 'record' or 'enum'
+
+   local v: Node
+   i, v = verify_kind(ps, i, "identifier", "variable")
+   if not v then
+      return fail(ps, i, "expected a variable name")
+   end
+
+   local nt: Node = new_node(ps.tokens, i, "newtype")
+   nt.newtype = new_type(ps, i, "typetype")
+   local rdef = new_type(ps, i, typename)
+   local iok = parse_body(ps, i, rdef, nt)
+   if iok then
+      i = iok
+      nt.newtype.def = rdef
+   end
+
+   local ok = store_field_in_record(v.tk, def, nt)
+   if not ok then
+      fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
+   end
+   return i
+end
+
+local function parse_record_body(ps: ParseState, i: number, def: Type, node: Node): number, Node
+   def.fields = {}
+   def.field_order = {}
+   if ps.tokens[i].tk == "<" then
+      i, def.typeargs = parse_typearg_list(ps, i)
+   end
+   while not ((not ps.tokens[i]) or ps.tokens[i].tk == "end") do
+      if ps.tokens[i].tk == "{" then
+         if def.typename == "arrayrecord" then
+            return fail(ps, i, "duplicated declaration of array element type in record")
+         end
+         i = i + 1
+         local t: Type
+         i, t = parse_type(ps, i)
+         if ps.tokens[i].tk == "}" then
+            node.yend = ps.tokens[i].y
+            i = verify_tk(ps, i, "}")
+         else
+            return fail(ps, i, "expected an array declaration")
+         end
+         def.typename = "arrayrecord"
+         def.elements = t
+      elseif ps.tokens[i].tk == "type" and ps.tokens[i + 1].tk ~= ":" then
+         i = i + 1
+         local v: Node
+         i, v = verify_kind(ps, i, "identifier", "variable")
+         if not v then
+            return fail(ps, i, "expected a variable name")
+         end
+         i = verify_tk(ps, i, "=")
+         local nt: Node
+         i, nt = parse_newtype(ps, i)
+         if not nt or not nt.newtype then
+            return fail(ps, i, "expected a type definition")
+         end
+
+         local ok = store_field_in_record(v.tk, def, nt)
+         if not ok then
+            return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
+         end
+      elseif ps.tokens[i].tk == "record" and ps.tokens[i+1].tk ~= ":" then
+         i = parse_nested_type(ps, i, def, "record", parse_record_body)
+      else
+         local v: Node
+         i, v = verify_kind(ps, i, "identifier", "variable")
+         local iv = i
+         if not v then
+            return fail(ps, i, "expected a variable name")
+         end
+         if ps.tokens[i].tk == ":" then
+            i = verify_tk(ps, i, ":")
+            local t: Type
+            i, t = parse_type(ps, i)
+            if not t then
+               return fail(ps, i, "expected a type")
+            end
+            if not def.fields[v.tk] then
+               def.fields[v.tk] = t
+               table.insert(def.field_order, v.tk)
+            else
+               local prev_t = def.fields[v.tk]
+               if t.typename == "function" and prev_t.typename == "function" then
+                  def.fields[v.tk] = new_type(ps, iv, "poly")
+                  def.fields[v.tk].types = { prev_t, t }
+               elseif t.typename == "function" and prev_t.typename == "poly" then
+                  table.insert(prev_t.types, t)
+               else
+                  return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
+               end
+            end
+         elseif ps.tokens[i].tk == "=" then
+            local next_word = ps.tokens[i + 1].tk
+            if next_word == "record" then
+               return fail(ps, i, "syntax error: this syntax is no longer valid; use '" .. next_word .. " " .. v.tk .. "'")
+            elseif next_word == "functiontype" then
+               return fail(ps, i, "syntax error: this syntax is no longer valid; use 'type " .. v.tk .. " = function('...")
+            else
+               return fail(ps, i, "syntax error: this syntax is no longer valid; use 'type " .. v.tk .. " = '...")
+            end
+         end
+      end
+   end
+   node.yend = ps.tokens[i].y
+   i = verify_tk(ps, i, "end")
+   return i, node
+end
+
 parse_newtype = function(ps: ParseState, i: number): number, Node
    local node: Node = new_node(ps.tokens, i, "newtype")
    node.newtype = new_type(ps, i, "typetype")
    if ps.tokens[i].tk == "record" then
       local def = new_type(ps, i, "record")
-      def.fields = {}
-      def.field_order = {}
-      node.newtype.def = def
       i = i + 1
-      if ps.tokens[i].tk == "<" then
-         i, def.typeargs = parse_typearg_list(ps, i)
-      end
-      while not ((not ps.tokens[i]) or ps.tokens[i].tk == "end") do
-         if ps.tokens[i].tk == "{" then
-            if def.typename == "arrayrecord" then
-               return fail(ps, i, "duplicated declaration of array element type in record")
-            end
-            i = i + 1
-            local t: Type
-            i, t = parse_type(ps, i)
-            if ps.tokens[i].tk == "}" then
-               node.yend = ps.tokens[i].y
-               i = verify_tk(ps, i, "}")
-            else
-               return fail(ps, i, "expected an array declaration")
-            end
-            def.typename = "arrayrecord"
-            def.elements = t
-         elseif ps.tokens[i].tk == "type" and ps.tokens[i + 1].tk ~= ":" then
-            i = i + 1
-            local v: Node
-            i, v = verify_kind(ps, i, "identifier", "variable")
-            if not v then
-               return fail(ps, i, "expected a variable name")
-            end
-            i = verify_tk(ps, i, "=")
-            local nt: Node
-            i, nt = parse_newtype(ps, i)
-            if not nt or not nt.newtype then
-               return fail(ps, i, "expected a type definition")
-            end
-
-            local ok = store_field_in_record(v.tk, def, nt)
-            if not ok then
-               return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
-            end
-         else
-            local v: Node
-            i, v = verify_kind(ps, i, "identifier", "variable")
-            local iv = i
-            if not v then
-               return fail(ps, i, "expected a variable name")
-            end
-            if ps.tokens[i].tk == ":" then
-               i = verify_tk(ps, i, ":")
-               local t: Type
-               i, t = parse_type(ps, i)
-               if not t then
-                  return fail(ps, i, "expected a type")
-               end
-               if not def.fields[v.tk] then
-                  def.fields[v.tk] = t
-                  table.insert(def.field_order, v.tk)
-               else
-                  local prev_t = def.fields[v.tk]
-                  if t.typename == "function" and prev_t.typename == "function" then
-                     def.fields[v.tk] = new_type(ps, iv, "poly")
-                     def.fields[v.tk].types = { prev_t, t }
-                  elseif t.typename == "function" and prev_t.typename == "poly" then
-                     table.insert(prev_t.types, t)
-                  else
-                     return fail(ps, i, "attempt to redeclare field '" .. v.tk .. "' (only functions can be overloaded)")
-                  end
-               end
-            elseif ps.tokens[i].tk == "=" then
-               local next_word = ps.tokens[i + 1].tk
-               if next_word == "functiontype" then
-                  return fail(ps, i, "syntax error: this syntax is no longer valid; use 'type " .. v.tk .. " = function('...")
-               else
-                  return fail(ps, i, "syntax error: this syntax is no longer valid; use 'type " .. v.tk .. " = '...")
-               end
-            end
-         end
-      end
-      node.yend = ps.tokens[i].y
-      i = verify_tk(ps, i, "end")
+      i = parse_record_body(ps, i, def, node)
+      node.newtype.def = def
       return i, node
    elseif ps.tokens[i].tk == "enum" then
       local def = new_type(ps, i, "enum")
@@ -2036,12 +2072,34 @@ local function parse_type_declaration(ps: ParseState, i: number, node_name: Node
    return i, asgn
 end
 
+local function parse_record(ps: ParseState, i: number, node_name: NodeKind): number, Node
+   local asgn: Node = new_node(ps.tokens, i, node_name)
+   local nt: Node = new_node(ps.tokens, i, "newtype")
+   asgn.value = nt
+   nt.newtype = new_type(ps, i, "typetype")
+   local def = new_type(ps, i, "record")
+   nt.newtype.def = def
+
+   i = i + 2 -- skip `local` or `global`, and `record`
+
+   i, asgn.var = verify_kind(ps, i, "identifier")
+   if not asgn.var then
+      return fail(ps, i, "expected a type name")
+   end
+   nt.newtype.def.names = { asgn.var.tk }
+
+   i = parse_record_body(ps, i, def, nt)
+   return i, asgn
+end
+
 local function parse_statement(ps: ParseState, i: number): number, Node
    if ps.tokens[i].tk == "local" then
       if ps.tokens[i+1].tk == "type" and ps.tokens[i+2].kind == "identifier" then
          return parse_type_declaration(ps, i, "local_type")
       elseif ps.tokens[i+1].tk == "function" then
          return parse_local_function(ps, i)
+      elseif ps.tokens[i+1].tk == "record" and ps.tokens[i+2].kind == "identifier"  then
+         return parse_record(ps, i, "local_type")
       else
          i = i + 1
          return parse_variable_declarations(ps, i, "local_declaration")
@@ -2049,6 +2107,8 @@ local function parse_statement(ps: ParseState, i: number): number, Node
    elseif ps.tokens[i].tk == "global" then
       if ps.tokens[i+1].tk == "type" and ps.tokens[i+2].kind == "identifier" then
          return parse_type_declaration(ps, i, "global_type")
+      elseif ps.tokens[i+1].tk == "record" and ps.tokens[i+2].kind == "identifier" then
+         return parse_record(ps, i, "global_type")
       elseif ps.tokens[i+1].tk == "function" then
          i = i + 1
          return parse_function(ps, i)
@@ -2126,14 +2186,14 @@ end
 -- AST traversal
 --------------------------------------------------------------------------------
 
-local type VisitorCallbacks = record<N, T>
+local record VisitorCallbacks<N, T>
    before: function(N, {T})
    before_statements: function({N}, {T})
    before_e2: function({N}, {T})
    after: function(N, {T}, T): T
 end
 
-local type Visitor = record<K, N, T>
+local record Visitor<K, N, T>
    cbs: {K:VisitorCallbacks<N, T>}
    after: VisitorCallbacks<N, T>
 end
@@ -2418,7 +2478,7 @@ local spaced_op: {number:{string:boolean}} = {
 function tl.pretty_print_ast(ast: Node, fast: boolean): string
    local indent = 0
 
-   local type Output = record
+   local record Output
       {string}
       y: number
       h: number
@@ -3319,14 +3379,14 @@ show_type = function(t: Type, seen: {Type:boolean}): string
    return ret
 end
 
-local type Error = record
+local record Error
    y: number
    x: number
    msg: string
    filename: string
 end
 
-local type Result = record
+local record Result
    ast: Node
    type: Type
    syntax_errors: {ParseError}
@@ -3370,7 +3430,7 @@ function tl.search_module(module_name: string, search_dtl: boolean): string, FIL
    return nil, nil, tried
 end
 
-local type Variable = record
+local record Variable
    t: Type
    is_const: boolean
    needs_compat53: boolean

--- a/tl.tl
+++ b/tl.tl
@@ -2047,6 +2047,17 @@ local function parse_variable_declarations(ps: ParseState, i: number, node_name:
    i, asgn.decltype = parse_type_list(ps, i, "decltype")
 
    if ps.tokens[i].tk == "=" then
+      -- produce nice error message when using <= 0.7.1 syntax
+      if ps.tokens[i + 1].tk == "record" or
+         ps.tokens[i + 1].tk == "enum"
+      then
+         local scope = node_name == "local_declaration" and "local" or "global"
+         fail(ps, i, "syntax error: this syntax is no longer valid; use '" .. scope .. " " .. ps.tokens[i + 1].tk .. " " .. asgn.vars[1].tk .. "'")
+      elseif ps.tokens[i + 1].tk == "functiontype" then
+         local scope = node_name == "local_declaration" and "local" or "global"
+         fail(ps, i, "syntax error: this syntax is no longer valid; use '" .. scope .. " type " .. asgn.vars[1].tk .. " = function('...")
+      end
+
       asgn.exps = new_node(ps.tokens, i, "values")
       local v = 1
       repeat

--- a/tl.tl
+++ b/tl.tl
@@ -837,6 +837,8 @@ local NodeKind = enum
    "argument_list"
    "local_function"
    "global_function"
+   "local_type"
+   "global_type"
    "record_function"
    "local_declaration"
    "global_declaration"
@@ -2008,20 +2010,45 @@ local function parse_variable_declarations(ps: ParseState, i: number, node_name:
    return i, asgn
 end
 
+local function parse_type_declaration(ps: ParseState, i: number, node_name: NodeKind): number, Node
+   i = i + 2 -- skip `local` or `global`, and `type`
+
+   local asgn: Node = new_node(ps.tokens, i, node_name)
+   i, asgn.var = parse_variable_name(ps, i)
+   if not asgn.var then
+      return fail(ps, i, "expected a type name")
+   end
+   i = verify_tk(ps, i, "=")
+   i, asgn.value = parse_newtype(ps, i)
+   if asgn.value then
+      asgn.value.newtype.def.names = { asgn.var.tk }
+   else
+      return i
+   end
+
+   return i, asgn
+end
+
 local function parse_statement(ps: ParseState, i: number): number, Node
    if ps.tokens[i].tk == "local" then
-      if ps.tokens[i+1].tk == "function" then
+      if ps.tokens[i+1].tk == "type" and ps.tokens[i+2].kind == "identifier" then
+         return parse_type_declaration(ps, i, "local_type")
+      elseif ps.tokens[i+1].tk == "function" then
          return parse_local_function(ps, i)
       else
          i = i + 1
          return parse_variable_declarations(ps, i, "local_declaration")
       end
    elseif ps.tokens[i].tk == "global" then
-      i = i + 1
-      if ps.tokens[i].tk == "function" then
+      if ps.tokens[i+1].tk == "type" and ps.tokens[i+2].kind == "identifier" then
+         return parse_type_declaration(ps, i, "global_type")
+      elseif ps.tokens[i+1].tk == "function" then
+         i = i + 1
          return parse_function(ps, i)
+      else
+         i = i + 1
+         return parse_variable_declarations(ps, i, "global_declaration")
       end
-      return parse_variable_declarations(ps, i, "global_declaration")
    elseif ps.tokens[i].tk == "function" then
       return parse_function(ps, i)
    elseif ps.tokens[i].tk == "if" then
@@ -2218,6 +2245,10 @@ local function recurse_node<T>(ast: Node,
       if ast.decltype then
          xs[3] = recurse_type(ast.decltype, visit_type)
       end
+   elseif ast.kind == "local_type"
+          or ast.kind == "global_type" then
+      xs[1] = recurse_node(ast.var, visit_node, visit_type)
+      xs[2] = recurse_node(ast.value, visit_node, visit_type)
    elseif ast.kind == "table_item" then
       xs[1] = recurse_node(ast.key, visit_node, visit_type)
       xs[2] = recurse_node(ast.value, visit_node, visit_type)
@@ -2479,6 +2510,25 @@ function tl.pretty_print_ast(ast: Node, fast: boolean): string
                table.insert(out, " =")
                add_child(out, children[2], " ")
             end
+            return out
+         end,
+      },
+      ["local_type"] = {
+         after = function(node: Node, children: {Output}): Output
+            local out: Output = { y = node.y, h = 0 }
+            table.insert(out, "local")
+            add_child(out, children[1], " ")
+            table.insert(out, " =")
+            add_child(out, children[2], " ")
+            return out
+         end,
+      },
+      ["global_type"] = {
+         after = function(node: Node, children: {Output}): Output
+            local out: Output = { y = node.y, h = 0 }
+            add_child(out, children[1], " ")
+            table.insert(out, " =")
+            add_child(out, children[2], " ")
             return out
          end,
       },
@@ -5588,6 +5638,37 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             -- TODO extract node type from `return`
             node.type = NONE
          end
+      },
+      ["local_type"] = {
+         before = function(node: Node)
+            add_var(node.var, node.var.tk, node.value.newtype, node.var.is_const)
+         end,
+         after = function(node: Node, children: {Type}): Type
+            dismiss_unresolved(node.var.tk)
+            node.type = NONE
+         end,
+      },
+      ["global_type"] = {
+         before = function(node: Node)
+            add_global(node.var, node.var.tk, node.value.newtype, node.var.is_const)
+         end,
+         after = function(node: Node, children: {Type}): Type
+            local existing, existing_is_const = find_global(node.var.tk)
+            local var = node.var
+            if existing then
+               if existing_is_const == true and not var.is_const then
+                  node_error(var, "global was previously declared as <const>: " .. var.tk)
+               end
+               if existing_is_const == false and var.is_const then
+                  node_error(var, "global was previously declared as not <const>: " .. var.tk)
+               end
+               if not same_type(existing, node.value.newtype) then
+                  node_error(var, "cannot redeclare global with a different type: previous type of " .. var.tk .. " is %s", existing)
+               end
+            end
+            dismiss_unresolved(var.tk)
+            node.type = NONE
+         end,
       },
       ["local_declaration"] = {
          before = function(node: Node)

--- a/tl.tl
+++ b/tl.tl
@@ -1930,7 +1930,7 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
       node.yend = ps.tokens[i].y
       i = verify_tk(ps, i, "end")
       return i, node
-   elseif ps.tokens[i].tk == "functiontype" then
+   elseif ps.tokens[i].tk == "functiontype" or ps.tokens[i].tk == "function" then
       i, node.newtype.def = parse_function_type(ps, i)
       return i, node
    end

--- a/tl.tl
+++ b/tl.tl
@@ -12,7 +12,7 @@ local type TypeCheckOptions = record
    result: Result
 end
 
-local LoadMode = enum
+local type LoadMode = enum
    "b"
    "t"
    "bt"
@@ -143,7 +143,7 @@ for _, c in ipairs({" ", "\t", "\v", "\n", "\r"}) do
    lex_space[c] = true
 end
 
-local LexState = enum
+local type LexState = enum
    "start"
    "any"
    "identifier"
@@ -680,7 +680,7 @@ local type ParseError = record
    filename: string
 end
 
-local TypeName = enum
+local type TypeName = enum
    "typetype"
    "nestedtype"
    "typevar"

--- a/tl.tl
+++ b/tl.tl
@@ -1013,7 +1013,6 @@ end
 local is_newtype: {string:boolean} = {
    ["enum"] = true,
    ["record"] = true,
-   ["functiontype"] = true,
 }
 
 local function parse_table_value(ps: ParseState, i: number): number, Node
@@ -1930,7 +1929,7 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
       node.yend = ps.tokens[i].y
       i = verify_tk(ps, i, "end")
       return i, node
-   elseif ps.tokens[i].tk == "functiontype" or ps.tokens[i].tk == "function" then
+   elseif ps.tokens[i].tk == "function" then
       i, node.newtype.def = parse_function_type(ps, i)
       return i, node
    end

--- a/tl.tl
+++ b/tl.tl
@@ -1,10 +1,10 @@
-local Env = record
+local type Env = record
    globals: {string:Variable}
    modules: {string:Type}
    skip_compat53: boolean
 end
 
-local TypeCheckOptions = record
+local type TypeCheckOptions = record
    lax: boolean
    filename: string
    skip_compat53: boolean
@@ -17,7 +17,7 @@ local LoadMode = enum
    "t"
    "bt"
 end
-local LoadFunction = functiontype(...:any): any...
+local type LoadFunction = functiontype(...:any): any...
 
 local tl = {
    load: function(string, string, LoadMode, {any:any}): LoadFunction, string = nil,
@@ -65,7 +65,7 @@ local keywords: {string:boolean} = {
 --   ["global"] = true,
 }
 
-local TokenKind = enum
+local type TokenKind = enum
    "keyword"
    "op"
    "string"
@@ -78,7 +78,7 @@ local TokenKind = enum
    "$EOF$"
 end
 
-local Token = record
+local type Token = record
    x: number
    y: number
    i: number
@@ -673,7 +673,7 @@ local function new_typeid(): number
    return last_typeid
 end
 
-local ParseError = record
+local type ParseError = record
    y: number
    x: number
    msg: string
@@ -719,7 +719,7 @@ local table_types: {TypeName:boolean} = {
    ["emptytable"] = true,
 }
 
-local Type = record
+local type Type = record
    {Type}
    y: number
    x: number
@@ -796,7 +796,7 @@ local Type = record
    nominals: {string:{Type}}
 end
 
-local Operator = record
+local type Operator = record
    y: number
    x: number
    arity: number
@@ -804,7 +804,7 @@ local Operator = record
    prec: number
 end
 
-local NodeKind = enum
+local type NodeKind = enum
    "op"
    "nil"
    "string"
@@ -848,23 +848,23 @@ local NodeKind = enum
    "paren"
 end
 
-local FactType = enum
+local type FactType = enum
    "is"
 end
 
-local Fact = record
+local type Fact = record
    fact: FactType
    var: string
    typ: Type
 end
 
-local KeyParsed = enum
+local type KeyParsed = enum
    "short"
    "long"
    "implicit"
 end
 
-local Node = record
+local type Node = record
    {Node}
    y: number
    x: number
@@ -944,13 +944,13 @@ local function is_type(t:Type): boolean
    return t.typename == "typetype" or t.typename == "nestedtype"
 end
 
-local ParseState = record
+local type ParseState = record
    tokens: {Token}
    errs: {ParseError}
    filename: string
 end
 
-local ParseTypeListMode = enum
+local type ParseTypeListMode = enum
    "rets"
    "decltype"
    "casttype"
@@ -1083,9 +1083,9 @@ local function parse_table_item(ps: ParseState, i: number, n: number): number, N
    return i, node, n + 1
 end
 
-local ParseItem = functiontype<T>(ParseState, number, number): number, T, number
+local type ParseItem = functiontype<T>(ParseState, number, number): number, T, number
 
-local SeparatorMode = enum
+local type SeparatorMode = enum
    "sep"
    "term"
 end
@@ -2119,14 +2119,14 @@ end
 -- AST traversal
 --------------------------------------------------------------------------------
 
-local VisitorCallbacks = record<N, T>
+local type VisitorCallbacks = record<N, T>
    before: function(N, {T})
    before_statements: function({N}, {T})
    before_e2: function({N}, {T})
    after: function(N, {T}, T): T
 end
 
-local Visitor = record<K, N, T>
+local type Visitor = record<K, N, T>
    cbs: {K:VisitorCallbacks<N, T>}
    after: VisitorCallbacks<N, T>
 end
@@ -2411,7 +2411,7 @@ local spaced_op: {number:{string:boolean}} = {
 function tl.pretty_print_ast(ast: Node, fast: boolean): string
    local indent = 0
 
-   local Output = record
+   local type Output = record
       {string}
       y: number
       h: number
@@ -3312,14 +3312,14 @@ show_type = function(t: Type, seen: {Type:boolean}): string
    return ret
 end
 
-local Error = record
+local type Error = record
    y: number
    x: number
    msg: string
    filename: string
 end
 
-local Result = record
+local type Result = record
    ast: Node
    type: Type
    syntax_errors: {ParseError}
@@ -3363,7 +3363,7 @@ function tl.search_module(module_name: string, search_dtl: boolean): string, FIL
    return nil, nil, tried
 end
 
-local Variable = record
+local type Variable = record
    t: Type
    is_const: boolean
    needs_compat53: boolean
@@ -4167,7 +4167,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       end
    end
 
-   local CompareTypes = functiontype(Type, Type, boolean): boolean, {Error}
+   local type CompareTypes = functiontype(Type, Type, boolean): boolean, {Error}
 
    local function compare_typevars(t1: Type, t2: Type, comp: CompareTypes): boolean, {Error}
       local tv1 = find_var(t1.typevar)
@@ -4218,7 +4218,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
 
    local is_a: function(Type, Type, boolean): boolean, {Error}
 
-   local TypeGetter = functiontype(string): Type
+   local type TypeGetter = functiontype(string): Type
 
    local function match_record_fields(t1: Type, t2: TypeGetter, cmp: CompareTypes): boolean, {Error}
       cmp = cmp or is_a

--- a/tl.tl
+++ b/tl.tl
@@ -5691,14 +5691,6 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       return UNKNOWN
    end
 
-   local function put_newtype_name_in_scope(node: Node)
-      if node.exps and node.exps[1] and node.exps[1].kind == "newtype" then
-         local t = node.exps[1].newtype.def
-         local var = node.vars[1]
-         add_var(var, var.tk, node.exps[1].newtype, var.is_const)
-      end
-   end
-
    local visit_node: Visitor<NodeKind, Node, Type> = {}
 
    visit_node.cbs = {
@@ -5751,9 +5743,6 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          end,
       },
       ["local_declaration"] = {
-         before = function(node: Node)
-            put_newtype_name_in_scope(node)
-         end,
          after = function(node: Node, children: {Type}): Type
             local vals: {Type} = get_assignment_values(children[2], #node.vars)
             for i, var in ipairs(node.vars) do
@@ -5788,9 +5777,6 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          end,
       },
       ["global_declaration"] = {
-         before = function(node: Node)
-            put_newtype_name_in_scope(node)
-         end,
          after = function(node: Node, children: {Type}): Type
             local vals: {Type} = get_assignment_values(children[2], #node.vars)
             for i, var in ipairs(node.vars) do

--- a/tl.tl
+++ b/tl.tl
@@ -1873,6 +1873,21 @@ local function parse_nested_type(ps: ParseState, i: number, def: Type, typename:
    return i
 end
 
+local function parse_enum_body(ps: ParseState, i: number, def: Type, node: Node): number, Node
+   def.enumset = {}
+   while not ((not ps.tokens[i]) or ps.tokens[i].tk == "end") do
+      local item: Node
+      i, item = verify_kind(ps, i, "string", "enum_item")
+      if item then
+         table.insert(node, item)
+         def.enumset[unquote(item.tk)] = true
+      end
+   end
+   node.yend = ps.tokens[i].y
+   i = verify_tk(ps, i, "end")
+   return i, node
+end
+
 local function parse_record_body(ps: ParseState, i: number, def: Type, node: Node): number, Node
    def.fields = {}
    def.field_order = {}
@@ -1915,6 +1930,8 @@ local function parse_record_body(ps: ParseState, i: number, def: Type, node: Nod
          end
       elseif ps.tokens[i].tk == "record" and ps.tokens[i+1].tk ~= ":" then
          i = parse_nested_type(ps, i, def, "record", parse_record_body)
+      elseif ps.tokens[i].tk == "enum" and ps.tokens[i+1].tk ~= ":" then
+         i = parse_nested_type(ps, i, def, "enum", parse_enum_body)
       else
          local v: Node
          i, v = verify_kind(ps, i, "identifier", "variable")
@@ -1945,7 +1962,7 @@ local function parse_record_body(ps: ParseState, i: number, def: Type, node: Nod
             end
          elseif ps.tokens[i].tk == "=" then
             local next_word = ps.tokens[i + 1].tk
-            if next_word == "record" then
+            if next_word == "record" or next_word == "enum" then
                return fail(ps, i, "syntax error: this syntax is no longer valid; use '" .. next_word .. " " .. v.tk .. "'")
             elseif next_word == "functiontype" then
                return fail(ps, i, "syntax error: this syntax is no longer valid; use 'type " .. v.tk .. " = function('...")
@@ -1971,19 +1988,9 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
       return i, node
    elseif ps.tokens[i].tk == "enum" then
       local def = new_type(ps, i, "enum")
-      node.newtype.def = def
-      def.enumset = {}
       i = i + 1
-      while not ((not ps.tokens[i]) or ps.tokens[i].tk == "end") do
-         local item: Node
-         i, item = verify_kind(ps, i, "string", "enum_item")
-         if item then
-            table.insert(node, item)
-            def.enumset[unquote(item.tk)] = true
-         end
-      end
-      node.yend = ps.tokens[i].y
-      i = verify_tk(ps, i, "end")
+      i = parse_enum_body(ps, i, def, node)
+      node.newtype.def = def
       return i, node
    else
       i, node.newtype.def = parse_type(ps, i)
@@ -2072,15 +2079,17 @@ local function parse_type_declaration(ps: ParseState, i: number, node_name: Node
    return i, asgn
 end
 
-local function parse_record(ps: ParseState, i: number, node_name: NodeKind): number, Node
+local type ParseBody = function(ps: ParseState, i: number, def: Type, node: Node): number, Node
+
+local function parse_type_constructor(ps: ParseState, i: number, node_name: NodeKind, type_name: TypeName, parse_body: ParseBody): number, Node
    local asgn: Node = new_node(ps.tokens, i, node_name)
    local nt: Node = new_node(ps.tokens, i, "newtype")
    asgn.value = nt
    nt.newtype = new_type(ps, i, "typetype")
-   local def = new_type(ps, i, "record")
+   local def = new_type(ps, i, type_name)
    nt.newtype.def = def
 
-   i = i + 2 -- skip `local` or `global`, and `record`
+   i = i + 2 -- skip `local` or `global`, and the constructor name
 
    i, asgn.var = verify_kind(ps, i, "identifier")
    if not asgn.var then
@@ -2088,7 +2097,7 @@ local function parse_record(ps: ParseState, i: number, node_name: NodeKind): num
    end
    nt.newtype.def.names = { asgn.var.tk }
 
-   i = parse_record_body(ps, i, def, nt)
+   i = parse_body(ps, i, def, nt)
    return i, asgn
 end
 
@@ -2098,8 +2107,10 @@ local function parse_statement(ps: ParseState, i: number): number, Node
          return parse_type_declaration(ps, i, "local_type")
       elseif ps.tokens[i+1].tk == "function" then
          return parse_local_function(ps, i)
-      elseif ps.tokens[i+1].tk == "record" and ps.tokens[i+2].kind == "identifier"  then
-         return parse_record(ps, i, "local_type")
+      elseif ps.tokens[i+1].tk == "record" and ps.tokens[i+2].kind == "identifier" then
+         return parse_type_constructor(ps, i, "local_type", "record", parse_record_body)
+      elseif ps.tokens[i+1].tk == "enum" and ps.tokens[i+2].kind == "identifier" then
+         return parse_type_constructor(ps, i, "local_type", "enum", parse_enum_body)
       else
          i = i + 1
          return parse_variable_declarations(ps, i, "local_declaration")
@@ -2108,7 +2119,9 @@ local function parse_statement(ps: ParseState, i: number): number, Node
       if ps.tokens[i+1].tk == "type" and ps.tokens[i+2].kind == "identifier" then
          return parse_type_declaration(ps, i, "global_type")
       elseif ps.tokens[i+1].tk == "record" and ps.tokens[i+2].kind == "identifier" then
-         return parse_record(ps, i, "global_type")
+         return parse_type_constructor(ps, i, "global_type", "record", parse_record_body)
+      elseif ps.tokens[i+1].tk == "enum" and ps.tokens[i+2].kind == "identifier" then
+         return parse_type_constructor(ps, i, "global_type", "enum", parse_enum_body)
       elseif ps.tokens[i+1].tk == "function" then
          i = i + 1
          return parse_function(ps, i)


### PR DESCRIPTION
Some thoughts on syntax changes in preparation for language additions:

* `local type Name = Type` for type declarations, no longer mixed with variable declarations. They always worked pretty differently from variable declarations (no `: Type` section, no multiple assignment, always auto-const).
  * `Type` there accepts any type, so you can give names to unions, etc. (so this not only a syntax change, but a new language feature)
  * remove `functiontype` as it becomes redundant, you just need to declare a `function` type as usual
* New shorthand forms `local record Name ... end` and `local enum Name ... end`, just like `local function Name...` exists in parallel to `local Name = function...` in Lua.
* both of the above for `global` as well, of course