### PR TITLE
tl: Initial exposure of types

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -698,13 +698,6 @@ local function new_typeid()
    return last_typeid
 end
 
-local ParseError = {}
-
-
-
-
-
-
 local TypeName = {}
 
 

--- a/tl.lua
+++ b/tl.lua
@@ -1,11 +1,4 @@
-local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) and require('compat53.module'); local assert = _tl_compat53 and _tl_compat53.assert or assert; local io = _tl_compat53 and _tl_compat53.io or io; local ipairs = _tl_compat53 and _tl_compat53.ipairs or ipairs; local load = _tl_compat53 and _tl_compat53.load or load; local math = _tl_compat53 and _tl_compat53.math or math; local os = _tl_compat53 and _tl_compat53.os or os; local package = _tl_compat53 and _tl_compat53.package or package; local pairs = _tl_compat53 and _tl_compat53.pairs or pairs; local string = _tl_compat53 and _tl_compat53.string or string; local table = _tl_compat53 and _tl_compat53.table or table; local _tl_table_unpack = unpack or table.unpack; local Env = {}
-
-
-
-
-
-
-local TypeCheckOptions = {}
+local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) and require('compat53.module'); local assert = _tl_compat53 and _tl_compat53.assert or assert; local io = _tl_compat53 and _tl_compat53.io or io; local ipairs = _tl_compat53 and _tl_compat53.ipairs or ipairs; local load = _tl_compat53 and _tl_compat53.load or load; local math = _tl_compat53 and _tl_compat53.math or math; local os = _tl_compat53 and _tl_compat53.os or os; local package = _tl_compat53 and _tl_compat53.package or package; local pairs = _tl_compat53 and _tl_compat53.pairs or pairs; local string = _tl_compat53 and _tl_compat53.string or string; local table = _tl_compat53 and _tl_compat53.table or table; local _tl_table_unpack = unpack or table.unpack; local TypeCheckOptions = {}
 
 
 
@@ -20,14 +13,41 @@ local LoadMode = {}
 
 local LoadFunction = {}
 
-local tl = {
-   load = nil,
-   process = nil,
-   process_string = nil,
-   gen = nil,
-   type_check = nil,
-   init_env = nil,
-}
+local tl = {Env = {}, Result = {}, Error = {}, }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+local Result = tl.Result
+local Env = tl.Env
+local Error = tl.Error
 
 
 
@@ -2620,11 +2640,11 @@ function tl.pretty_print_ast(ast, mode)
 
    local function print_record_def(typ)
       local out = { "{" }
-      for name, field in pairs(typ.fields) do
-         if field.typename == "typetype" and is_record_type(field.def) then
+      for _, name in ipairs(typ.field_order) do
+         if typ.fields[name].typename == "typetype" and is_record_type(typ.fields[name].def) then
             table.insert(out, name)
             table.insert(out, " = ")
-            table.insert(out, print_record_def(field.def))
+            table.insert(out, print_record_def(typ.fields[name].def))
             table.insert(out, ", ")
          end
       end
@@ -3463,22 +3483,6 @@ show_type = function(t, seen)
    end
    return ret
 end
-
-local Error = {}
-
-
-
-
-
-
-local Result = {}
-
-
-
-
-
-
-
 
 local function search_for(module_name, suffix, path, tried)
    for entry in path:gmatch("[^;]+") do

--- a/tl.tl
+++ b/tl.tl
@@ -31,7 +31,7 @@ local record tl
    record Result
       ast: Node
       type: Type
-      syntax_errors: {ParseError}
+      syntax_errors: {Error}
       type_errors: {Error}
       unknowns: {Error}
       env: Env
@@ -698,13 +698,6 @@ local function new_typeid(): number
    return last_typeid
 end
 
-local record ParseError
-   y: number
-   x: number
-   msg: string
-   filename: string
-end
-
 local enum TypeName
    "typetype"
    "nestedtype"
@@ -971,7 +964,7 @@ end
 
 local record ParseState
    tokens: {Token}
-   errs: {ParseError}
+   errs: {Error}
    filename: string
 end
 
