### PR TITLE
Add error checking for when tl doesn't catch lua errors

### DIFF
--- a/spec/error_reporting/module_error_spec.lua
+++ b/spec/error_reporting/module_error_spec.lua
@@ -1,0 +1,32 @@
+local tl = require("tl")
+local util = require("spec.util")
+
+describe("Uncaught compiler errors", function()
+   local old_parse_program
+   setup(function()
+      old_parse_program = tl.parse_program
+      tl.parse_program = function(tokens, _, chunkname)
+         return old_parse_program(tokens, {}, chunkname)
+      end
+   end)
+   teardown(function()
+      tl.parse_program = old_parse_program
+   end)
+   it("should be reported when loading modules", function()
+      util.run_mock_project(finally, {
+         dir_name = "uncaught_compiler_error_test",
+         dir_structure = {
+            ["my_module.tl"] = [[todo, write module :)]],
+            ["my_script.tl"] = [[local mod = require("my_module"); mod.do_things()]],
+         },
+         cmd = "run",
+         args = "my_script.tl",
+         generated_files = {},
+         popen = {
+            status = nil,
+            exit = "exit",
+            code = 1,
+         },
+      })
+   end)
+end)

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -179,11 +179,6 @@ function util.run_mock_project(finally, t)
    local actual_dir_structure = util.get_dir_structure(".")
    lfs.chdir(current_dir)
    if t.popen then
-      -- t.popen = t.popen or {
-      --    status = true,
-      --    exit = "exit",
-      --    code = 0,
-      -- }
       util.assert_popen_close(
          t.popen.status,
          t.popen.exit,

--- a/tl
+++ b/tl
@@ -301,7 +301,7 @@ local function type_check_file(file_name)
    local has_syntax_errors = report_errors("syntax error", result.syntax_errors)
    if has_syntax_errors then
       exit = 1
-      return 
+      return
    end
 
    local ok = report_type_errors(result)
@@ -346,7 +346,7 @@ local function type_check_and_load(filename, modules)
 
    local chunk, err = (loadstring or load)(tl.pretty_print_ast(result.ast), "@" .. filename)
    if err then
-      die("!!Error uncaught by tl!!: " .. err)
+      die("Internal Compiler Error: Teal generator produced invalid Lua. Please report a bug at https://github.com/teal-language/tl")
    end
    return chunk
 end

--- a/tl.lua
+++ b/tl.lua
@@ -12,7 +12,15 @@ local TypeCheckOptions = {}
 
 
 
+local LoadMode = {}
+
+
+
+
+local LoadFunction = {}
+
 local tl = {
+   load = nil,
    process = nil,
    process_string = nil,
    gen = nil,
@@ -6509,17 +6517,21 @@ local function tl_package_loader(module_name)
    if found_filename then
       local input = fd:read("*a")
       fd:close()
-      local tokens = tl.lex(input)
       local errs = {}
-      local i, program = tl.parse_program(tokens, errs, found_filename)
+      local _, program = tl.parse_program(tl.lex(input), errs, module_name)
+      if #errs > 0 then
+         error(module_name .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg)
+      end
       local code = tl.pretty_print_ast(program, true)
-      local chunk = load(code, found_filename)
+      local chunk, err = load(code, module_name, "t")
       if chunk then
          return function()
             local ret = chunk()
             package.loaded[module_name] = ret
             return ret
          end
+      else
+         error("Internal Compiler Error: Teal generator produced invalid Lua. Please report a bug at https://github.com/teal-language/tl")
       end
    end
    return table.concat(tried, "\n\t")
@@ -6532,14 +6544,6 @@ function tl.loader()
       table.insert(package.loaders, 2, tl_package_loader)
    end
 end
-
-local LoadMode = {}
-
-
-
-
-
-local LoadFunction = {}
 
 function tl.load(input, chunkname, mode, env)
    local tokens = tl.lex(input)

--- a/tl.tl
+++ b/tl.tl
@@ -12,7 +12,15 @@ local TypeCheckOptions = record
    result: Result
 end
 
+local LoadMode = enum
+   "b"
+   "t"
+   "bt"
+end
+local LoadFunction = functiontype(...:any): any...
+
 local tl = {
+   load: function(string, string, LoadMode, {any:any}): LoadFunction, string = nil,
    process: function(string, Env, Result, {string}): (Result, string) = nil,
    process_string: function(string, boolean, Env, Result, {string}, string): (Result, string) = nil,
    gen: function(string): string = nil,
@@ -6509,17 +6517,21 @@ local function tl_package_loader(module_name: string): any
    if found_filename then
       local input = fd:read("*a")
       fd:close()
-      local tokens = tl.lex(input)
-      local errs = {}
-      local i, program = tl.parse_program(tokens, errs, found_filename)
+      local errs: {ParseError} = {}
+      local _, program = tl.parse_program(tl.lex(input), errs, module_name)
+      if #errs > 0 then
+         error(module_name .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg)
+      end
       local code = tl.pretty_print_ast(program, true)
-      local chunk = load(code, found_filename)
+      local chunk, err = load(code, module_name, "t")
       if chunk then
          return function(): any
             local ret = chunk()
             package.loaded[module_name] = ret
             return ret
          end
+      else
+         error("Internal Compiler Error: Teal generator produced invalid Lua. Please report a bug at https://github.com/teal-language/tl")
       end
    end
    return table.concat(tried, "\n\t")
@@ -6532,14 +6544,6 @@ function tl.loader()
       table.insert(package.loaders, 2, tl_package_loader)
    end
 end
-
-local LoadMode = enum
-   "b"
-   "t"
-   "bt"
-end
-
-local LoadFunction = functiontype(...:any): any...
 
 function tl.load(input: string, chunkname: string, mode: LoadMode, env: {any:any}): LoadFunction, string
    local tokens = tl.lex(input)


### PR DESCRIPTION
In addition, use `tl.load` to load modules since the code for both was very similar.