### PR TITLE
Chore: make run_mock_project and tmp_dir no longer require a dir_name

### DIFF
--- a/spec/api/process_spec.lua
+++ b/spec/api/process_spec.lua
@@ -24,7 +24,7 @@ describe("tl.process", function()
       it("should cache modules by filename to prevent code being loaded more than once (#245)", function()
 
          local current_dir = lfs.currentdir()
-         local dir_name = util.write_tmp_dir(finally, "module_cache", {
+         local dir_name = util.write_tmp_dir(finally, {
             ["foo.tl"] = [[ require("bar") ]],
             ["bar.tl"] = [[ global x = 10 ]],
          })

--- a/spec/cli/build_dir_spec.lua
+++ b/spec/cli/build_dir_spec.lua
@@ -3,7 +3,6 @@ local util = require("spec.util")
 describe("-b --build-dir argument", function()
    it("generates files in the given directory", function()
       util.run_mock_project(finally, {
-         dir_name = "build_dir_test",
          dir_structure = {
             ["tlconfig.lua"] = [[return {
                build_dir = "build",
@@ -25,7 +24,6 @@ describe("-b --build-dir argument", function()
    end)
    it("replicates the directory structure of the source", function()
       util.run_mock_project(finally, {
-         dir_name = "build_dir_nested_test",
          dir_structure = {
             ["tlconfig.lua"] = [[return {
                build_dir = "build",
@@ -57,7 +55,6 @@ describe("-b --build-dir argument", function()
    end)
    it("dies when no config is found", function()
       util.run_mock_project(finally, {
-         dir_name = "build_dir_die_test",
          dir_structure = {},
          cmd = "build",
          generated_files = {},

--- a/spec/cli/output_spec.lua
+++ b/spec/cli/output_spec.lua
@@ -1,86 +1,80 @@
-local lfs = require("lfs")
 local util = require("spec.util")
 
--- local path_separator = "/"
--- local function tl_name_to_relative_lua(file_name)
---    local tail = file_name:match("[^%" .. path_separator .. "]+$")
---    local name, ext = tail:match("(.+)%.([a-zA-Z]+)$")
---    if not name then name = tail end
---    return name .. ".lua"
--- end
-local curr_dir = lfs.currentdir()
-local tlcmd = "LUA_PATH+=" .. curr_dir .. "/?.tl"
-
 describe("-o --output", function()
-   setup(function()
-      os.execute("LUA_PATH+=" .. curr_dir .. "/?.lua")
-      util.chdir_setup()
-   end)
-   teardown(util.chdir_teardown)
    it("should gen in the current directory when not provided", function()
-      util.write_tmp_dir(finally, "gen_curr_dir_test", {
-         bar = {
-            ["foo.tl"] = [[print 'hey']]
-         }
+      util.run_mock_project(finally, {
+         dir_structure = {
+            bar = {
+               ["foo.tl"] = [[print 'hey']],
+            },
+         },
+         generated_files = { "foo.lua" },
+         cmd = "gen",
+         args = "bar/foo.tl",
+         popen = {
+            status = true,
+            exit = "exit",
+            code = 0,
+         },
       })
-      assert(lfs.chdir("/tmp/gen_curr_dir_test"))
-      local pd = io.popen(curr_dir .. "/tl gen bar/foo.tl", "r")
-      local output = pd:read("*a")
-      lfs.chdir(curr_dir)
-      util.assert_popen_close(true, "exit", 0, pd:close())
-      assert.match("Wrote: foo.lua", output, 1, true)
    end)
    it("should work with nested directories", function()
-      local dir_name = "gen_curr_dir_nested_test"
-      util.write_tmp_dir(finally, dir_name, {
-         a={b={c={["foo.tl"] = [[print 'hey']]}}}
+      util.run_mock_project(finally, {
+         dir_structure = {a={b={c={["foo.tl"] = [[print 'hey']]}}}},
+         generated_files = { "foo.lua" },
+         cmd = "gen",
+         args = "a/b/c/foo.tl",
+         popen = {
+            status = true,
+            exit = "exit",
+            code = 0,
+         },
       })
-      assert(lfs.chdir("/tmp/gen_curr_dir_nested_test"))
-      local pd = io.popen(curr_dir .. "/tl gen a/b/c/foo.tl", "r")
-      local output = pd:read("*a")
-      lfs.chdir(curr_dir)
-      util.assert_popen_close(true, "exit", 0, pd:close())
-      assert.match("Wrote: foo.lua", output, 1, true)
    end)
    it("should write to the given filename", function()
-      local name = "foo.tl"
-      local outfile = "bar.lua"
-      util.write_tmp_dir(finally, "output_name_test", {
-         [name] = [[print 'hey']],
+      util.run_mock_project(finally, {
+         args = "foo.tl -o my_output_file.lua",
+         dir_structure = { ["foo.tl"] = [[print 'hey']] },
+         generated_files = { "my_output_file.lua" },
+         cmd = "gen",
+         popen = {
+            status = true,
+            exit = "exit",
+            code = 0,
+         },
       })
-      assert(lfs.chdir("/tmp/output_name_test"))
-      local pd = io.popen(curr_dir .. "/tl gen " .. name .. " -o " .. outfile, "r")
-      local output = pd:read("*a")
-      util.assert_popen_close(true, "exit", 0, pd:close())
-      assert.match("Wrote: " .. outfile, output, 1, true)
    end)
    it("should write to the given filename in a directory", function()
-      local name = "foo.tl"
-      local outfile = "a/b/c/d.lua"
-      local dir_name = "nested_dir_output_test"
-      util.write_tmp_dir(finally, dir_name, {
-         [name] = [[print 'foo']],
-         a={b={c={}}},
+      util.run_mock_project(finally, {
+         args = "foo.tl -o a/b/c/d.lua",
+         dir_structure = {
+            ["foo.tl"] = [[print 'hey']],
+            a={b={c={}}},
+         },
+         generated_files = {
+            a={b={c={"d.lua"}}},
+         },
+         cmd = "gen",
+         popen = {
+            status = true,
+            exit = "exit",
+            code = 0,
+         },
       })
-      assert(lfs.chdir("/tmp/" .. dir_name))
-      local pd = io.popen(curr_dir .. "/tl gen " .. name .. " -o " .. outfile, "r")
-      local output = pd:read("*a")
-      lfs.chdir(curr_dir)
-      util.assert_popen_close(true, "exit", 0, pd:close())
-      assert.match("Wrote: " .. outfile, output, 1, true)
    end)
    it("should gracefully error when the output directory doesn't exist", function()
-      local name = "foo.tl"
-      local outfile = "a/b/c/d.lua"
-      local dir_name = "nested_dir_output_fail_test"
-      util.write_tmp_dir(finally, dir_name, {
-         [name] = [[print 'foo']],
+      util.run_mock_project(finally, {
+         args = "foo.tl -o a/b/c/d.lua",
+         dir_structure = {
+            ["foo.tl"] = [[print 'hey']],
+         },
+         generated_files = {},
+         cmd = "gen",
+         popen = {
+            status = nil,
+            exit = "exit",
+            code = 1,
+         },
       })
-      assert(lfs.chdir("/tmp/" .. dir_name))
-      local pd = io.popen(curr_dir .. "/tl gen " .. name .. " -o " .. outfile .. " 2>&1", "r")
-      local output = pd:read("*a")
-      lfs.chdir(curr_dir)
-      util.assert_popen_close(nil, "exit", 1, pd:close())
-      assert.match("cannot write " .. outfile .. ": " .. outfile .. ": No such file or directory", output, 1, true)
    end)
 end)

--- a/spec/cli/source_dir_spec.lua
+++ b/spec/cli/source_dir_spec.lua
@@ -3,7 +3,6 @@ local util = require("spec.util")
 describe("-s --source-dir argument", function()
    it("recursively traverses the directory by default", function()
       util.run_mock_project(finally, {
-         dir_name = "source_dir_traversal_test",
          dir_structure = {
             ["tlconfig.lua"] = [[return { source_dir = "src" }]],
             ["src"] = {
@@ -34,7 +33,6 @@ describe("-s --source-dir argument", function()
    end)
    it("should die when the given directory doesn't exist", function()
       util.run_mock_project(finally, {
-         dir_name = "no_source_dir_test",
          dir_structure = {
             ["tlconfig.lua"] = [[return {source_dir="src"}]],
             ["foo.tl"] = [[print 'hi']],
@@ -46,7 +44,6 @@ describe("-s --source-dir argument", function()
    end)
    it("should not include files from other directories", function()
       util.run_mock_project(finally, {
-         dir_name = "source_dir_exc",
          dir_structure = {
             ["tlconfig.lua"] = [[return {
                source_dir = "foo",
@@ -68,7 +65,6 @@ describe("-s --source-dir argument", function()
    end)
    it("should correctly match directory names", function()
       util.run_mock_project(finally, {
-         dir_name = "source_dir_exc",
          dir_structure = {
             ["tlconfig.lua"] = [[return {
                source_dir = "foo",

--- a/spec/config/files_spec.lua
+++ b/spec/config/files_spec.lua
@@ -3,7 +3,6 @@ local util = require("spec.util")
 describe("files config option", function()
    it("should compile the given list of files", function()
       util.run_mock_project(finally, {
-         dir_name = "files_test",
          dir_structure = {
             ["tlconfig.lua"] = [[return { files = { "foo.tl", "bar.tl" } }]],
             ["foo.tl"] = [[print "a"]],

--- a/spec/config/glob_spec.lua
+++ b/spec/config/glob_spec.lua
@@ -4,7 +4,6 @@ describe("globs", function()
    describe("*", function()
       it("should match non directory separators", function()
          util.run_mock_project(finally, {
-            dir_name = "non_dir_sep_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return { include = {"*"} }]],
                ["a.tl"] = [[print "a"]],
@@ -22,7 +21,6 @@ describe("globs", function()
       end)
       it("should match when other characters are present in the pattern", function()
          util.run_mock_project(finally, {
-            dir_name = "other_chars_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return { include = { "ab*cd.tl" } }]],
                ["abzcd.tl"] = [[print "a"]],
@@ -44,7 +42,6 @@ describe("globs", function()
       end)
       it("should only match .tl by default", function()
          util.run_mock_project(finally, {
-            dir_name = "match_only_teal_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return { include = { "*" } }]],
                ["foo.tl"] = [[print "a"]],
@@ -60,7 +57,6 @@ describe("globs", function()
       end)
       it("should not match .d.tl files", function()
          util.run_mock_project(finally, {
-            dir_name = "dont_match_d_tl",
             dir_structure = {
                ["tlconfig.lua"] = [[return { include = { "*" } }]],
                ["foo.tl"] = [[print "a"]],
@@ -74,7 +70,6 @@ describe("globs", function()
       end)
       it("should match directories in the middle of a path", function()
          util.run_mock_project(finally, {
-            dir_name = "match_dirs_in_middle_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return { include = { "foo/*/baz.tl" } }]],
                ["foo"] = {
@@ -108,7 +103,6 @@ describe("globs", function()
    describe("**/", function()
       it("should match the current directory", function()
          util.run_mock_project(finally, {
-            dir_name = "match_current_dir_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return { include = { "**/*" } }]],
                ["foo.tl"] = [[print "a"]],
@@ -125,7 +119,6 @@ describe("globs", function()
       end)
       it("should match any subdirectory", function()
          util.run_mock_project(finally, {
-            dir_name = "match_sub_dir_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return { include = { "**/*" } }]],
                ["foo"] = {
@@ -162,7 +155,6 @@ describe("globs", function()
       end)
       it("should not get the order of directories confused", function()
          util.run_mock_project(finally, {
-            dir_name = "match_order_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return { include = { "foo/**/bar/**/baz/a.tl" } }]],
                ["foo"] = {
@@ -203,7 +195,6 @@ describe("globs", function()
    describe("* and **/", function()
       it("should work together", function()
          util.run_mock_project(finally, {
-            dir_name = "glob_interference_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return { include = { "**/foo/*/bar/**/*" } }]],
                ["foo"] = {

--- a/spec/config/interactions_spec.lua
+++ b/spec/config/interactions_spec.lua
@@ -4,7 +4,6 @@ describe("config option interactions", function()
    describe("include+exclude", function()
       it("exclude should have precedence over include", function()
          util.run_mock_project(finally, {
-            dir_name = "interaction_inc_exc_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return {
                   include = {
@@ -39,7 +38,6 @@ describe("config option interactions", function()
    describe("source_dir+build_dir", function()
       it("Having source_dir inside of build_dir works", function()
          util.run_mock_project(finally, {
-            dir_name = "source_dir_in_build_dir_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return {
                   source_dir = "foo/bar",
@@ -63,7 +61,6 @@ describe("config option interactions", function()
       end)
       it("Having build_dir inside of source_dir works", function()
          util.run_mock_project(finally, {
-            dir_name = "build_dir_in_source_dir_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return {
                   source_dir = "foo",
@@ -89,7 +86,6 @@ describe("config option interactions", function()
    describe("source_dir+include+exclude", function()
       it("nothing outside of source_dir is included", function()
          util.run_mock_project(finally, {
-            dir_name = "source_dir_inc_exc_test",
             dir_structure = {
                ["tlconfig.lua"] = [[return {
                   source_dir = "src",
@@ -127,7 +123,6 @@ describe("config option interactions", function()
       end)
       it("include and exclude work as expected", function()
          util.run_mock_project(finally, {
-            dir_name = "source_dir_inc_exc_2",
             dir_structure = {
                ["tlconfig.lua"] = [[return {
                   source_dir = ".",

--- a/spec/config/type_check_spec.lua
+++ b/spec/config/type_check_spec.lua
@@ -3,7 +3,6 @@ local util = require("spec.util")
 describe("config type checking", function()
    it("should error out when config.include is not a {string}", function()
       util.run_mock_project(finally, {
-         dir_name = "config_type_check",
          dir_structure = {
             ["tlconfig.lua"] = [[return { include = "*.tl" }]],
             ["foo.tl"] = [[print "a"]],
@@ -20,7 +19,6 @@ describe("config type checking", function()
    end)
    it("should error out when config.source_dir is not a string", function()
       util.run_mock_project(finally, {
-         dir_name = "config_type_check2",
          dir_structure = {
             ["tlconfig.lua"] = [[return { source_dir = true }]],
             ["foo.tl"] = [[print "a"]],

--- a/spec/error_reporting/module_error_spec.lua
+++ b/spec/error_reporting/module_error_spec.lua
@@ -14,7 +14,6 @@ describe("Uncaught compiler errors", function()
    end)
    it("should be reported when loading modules", function()
       util.run_mock_project(finally, {
-         dir_name = "uncaught_compiler_error_test",
          dir_structure = {
             ["my_module.tl"] = [[todo, write module :)]],
             ["my_script.tl"] = [[local mod = require("my_module"); mod.do_things()]],


### PR DESCRIPTION
Just to make test writing a bit easier for things like `build`.

They're not super useful except when temporarily replacing a `finally`
with a stub to see what went wrong, and a specific filename isn't
necessary for that and just makes writing the tests more annoying.