### PR TITLE
fix file handle leak in tl.process

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -6459,8 +6459,8 @@ function tl.process(filename, env, result, preload_modules)
    end
 
    local input, err = fd:read("*a")
+   fd:close()
    if not input then
-      fd:close()
       return nil, "could not read " .. filename .. ": " .. err
    end
 

--- a/tl.tl
+++ b/tl.tl
@@ -6459,8 +6459,8 @@ function tl.process(filename: string, env: Env, result: Result, preload_modules:
    end
 
    local input, err = fd:read("*a")
+   fd:close()
    if not input then
-      fd:close()
       return nil, "could not read " .. filename .. ": " .. err
    end
 


### PR DESCRIPTION
Found this when toying around with my own cli and testing a build with like 20k files of just `print` statements and `tl.process` apparently only closed the file handle when it failed to read.