### PR TITLE
fix /tmp/config_type_check not being removed

### DIFF
--- a/spec/config/type_check_spec.lua
+++ b/spec/config/type_check_spec.lua
@@ -1,7 +1,7 @@
 local util = require("spec.util")
 
 describe("config type checking", function()
-   it("should error out when a config entry isn't the correct type", function()
+   it("should error out when config.include is not a {string}", function()
       util.run_mock_project(finally, {
          dir_name = "config_type_check",
          dir_structure = {
@@ -17,6 +17,8 @@ describe("config type checking", function()
          },
          cmd_output = "Error while loading config: Expected include to be a {string}\n",
       })
+   end)
+   it("should error out when config.source_dir is not a string", function()
       util.run_mock_project(finally, {
          dir_name = "config_type_check2",
          dir_structure = {


### PR DESCRIPTION
When running `make` I ran into the problem of the `type_check_spec` test to fail because the `/tmp/config_type_check` folder didn't get removed.

This was caused because `finally` only executes the last function that it was given.

Splitting the 2 tests up fixes this, as the cleanup function from the first test runs before the second overwrites it. It is now also possible to remove the `2` from the second folder, though I didn't do that in this PR (Can push that change as well if desired).