### PR TITLE
tl.process: Cache required modules to not load code more than once

### DIFF
--- a/spec/api/process_spec.lua
+++ b/spec/api/process_spec.lua
@@ -20,4 +20,21 @@ describe("tl.process", function()
          util.assert_line_by_line(expected_lua_code, pretty_result_string)
       end)
    end)
+   describe("process", function()
+      it("should cache modules by filename to prevent code being loaded more than once (#245)", function()
+
+         local current_dir = lfs.currentdir()
+         local dir_name = util.write_tmp_dir(finally, "module_cache", {
+            ["foo.tl"] = [[ require("bar") ]],
+            ["bar.tl"] = [[ global x = 10 ]],
+         })
+
+         assert(lfs.chdir(dir_name))
+         local foo_result, foo_err = tl.process("foo.tl")
+         local bar_result, bar_err = tl.process("bar.tl", foo_result.env)
+         assert(lfs.chdir(current_dir))
+         assert(foo_result, foo_err)
+         assert(bar_result, bar_err)
+      end)
+   end)
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -4,6 +4,7 @@ local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) 
 
 
 
+
 local TypeCheckOptions = {}
 
 
@@ -3534,6 +3535,7 @@ end
 
 local function require_module(module_name, lax, env, result)
    local modules = env.modules
+   local loaded = env.loaded
 
    if modules[module_name] then
       return modules[module_name], true
@@ -3550,6 +3552,7 @@ local function require_module(module_name, lax, env, result)
          _result.type = BOOLEAN
       end
 
+      loaded[found] = _result
       modules[module_name] = _result.type
 
       return _result.type, true
@@ -4100,6 +4103,7 @@ end
 function tl.init_env(lax, skip_compat53)
    local env = {
       modules = {},
+      loaded = {},
       globals = init_globals(lax),
       skip_compat53 = skip_compat53,
    }
@@ -6692,6 +6696,9 @@ function tl.type_check(ast, opts)
 end
 
 function tl.process(filename, env, result, preload_modules)
+   if env and env.loaded and env.loaded[filename] then
+      return env.loaded[filename]
+   end
    local fd, err = io.open(filename, "r")
    if not fd then
       return nil, "could not open " .. filename .. ": " .. err
@@ -6728,6 +6735,9 @@ function tl.process_string(input, is_lua, env, result, preload_modules,
 filename)
 
    env = env or tl.init_env(is_lua)
+   if env.loaded and env.loaded[filename] then
+      return env.loaded[filename]
+   end
    result = result or {
       syntax_errors = {},
       type_errors = {},
@@ -6775,6 +6785,7 @@ filename)
    result.ast = program
    result.env = env
 
+   env.loaded[filename] = result
    return result
 end
 

--- a/tl.tl
+++ b/tl.tl
@@ -1,6 +1,7 @@
 local record Env
    globals: {string:Variable}
    modules: {string:Type}
+   loaded: {string:Result}
    skip_compat53: boolean
 end
 
@@ -3534,6 +3535,7 @@ end
 
 local function require_module(module_name: string, lax: boolean, env: Env, result: Result): Type, boolean
    local modules = env.modules
+   local loaded = env.loaded
 
    if modules[module_name] then
       return modules[module_name], true
@@ -3550,6 +3552,7 @@ local function require_module(module_name: string, lax: boolean, env: Env, resul
          _result.type = BOOLEAN
       end
 
+      loaded[found] = _result
       modules[module_name] = _result.type
 
       return _result.type, true
@@ -4100,6 +4103,7 @@ end
 function tl.init_env(lax: boolean, skip_compat53: boolean): Env
    local env = {
       modules = {},
+      loaded = {},
       globals = init_globals(lax),
       skip_compat53 = skip_compat53,
    }
@@ -6692,6 +6696,9 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
 end
 
 function tl.process(filename: string, env: Env, result: Result, preload_modules: {string}): Result, string
+   if env and env.loaded and env.loaded[filename] then
+      return env.loaded[filename]
+   end
    local fd, err = io.open(filename, "r")
    if not fd then
       return nil, "could not open " .. filename .. ": " .. err
@@ -6728,6 +6735,9 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
                            filename: string): Result, string
 
    env = env or tl.init_env(is_lua)
+   if env.loaded and env.loaded[filename] then
+      return env.loaded[filename]
+   end
    result = result or {
       syntax_errors = {},
       type_errors = {},
@@ -6775,6 +6785,7 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
    result.ast = program
    result.env = env
 
+   env.loaded[filename] = result
    return result
 end
 


### PR DESCRIPTION
Fixes #245
Adds a `loaded: {string:Result}` field to `Env` to map filenames to results.

There ended up being some hitches trying to change `Env.modules` to map from filenames to `Result`s instead of the literal `require` argument to a type. So it ended up being simpler to add an `Env.loaded` field to map the filenames to the compiled results.