@@ -2227,7 +2220,7 @@ parse_statements = function(ps: ParseState, i: number, filename: string, topleve
    return i, node
 end
 
-function tl.parse_program(tokens: {Token}, errs: {ParseError}, filename: string): number, Node
+function tl.parse_program(tokens: {Token}, errs: {Error}, filename: string): number, Node
    errs = errs or {}
    local ps: ParseState = {
       tokens = tokens,
@@ -6816,7 +6809,7 @@ local function tl_package_loader(module_name: string): any
    if found_filename then
       local input = fd:read("*a")
       fd:close()
-      local errs: {ParseError} = {}
+      local errs: {Error} = {}
       local _, program = tl.parse_program(tl.lex(input), errs, module_name)
       if #errs > 0 then
          error(module_name .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg)
@@ -6846,7 +6839,7 @@ end
 
 tl.load = function(input: string, chunkname: string, mode: LoadMode, env: {any:any}): LoadFunction, string
    local tokens = tl.lex(input)
-   local errs: {ParseError} = {}
+   local errs: {Error} = {}
    local i, program = tl.parse_program(tokens, errs, chunkname)
    if #errs > 0 then
       return nil, (chunkname or "") .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg

--- a/tl.tl
+++ b/tl.tl
@@ -1,10 +1,3 @@
-local record Env
-   globals: {string:Variable}
-   modules: {string:Type}
-   loaded: {string:Result}
-   skip_compat53: boolean
-end
-
 local record TypeCheckOptions
    lax: boolean
    filename: string
@@ -20,14 +13,41 @@ local enum LoadMode
 end
 local type LoadFunction = function(...:any): any...
 
-local tl = {
-   load: function(string, string, LoadMode, {any:any}): LoadFunction, string = nil,
-   process: function(string, Env, Result, {string}): (Result, string) = nil,
-   process_string: function(string, boolean, Env, Result, {string}, string): (Result, string) = nil,
-   gen: function(string, Env): string = nil,
-   type_check: function(Node, TypeCheckOptions): ({Error}, {Error}, Type) = nil,
-   init_env: function(boolean, boolean): Env = nil,
-}
+local record tl
+   load: function(string, string, LoadMode, {any:any}): LoadFunction, string
+   process: function(string, Env, Result, {string}): (Result, string)
+   process_string: function(string, boolean, Env, Result, {string}, string): (Result, string)
+   gen: function(string): string
+   type_check: function(Node, TypeCheckOptions): ({Error}, {Error}, Type)
+   init_env: function(boolean, boolean): Env
+
+   record Env
+      globals: {string:Variable}
+      modules: {string:Type}
+      loaded: {string:Result}
+      skip_compat53: boolean
+   end
+
+   record Result
+      ast: Node
+      type: Type
+      syntax_errors: {ParseError}
+      type_errors: {Error}
+      unknowns: {Error}
+      env: Env
+   end
+
+   record Error
+      y: number
+      x: number
+      msg: string
+      filename: string
+   end
+end
+
+local Result = tl.Result
+local Env = tl.Env
+local Error = tl.Error
 
 --------------------------------------------------------------------------------
 -- Lexer
@@ -2620,11 +2640,11 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
 
    local function print_record_def(typ: Type): string
       local out: {string} = { "{" }
-      for name, field in pairs(typ.fields) do
-         if field.typename == "typetype" and is_record_type(field.def) then
+      for _, name in ipairs(typ.field_order) do
+         if typ.fields[name].typename == "typetype" and is_record_type(typ.fields[name].def) then
             table.insert(out, name)
             table.insert(out, " = ")
-            table.insert(out, print_record_def(field.def))
+            table.insert(out, print_record_def(typ.fields[name].def))
             table.insert(out, ", ")
          end
       end
@@ -3462,22 +3482,6 @@ show_type = function(t: Type, seen: {Type:boolean}): string
       ret = ret .. " (inferred at "..t.inferred_at_file..":"..t.inferred_at.y..":"..t.inferred_at.x..": )"
    end
    return ret
-end
-
-local record Error
-   y: number
-   x: number
-   msg: string
-   filename: string
-end
-
-local record Result
-   ast: Node
-   type: Type
-   syntax_errors: {ParseError}
-   type_errors: {Error}
-   unknowns: {Error}
-   env: Env
 end
 
 local function search_for(module_name: string, suffix: string, path: string, tried: {string}): string, FILE, {string}
@@ -6852,4 +6856,3 @@ tl.load = function(input: string, chunkname: string, mode: LoadMode, env: {any:a
 end
 
 return tl
-

--- a/tl.tl
+++ b/tl.tl
@@ -17,7 +17,7 @@ local record tl
    load: function(string, string, LoadMode, {any:any}): LoadFunction, string
    process: function(string, Env, Result, {string}): (Result, string)
    process_string: function(string, boolean, Env, Result, {string}, string): (Result, string)
-   gen: function(string): string
+   gen: function(string, Env): string
    type_check: function(Node, TypeCheckOptions): ({Error}, {Error}, Type)
    init_env: function(boolean, boolean): Env
 


### PR DESCRIPTION

This is just directly exposing the types as they are, but it definitely helps with cli drivers and things that want to work with the compiler programmatically in Teal itself.

Additionally at line 48 with
```
local Result = tl.Result
local Env = tl.Env
local Error = tl.Error
```

Causes a bunch of `Type is not Type` errors when done like
```
local type Result = tl.Result
local type Env = tl.Env
local type Error = tl.Error
```
Which could be the same cause as #198, but might be different?

Also the makefile failed at the `diff` step, since record fields don't get generated in order, hence the change at line 2643