### PR TITLE
Remove/fix shadow variable declarations

### DIFF
--- a/tl
+++ b/tl
@@ -107,7 +107,7 @@ local function get_config()
       config[k] = v
    end
 
-   local err = validate_config(config)
+   err = validate_config(config)
 
    if err then
       die("Error while loading config: " .. err)
@@ -363,7 +363,7 @@ local function type_check_and_load(filename, modules)
       end
    end
 
-   local chunk, err = (loadstring or load)(tl.pretty_print_ast(result.ast), "@" .. filename)
+   local chunk; chunk, err = (loadstring or load)(tl.pretty_print_ast(result.ast), "@" .. filename)
    if err then
       die("Internal Compiler Error: Teal generator produced invalid Lua. Please report a bug at https://github.com/teal-language/tl")
    end
@@ -395,12 +395,12 @@ if cmd == "run" then
    end
 
    -- shift back all non-arguments to negative positions
-   for p, a in ipairs(neg_arg) do
-      arg[-p] = a
+   for p2, a in ipairs(neg_arg) do
+      arg[-p2] = a
    end
    -- put script in arg[0] and arguments in positive positions
-   for p, a in ipairs(args["script"]) do
-      arg[p - 1] = a
+   for p2, a in ipairs(args["script"]) do
+      arg[p2 - 1] = a
    end
    -- cleanup the rest
    n = nargs
@@ -436,7 +436,7 @@ local function write_out(result, output_file)
          die("cannot write " .. output_file .. ": " .. err)
       end
 
-      local ok, err = ofd:write(tl.pretty_print_ast(result.ast) .. "\n")
+      local ok; ok, err = ofd:write(tl.pretty_print_ast(result.ast) .. "\n")
       if err then
          die("error writing " .. output_file .. ": " .. err)
       end
@@ -585,7 +585,7 @@ local function traverse(dirname, emptyref)
    local paths = {} --lookup table for string paths to help
    -- with pattern matching while iterating over a project
    -- paths[files.foo.bar] -> "foo/bar"
-   local emptyref = emptyref or {}
+   emptyref = emptyref or {}
    for file in lfs.dir(dirname) do
       if file ~= "." and file ~= ".." then
          if lfs.attributes(path_concat(dirname, file), "mode") == "directory" then

--- a/tl.lua
+++ b/tl.lua
@@ -4103,7 +4103,7 @@ local function init_globals(lax)
    return globals
 end
 
-function tl.init_env(lax, skip_compat53)
+tl.init_env = function(lax, skip_compat53)
    local env = {
       modules = {},
       loaded = {},
@@ -4121,7 +4121,7 @@ function tl.init_env(lax, skip_compat53)
    return env
 end
 
-function tl.type_check(ast, opts)
+tl.type_check = function(ast, opts)
    opts = opts or {}
    opts.env = opts.env or tl.init_env(opts.lax, opts.skip_compat53)
    local lax = opts.lax
@@ -6698,7 +6698,7 @@ function tl.type_check(ast, opts)
    return errors, unknowns, module_type
 end
 
-function tl.process(filename, env, result, preload_modules)
+tl.process = function(filename, env, result, preload_modules)
    if env and env.loaded and env.loaded[filename] then
       return env.loaded[filename]
    end
@@ -6792,7 +6792,7 @@ filename)
    return result
 end
 
-function tl.gen(input, env)
+tl.gen = function(input, env)
    env = env or tl.init_env()
    local result, err = tl.process_string(input, false, env)
 
@@ -6840,7 +6840,7 @@ function tl.loader()
    end
 end
 
-function tl.load(input, chunkname, mode, env)
+tl.load = function(input, chunkname, mode, env)
    local tokens = tl.lex(input)
    local errs = {}
    local i, program = tl.parse_program(tokens, errs, chunkname)

--- a/tl.lua
+++ b/tl.lua
@@ -1024,8 +1024,8 @@ local function parse_table_value(ps, i)
    if is_newtype[ps.tokens[i].tk] then
       return parse_newtype(ps, i)
    else
-      local i, node, _ = parse_expression(ps, i)
-      return i, node
+      local i2, node, _ = parse_expression(ps, i)
+      return i2, node
    end
 end
 
@@ -1530,7 +1530,7 @@ do
       return i, e1
    end
 
