### PR TITLE
Pass command line args to target script in `tl run`

### DIFF
--- a/tl
+++ b/tl
@@ -391,7 +391,7 @@ if cmd == "run" then
    end
 
    tl.loader()
-   return chunk()
+   return chunk((unpack or table.unpack)(arg))
 end
 
 --------------------------------------------------------------------


### PR DESCRIPTION
I noticed that `tl run` wasn't passing args through to Teal scripts:

```lua
-- ok.tl
for _, a in ipairs({...}) do
    print(a)
end
```

```sh
$ ./tl run ok.tl 123 456
<no output>
$ lua ok.tl 123 456
123
456
```

Someone already did the hard work of setting up the args properly, so this PR just passes them along to the target Lua script:

```sh
$ git checkout run-with-args
Switched to branch 'run-with-args'
$ ./tl run ok.tl 123 456
123
456
```