### PR TITLE
fix: make tl.process always return a new Result

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -6766,10 +6766,10 @@ filename)
    if env.loaded and env.loaded[filename] then
       return env.loaded[filename]
    end
-   result = result or {
-      syntax_errors = {},
-      type_errors = {},
-      unknowns = {},
+   result = {
+      syntax_errors = result and result.syntax_errors or {},
+      type_errors = result and result.type_errors or {},
+      unknowns = result and result.unknowns or {},
    }
    preload_modules = preload_modules or {}
    filename = filename or ""

--- a/tl.tl
+++ b/tl.tl
@@ -6766,10 +6766,10 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
    if env.loaded and env.loaded[filename] then
       return env.loaded[filename]
    end
-   result = result or {
-      syntax_errors = {},
-      type_errors = {},
-      unknowns = {},
+   result = {
+      syntax_errors = result and result.syntax_errors or {},
+      type_errors = result and result.type_errors or {},
+      unknowns = result and result.unknowns or {},
    }
    preload_modules = preload_modules or {}
    filename = filename or ""


### PR DESCRIPTION
This makes `tl.process_string` and `tl.process` always return a new `Result` object.

If an existing `Result` is passed as input, the new `Result` shares the lists of errors with the old one (so that errors accumulate, as currently expected by the main `tl` driver and the tests), but the `type` and `ast` fields become unique per processed file.

Fixes #265.