### PR TITLE
improve "X is not a X" messages

### DIFF
--- a/spec/stdlib/require_spec.lua
+++ b/spec/stdlib/require_spec.lua
@@ -321,8 +321,7 @@ describe("require", function()
 
       assert.same({}, result.syntax_errors)
       assert.same(1, #result.type_errors)
-      -- not ideal message, but technically correct...
-      assert.match("Point is not a Point", result.type_errors[1].msg, 1, true)
+      assert.match("Point (defined in foo.tl:3) is not a Point (defined in ./point.tl:1)", result.type_errors[1].msg, 1, true)
    end)
 
    it("catches errors in exported functions", function ()

--- a/tl.lua
+++ b/tl.lua
@@ -4487,7 +4487,19 @@ function tl.type_check(ast, opts)
             end
          end
       else
-         return false, terr(t1, "%s is not a %s", t1, t2)
+         local t1name = show_type(t1)
+         local t2name = show_type(t2)
+         if t1name == t2name then
+            local t1r = t1.resolved or t1
+            if t1r.filename then
+               t1name = t1name .. " (defined in " .. t1r.filename .. ":" .. t1r.y .. ")"
+            end
+            local t2r = t2.resolved or t2
+            if t2r.filename then
+               t2name = t2name .. " (defined in " .. t2r.filename .. ":" .. t2r.y .. ")"
+            end
+         end
+         return false, terr(t1, t1name .. " is not a " .. t2name)
       end
    end
 
@@ -5267,6 +5279,13 @@ function tl.type_check(ast, opts)
          resolved = a_type({ typename = "bad_nominal", names = t.names })
       end
 
+      if not t.filename then
+         t.filename = resolved.filename
+         if t.x == nil and t.y == nil then
+            t.x = resolved.x
+            t.y = resolved.x
+         end
+      end
       t.found = typetype
       t.resolved = resolved
       return resolved
@@ -6131,6 +6150,7 @@ function tl.type_check(ast, opts)
       ["table_literal"] = {
          after = function(node, children)
             node.type = a_type({
+               filename = filename,
                y = node.y,
                x = node.x,
                typename = "emptytable",

--- a/tl.tl
+++ b/tl.tl
@@ -4487,7 +4487,19 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
             end
          end
       else
-         return false, terr(t1, "%s is not a %s", t1, t2)
+         local t1name = show_type(t1)
+         local t2name = show_type(t2)
+         if t1name == t2name then
+            local t1r = t1.resolved or t1
+            if t1r.filename then
+               t1name = t1name .. " (defined in " .. t1r.filename .. ":" .. t1r.y .. ")"
+            end
+            local t2r = t2.resolved or t2
+            if t2r.filename then
+               t2name = t2name .. " (defined in " .. t2r.filename .. ":" .. t2r.y .. ")"
+            end
+         end
+         return false, terr(t1, t1name .. " is not a " .. t2name)
       end
    end
 
@@ -5267,6 +5279,13 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
          resolved = a_type { typename = "bad_nominal", names = t.names }
       end
 
+      if not t.filename then
+         t.filename = resolved.filename
+         if t.x == nil and t.y == nil then
+            t.x = resolved.x
+            t.y = resolved.x
+         end
+      end
       t.found = typetype
       t.resolved = resolved
       return resolved
@@ -6131,6 +6150,7 @@ function tl.type_check(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Typ
       ["table_literal"] = {
          after = function(node: Node, children: {Type}): Type
             node.type = a_type {
+               filename = filename,
                y = node.y,
                x = node.x,
                typename = "emptytable",


### PR DESCRIPTION
Sometimes different types will have the same name, and we don't have a canonical full-path name, because modules can be required under different names, so `modulename.Type` is not always a valid representation of type `Type` declared in module `modulename`.

This will show the filename and line number of the declared types when two mismatched types have identical names. See the test cases in this PR for details.

Closes #198.