-   local function E(ps, i, lhs, min_precedence)
+   E = function(ps, i, lhs, min_precedence)
       local lookahead = ps.tokens[i].tk
       while precedences[2][lookahead] and precedences[2][lookahead] >= min_precedence do
          local t1 = ps.tokens[i]
@@ -1603,7 +1603,7 @@ end
 
 parse_argument_list = function(ps, i)
    local node = new_node(ps.tokens, i, "argument_list")
-   local i, node = parse_bracket_list(ps, i, node, "(", ")", "sep", parse_argument)
+   i, node = parse_bracket_list(ps, i, node, "(", ")", "sep", parse_argument)
    for a, arg in ipairs(node) do
       if arg.tk == "..." and a ~= #node then
          return fail(ps, i, "'...' can only be last argument")
@@ -1625,7 +1625,7 @@ local function parse_argument_type(ps, i)
       end
    end
 
-   local i, typ = parse_type(ps, i)
+   local typ; i, typ = parse_type(ps, i)
    if typ then
       typ.is_va = is_va
    end
@@ -1667,10 +1667,10 @@ local function parse_function(ps, i)
       fn.kind = "record_function"
       local owner = names[1]
       owner.kind = "variable"
-      for i = 2, #names - 1 do
-         local dot = { y = names[i].y, x = names[i].x - 1, arity = 2, op = "." }
-         names[i].kind = "identifier"
-         local op = { y = names[i].y, x = names[i].x, kind = "op", op = dot, e1 = owner, e2 = names[i] }
+      for i2 = 2, #names - 1 do
+         local dot = { y = names[i2].y, x = names[i2].x - 1, arity = 2, op = "." }
+         names[i2].kind = "identifier"
+         local op = { y = names[i2].y, x = names[i2].x, kind = "op", op = dot, e1 = owner, e2 = names[i2] }
          owner = op
       end
       fn.fn_owner = owner
@@ -2103,7 +2103,7 @@ local function parse_type_declaration(ps, i, node_name)
    return i, asgn
 end
 
-local ParseBody = {}
+
 
 local function parse_type_constructor(ps, i, node_name, type_name, parse_body)
    local asgn = new_node(ps.tokens, i, node_name)
@@ -3339,7 +3339,7 @@ local binop_types = {
    },
 }
 
-local show_type
+
 
 local function is_unknown(t)
    return t.typename == "unknown" or
@@ -3496,19 +3496,20 @@ end
 
 function tl.search_module(module_name, search_dtl)
    local found
+   local fd
    local tried = {}
    local path = os.getenv("TL_PATH") or package.path
    if search_dtl then
-      local found, fd, tried = search_for(module_name, ".d.tl", path, tried)
+      found, fd, tried = search_for(module_name, ".d.tl", path, tried)
       if found then
          return found, fd
       end
    end
-   local found, fd, tried = search_for(module_name, ".tl", path, tried)
+   found, fd, tried = search_for(module_name, ".tl", path, tried)
    if found then
       return found, fd
    end
-   local found, fd, tried = search_for(module_name, ".lua", path, tried)
+   found, fd, tried = search_for(module_name, ".lua", path, tried)
    if found then
       return found, fd
    end
