### PR TITLE
Add testcases for __tostring metamethod

### DIFF
--- a/spec/declaration/record_method_spec.lua
+++ b/spec/declaration/record_method_spec.lua
@@ -279,4 +279,21 @@ describe("record method", function()
       ]], output)
    end)
 
+   it("__tostring works with explicit return type", util.check [[
+         local foo_mt = record
+         end
+
+         function foo_mt:__tostring() : string
+            return ""
+         end
+      ]])
+
+   it("__tostring works without explicit return type", util.check [[
+         local foo_mt = record
+         end
+
+         function foo_mt:__tostring()
+            return ""
+         end
+      ]])
 end)


### PR DESCRIPTION
Based on

https://github.com/teal-language/tl/blob/4d031432fe0d0823fdb72437b56d8581d4417af0/tl.tl#L3479

I'm assuming that a `__tostring` metatable field should not need to explicitly state that it returns a string, however this test case in this PR fails with

> excess return values, expected 0 got 1