### PR TITLE
tl: never return nil from stdlib function assert()

### DIFF
--- a/spec/stdlib/assert_spec.lua
+++ b/spec/stdlib/assert_spec.lua
@@ -1,0 +1,23 @@
+local tl = require("tl")
+local util = require("spec.util")
+
+describe("assert", function()
+   it("unwraps a specifically T|nil value into a T value", function()
+      util.mock_io(finally, {
+         ["assert.tl"] = [[
+            local function test(x: string): string
+               return x
+            end
+
+            local x: string|nil = "hello"
+
+            test(assert(x))
+         ]]
+      })
+      local result, err = tl.process("assert.tl")
+
+      assert.same({}, result.syntax_errors)
+      assert.same({}, result.type_errors)
+      assert.same({}, result.unknowns)
+   end)
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -3566,8 +3566,8 @@ local standard_library = {
    ["assert"] = a_type({
       typename = "poly",
       types = {
-         a_type({ typename = "function", typeargs = { ARG_ALPHA }, args = { ALPHA }, rets = { ALPHA } }),
-         a_type({ typename = "function", typeargs = { ARG_ALPHA, ARG_BETA }, args = { ALPHA, BETA }, rets = { ALPHA } }),
+         a_type({ typename = "function", typeargs = { ARG_ALPHA }, args = { a_type({ typename = "union", types = { ALPHA, NIL } }) }, rets = { ALPHA } }),
+         a_type({ typename = "function", typeargs = { ARG_ALPHA, ARG_BETA }, args = { a_type({ typename = "union", types = { ALPHA, NIL } }), BETA }, rets = { ALPHA } }),
       },
    }),
    ["collectgarbage"] = a_type({ typename = "function", args = { STRING }, rets = { a_type({ typename = "union", types = { BOOLEAN, NUMBER } }), NUMBER, NUMBER } }),

--- a/tl.tl
+++ b/tl.tl
@@ -3566,8 +3566,8 @@ local standard_library: {string:Type} = {
    ["assert"] = a_type {
       typename = "poly",
       types = {
-         a_type { typename = "function", typeargs = { ARG_ALPHA }, args = { ALPHA }, rets = { ALPHA } },
-         a_type { typename = "function", typeargs = { ARG_ALPHA, ARG_BETA }, args = { ALPHA, BETA }, rets = { ALPHA } },
+         a_type { typename = "function", typeargs = { ARG_ALPHA }, args = { a_type { typename = "union", types = { ALPHA, NIL  } } }, rets = { ALPHA } },
+         a_type { typename = "function", typeargs = { ARG_ALPHA, ARG_BETA }, args = { a_type { typename = "union", types = { ALPHA, NIL  } }, BETA }, rets = { ALPHA } },
       }
    },
    ["collectgarbage"] = a_type { typename = "function", args = { STRING }, rets = { a_type { typename = "union", types = { BOOLEAN, NUMBER } }, NUMBER, NUMBER } },


### PR DESCRIPTION
This makes it so the first argument passed to `assert()` can be ALPHA or nil, so the type of ALPHA can be considered not-nil by the fact that nil is a "non-alpha" case.

I have tested this locally (with code I'm actively writing) and it seems to work.