@@ -6552,18 +6553,18 @@ function tl.type_check(ast, opts)
          ["record"] = {
             before = function(typ, children)
                begin_scope()
-               for name, typ in pairs(typ.fields) do
-                  if typ.typename == "typetype" then
-                     typ.typename = "nestedtype"
-                     add_var(nil, name, typ)
+               for name, typ2 in pairs(typ.fields) do
+                  if typ2.typename == "typetype" then
+                     typ2.typename = "nestedtype"
+                     add_var(nil, name, typ2)
                   end
                end
             end,
             after = function(typ, children)
                end_scope()
-               for name, typ in pairs(typ.fields) do
-                  if typ.typename == "nestedtype" then
-                     typ.typename = "typetype"
+               for name, typ2 in pairs(typ.fields) do
+                  if typ2.typename == "nestedtype" then
+                     typ2.typename = "typetype"
                   end
                end
                return typ
@@ -6706,7 +6707,7 @@ function tl.process(filename, env, result, preload_modules)
       return nil, "could not open " .. filename .. ": " .. err
    end
 
-   local input, err = fd:read("*a")
+   local input; input, err = fd:read("*a")
    fd:close()
    if not input then
       return nil, "could not read " .. filename .. ": " .. err

--- a/tl.tl
+++ b/tl.tl
@@ -24,7 +24,7 @@ local tl = {
    load: function(string, string, LoadMode, {any:any}): LoadFunction, string = nil,
    process: function(string, Env, Result, {string}): (Result, string) = nil,
    process_string: function(string, boolean, Env, Result, {string}, string): (Result, string) = nil,
-   gen: function(string): string = nil,
+   gen: function(string, Env): string = nil,
    type_check: function(Node, TypeCheckOptions): ({Error}, {Error}, Type) = nil,
    init_env: function(boolean, boolean): Env = nil,
 }
@@ -4103,7 +4103,7 @@ local function init_globals(lax: boolean): {string:Variable}
    return globals
 end
 
-function tl.init_env(lax: boolean, skip_compat53: boolean): Env
+tl.init_env = function(lax: boolean, skip_compat53: boolean): Env
    local env = {
       modules = {},
       loaded = {},
@@ -4121,7 +4121,7 @@ function tl.init_env(lax: boolean, skip_compat53: boolean): Env
    return env
 end
 
-function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Type
+tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Type
    opts = opts or {}
    opts.env = opts.env or tl.init_env(opts.lax, opts.skip_compat53)
    local lax = opts.lax
@@ -6698,7 +6698,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
    return errors, unknowns, module_type
 end
 
-function tl.process(filename: string, env: Env, result: Result, preload_modules: {string}): Result, string
+tl.process = function(filename: string, env: Env, result: Result, preload_modules: {string}): Result, string
    if env and env.loaded and env.loaded[filename] then
       return env.loaded[filename]
    end
@@ -6792,7 +6792,7 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
    return result
 end
 
-function tl.gen(input: string, env: Env): string, Result
+tl.gen = function(input: string, env: Env): string, Result
    env = env or tl.init_env()
    local result, err = tl.process_string(input, false, env)
 
@@ -6840,7 +6840,7 @@ function tl.loader()
    end
 end
 
-function tl.load(input: string, chunkname: string, mode: LoadMode, env: {any:any}): LoadFunction, string
+tl.load = function(input: string, chunkname: string, mode: LoadMode, env: {any:any}): LoadFunction, string
    local tokens = tl.lex(input)
    local errs: {ParseError} = {}
    local i, program = tl.parse_program(tokens, errs, chunkname)

--- a/tl.tl
+++ b/tl.tl
@@ -1024,8 +1024,8 @@ local function parse_table_value(ps: ParseState, i: number): number, Node
    if is_newtype[ps.tokens[i].tk] then
       return parse_newtype(ps, i)
    else
-      local i, node, _ = parse_expression(ps, i)
-      return i, node
+      local i2, node, _ = parse_expression(ps, i)
+      return i2, node
    end
 end
 
@@ -1451,7 +1451,7 @@ do
       return { y = tk.y, x = tk.x, arity = arity, op = op, prec = precedences[arity][op] }
    end
 
-   local E: function(ParseState, number): number, Node
+   local E: function(ParseState, number, Node, number): number, Node
 
    local function P(ps: ParseState, i: number): number, Node
       if ps.tokens[i].kind == "$EOF$" then
@@ -1530,7 +1530,7 @@ do
       return i, e1
    end
 
-   local function E(ps: ParseState, i: number, lhs: Node, min_precedence: number): number, Node
+   E = function(ps: ParseState, i: number, lhs: Node, min_precedence: number): number, Node
       local lookahead = ps.tokens[i].tk
       while precedences[2][lookahead] and precedences[2][lookahead] >= min_precedence do
          local t1 = ps.tokens[i]
@@ -1603,7 +1603,7 @@ end
 
 parse_argument_list = function(ps: ParseState, i: number): number, Node
    local node = new_node(ps.tokens, i, "argument_list")
-   local i, node = parse_bracket_list(ps, i, node, "(", ")", "sep", parse_argument)
+   i, node = parse_bracket_list(ps, i, node, "(", ")", "sep", parse_argument)
    for a, arg in ipairs(node) do
       if arg.tk == "..." and a ~= #node then
          return fail(ps, i, "'...' can only be last argument")
@@ -1625,7 +1625,7 @@ local function parse_argument_type(ps: ParseState, i: number): number, Type, num
       end
    end
 
-   local i, typ = parse_type(ps, i)
+   local typ: Type; i, typ = parse_type(ps, i)
    if typ then
       typ.is_va = is_va
    end
@@ -1667,10 +1667,10 @@ local function parse_function(ps: ParseState, i: number): number, Node
       fn.kind = "record_function"
       local owner = names[1]
       owner.kind = "variable"
-      for i = 2, #names - 1 do
-         local dot = { y = names[i].y, x = names[i].x - 1, arity = 2, op = "." }
-         names[i].kind = "identifier"
-         local op = { y = names[i].y, x = names[i].x, kind = "op", op = dot, e1 = owner, e2 = names[i] }
+      for i2 = 2, #names - 1 do
+         local dot = { y = names[i2].y, x = names[i2].x - 1, arity = 2, op = "." }
+         names[i2].kind = "identifier"
+         local op = { y = names[i2].y, x = names[i2].x, kind = "op", op = dot, e1 = owner, e2 = names[i2] }
          owner = op
       end
       fn.fn_owner = owner
@@ -2103,7 +2103,7 @@ local function parse_type_declaration(ps: ParseState, i: number, node_name: Node
    return i, asgn
 end
 
-local type ParseBody = function(ps: ParseState, i: number, def: Type, node: Node): number, Node
+--local type ParseBody = function(ps: ParseState, i: number, def: Type, node: Node): number, Node
 
 local function parse_type_constructor(ps: ParseState, i: number, node_name: NodeKind, type_name: TypeName, parse_body: ParseBody): number, Node
    local asgn: Node = new_node(ps.tokens, i, node_name)
@@ -3339,7 +3339,7 @@ local binop_types: {string:{TypeName:{TypeName:Type}}} = {
    },
 }
 
-local show_type: function(Type): string
+--local show_type: function(Type): string
 
 local function is_unknown(t: Type): boolean
    return t.typename == "unknown"
@@ -3496,19 +3496,20 @@ end
 
 function tl.search_module(module_name: string, search_dtl: boolean): string, FILE, {string}
    local found: string
+   local fd: FILE
    local tried: {string} = {}
    local path = os.getenv("TL_PATH") or package.path
    if search_dtl then
-      local found, fd, tried = search_for(module_name, ".d.tl", path, tried)
+      found, fd, tried = search_for(module_name, ".d.tl", path, tried)
       if found then
          return found, fd
       end
    end
-   local found, fd, tried = search_for(module_name, ".tl", path, tried)
+   found, fd, tried = search_for(module_name, ".tl", path, tried)
    if found then
       return found, fd
    end
-   local found, fd, tried = search_for(module_name, ".lua", path, tried)
+   found, fd, tried = search_for(module_name, ".lua", path, tried)
    if found then
       return found, fd
    end
@@ -6552,18 +6553,18 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          ["record"] = {
             before = function(typ: Type, children: {Type})
                begin_scope()
-               for name, typ in pairs(typ.fields) do
-                  if typ.typename == "typetype" then
-                     typ.typename = "nestedtype"
-                     add_var(nil, name, typ)
+               for name, typ2 in pairs(typ.fields) do
+                  if typ2.typename == "typetype" then
+                     typ2.typename = "nestedtype"
+                     add_var(nil, name, typ2)
                   end
                end
             end,
             after = function(typ: Type, children: {Type}): Type
                end_scope()
-               for name, typ in pairs(typ.fields) do
-                  if typ.typename == "nestedtype" then
-                     typ.typename = "typetype"
+               for name, typ2 in pairs(typ.fields) do
+                  if typ2.typename == "nestedtype" then
+                     typ2.typename = "typetype"
                   end
                end
                return typ
@@ -6706,7 +6707,7 @@ function tl.process(filename: string, env: Env, result: Result, preload_modules:
       return nil, "could not open " .. filename .. ": " .. err
    end
 
-   local input, err = fd:read("*a")
+   local input: string; input, err = fd:read("*a")
    fd:close()
    if not input then
       return nil, "could not read " .. filename .. ": " .. err


### PR DESCRIPTION
While trying to convert this project to LJS (https://github.com/mingodad/ljs) I was getting several errors related to redeclaration of variables (shadow variables) because in LJS it's an error to redeclare a variable in the same scope and a warning when shadowing a variable in outer scope.

And fixing this problem I found two interesting problems/bugs due to variable/type redeclaration:
```
local E: function(ParseState, number, Node): number, Node
...
local function E(ps, i, lhs, min_precedence)
```
```
local show_type: function(Type): string
...
local show_type: function(Type, {Type:boolean}): string
```
**I think that's a good idea to flag variable redecalration as an error !**
