### PR TITLE
fix: only infer an array if we can infer the elements

### DIFF
--- a/spec/inference/emptytable_spec.lua
+++ b/spec/inference/emptytable_spec.lua
@@ -1,6 +1,16 @@
 local util = require("spec.util")
 
 describe("empty table without type annotation", function()
+   it("an empty return produces no type information (regression test for #234)", util.check_type_error([[
+      local function heyyyy()
+      end
+
+      local ret_value = {heyyyy()}
+      table.unpack(ret_value)
+   ]], {
+      { msg = "cannot determine type of array elements" },
+   }))
+
    it("has its type determined by its first use", util.check_type_error([[
       local t = {}
       for i = 1, 10 do

--- a/tl.lua
+++ b/tl.lua
@@ -6131,6 +6131,10 @@ function tl.type_check(ast, opts)
                   else
                      node.type.elements = expand_type(node, node.type.elements, child.vtype)
                   end
+                  if not node.type.elements then
+                     node_error(node, "cannot determine type of array elements")
+                     is_array = false
+                  end
                else
                   is_map = true
                   node.type.keys = expand_type(node, node.type.keys, child.ktype)

--- a/tl.tl
+++ b/tl.tl
@@ -6131,6 +6131,10 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
                   else
                      node.type.elements = expand_type(node, node.type.elements, child.vtype)
                   end
+                  if not node.type.elements then
+                     node_error(node, "cannot determine type of array elements")
+                     is_array = false
+                  end
                else
                   is_map = true
                   node.type.keys = expand_type(node, node.type.keys, child.ktype)


### PR DESCRIPTION
When resolving the type of a table literal, a function with no
returns produces an empty tuple, and that does not give us enough
data to resolve a type.

Fixes #234.