### PR TITLE
lexer: fixes for the pretty-printer

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -582,6 +582,8 @@ local add_space = {
    ["op:{"] = true,
    ["op:#"] = true,
 
+   ["::identifier"] = true,
+
    [",:identifier"] = true,
    [",:keyword"] = true,
    [",:string"] = true,

--- a/tl.lua
+++ b/tl.lua
@@ -626,6 +626,7 @@ local should_indent = {
    ["elseif"] = true,
    ["else"] = true,
    ["function"] = true,
+   ["record"] = true,
 }
 
 function tl.pretty_print_tokens(tokens)

--- a/tl.lua
+++ b/tl.lua
@@ -555,13 +555,14 @@ end
 
 
 local add_space = {
-   ["word:keyword"] = true,
-   ["word:word"] = true,
-   ["word:string"] = true,
-   ["word:="] = true,
-   ["word:op"] = true,
+   ["identifier:identifier"] = true,
+   ["identifier:keyword"] = true,
+   ["identifier:word"] = true,
+   ["identifier:string"] = true,
+   ["identifier:="] = true,
+   ["identifier:op"] = true,
 
-   ["keyword:word"] = true,
+   ["keyword:identifier"] = true,
    ["keyword:keyword"] = true,
    ["keyword:string"] = true,
    ["keyword:number"] = true,
@@ -571,7 +572,7 @@ local add_space = {
    ["keyword:("] = true,
    ["keyword:#"] = true,
 
-   ["=:word"] = true,
+   ["=:identifier"] = true,
    ["=:keyword"] = true,
    ["=:string"] = true,
    ["=:number"] = true,
@@ -581,30 +582,30 @@ local add_space = {
    ["op:{"] = true,
    ["op:#"] = true,
 
-   [",:word"] = true,
+   [",:identifier"] = true,
    [",:keyword"] = true,
    [",:string"] = true,
    [",:{"] = true,
 
    ["):op"] = true,
-   ["):word"] = true,
+   ["):identifier"] = true,
    ["):keyword"] = true,
 
    ["op:string"] = true,
    ["op:number"] = true,
-   ["op:word"] = true,
+   ["op:identifier"] = true,
    ["op:keyword"] = true,
 
-   ["]:word"] = true,
+   ["]:identifier"] = true,
    ["]:keyword"] = true,
    ["]:="] = true,
    ["]:op"] = true,
 
    ["string:op"] = true,
-   ["string:word"] = true,
+   ["string:identifier"] = true,
    ["string:keyword"] = true,
 
-   ["number:word"] = true,
+   ["number:identifier"] = true,
    ["number:keyword"] = true,
 }
 

--- a/tl.tl
+++ b/tl.tl
@@ -582,6 +582,8 @@ local add_space: {string:boolean} = {
    ["op:{"] = true,
    ["op:#"] = true,
 
+   ["::identifier"] = true,
+
    [",:identifier"] = true,
    [",:keyword"] = true,
    [",:string"] = true,

--- a/tl.tl
+++ b/tl.tl
@@ -626,6 +626,7 @@ local should_indent: {string:boolean} = {
    ["elseif"] = true,
    ["else"] = true,
    ["function"] = true,
+   ["record"] = true,
 }
 
 function tl.pretty_print_tokens(tokens: {Token}): string

--- a/tl.tl
+++ b/tl.tl
@@ -555,13 +555,14 @@ end
 --------------------------------------------------------------------------------
 
 local add_space: {string:boolean} = {
-   ["word:keyword"] = true,
-   ["word:word"] = true,
-   ["word:string"] = true,
-   ["word:="] = true,
-   ["word:op"] = true,
+   ["identifier:identifier"] = true,
+   ["identifier:keyword"] = true,
+   ["identifier:word"] = true,
+   ["identifier:string"] = true,
+   ["identifier:="] = true,
+   ["identifier:op"] = true,
 
-   ["keyword:word"] = true,
+   ["keyword:identifier"] = true,
    ["keyword:keyword"] = true,
    ["keyword:string"] = true,
    ["keyword:number"] = true,
@@ -571,7 +572,7 @@ local add_space: {string:boolean} = {
    ["keyword:("] = true,
    ["keyword:#"] = true,
 
-   ["=:word"] = true,
+   ["=:identifier"] = true,
    ["=:keyword"] = true,
    ["=:string"] = true,
    ["=:number"] = true,
@@ -581,30 +582,30 @@ local add_space: {string:boolean} = {
    ["op:{"] = true,
    ["op:#"] = true,
 
-   [",:word"] = true,
+   [",:identifier"] = true,
    [",:keyword"] = true,
    [",:string"] = true,
    [",:{"] = true,
 
    ["):op"] = true,
-   ["):word"] = true,
+   ["):identifier"] = true,
    ["):keyword"] = true,
 
    ["op:string"] = true,
    ["op:number"] = true,
-   ["op:word"] = true,
+   ["op:identifier"] = true,
    ["op:keyword"] = true,
 
-   ["]:word"] = true,
+   ["]:identifier"] = true,
    ["]:keyword"] = true,
    ["]:="] = true,
    ["]:op"] = true,
 
    ["string:op"] = true,
-   ["string:word"] = true,
+   ["string:identifier"] = true,
    ["string:keyword"] = true,
 
-   ["number:word"] = true,
+   ["number:identifier"] = true,
    ["number:keyword"] = true,
 }
 


### PR DESCRIPTION
"Various fixes and improvements." Most notably, it looks like words got renamed to identifiers, but the token pretty-printer (which... isn't presently used anywhere) never got updated to match.

Before:

```lua
localtypeatom=number

localtypecell=record
h:noun
t:noun
end

localtypenoun=atom|cell

functionhead(n:noun):noun
   ifniscellthen
      returnn.h
   else
      assert(false, 'head of atom; ' ..n)
   end
end
```

After:

```lua
local type atom = number

local type cell = record
   h: noun
   t: noun
end

local type noun = atom | cell

function head(n: noun): noun
   if n is cell then
      return n.h
   else
      assert(false, 'head of atom; ' .. n)
   end
end
```