### PR TITLE
Add tuple type

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -97,7 +97,7 @@ precedence, see below.
 *  type ::= ‘(’ type ‘)’ | basetype {‘|’ basetype}
 
 *  basetype ::= ‘string’ | ‘boolean’ | ‘nil’ | ‘number’ |
-*      ‘{’ type ‘}’ | ‘{’ type ‘:’ type ‘}’ | functiontype
+*      ‘{’ type {',' type} ‘}’ | ‘{’ type ‘:’ type ‘}’ | functiontype
 *      | Name {{‘.’ Name }} [typeargs]
 
 *  typelist ::= type {‘,’ type}

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -135,10 +135,13 @@ These are the types in Teal:
 * boolean
 * number
 * string
+* thread
 * userdata
 * function
+* array
 * record
 * arrayrecord
+* tuple
 * map
 * enum
 * any
@@ -249,6 +252,45 @@ local sum = 0
 for i = 1, #sizes do
    sum = sum + sizes[i] -- will crash at runtime!
 end
+```
+
+## Tuples
+
+Another common usage of tables in Lua are tuples. Tables of a known size, with the integer keys being known types.
+Commonly used when you want to use table literals, but not have to type in field names for conciseness
+```
+-- Tuples of name, age
+local p1 = { "Anna", 15 }
+local p2 = { "Bob", 37 }
+local p3 = { "Chris", 65 }
+```
+
+When indexing into tuples with number constants, their type is correctly inferred, and trying to go out of range will produce an error.
+```
+local age_of_p1: number = p1[2] -- no type errors here
+local nonsense = p1[3] -- error! index 3 out of range for tuple {1: string, 2: number}
+```
+
+And when indexing with a `number` variable, Teal will do it's best by making a [union](#union) of all the types in the tuple (following the restrictions on unions detailed below)
+```
+local my_number = math.random(1, 2)
+local var = p1[my_number] -- => var is a string | number union
+```
+
+Tuples will additionally help you keep track of accidentally adding more elements than they expect (as long as they're length is annotated and not inferred).
+```
+local p4: {string, number} = { "Delilah", 32, false } -- error! expected maximum length of 2, got 3
+```
+
+One thing to keep in mind when using tuples versus arrays is type inference, and when you should or shouldn't need it.
+A table will be inferred as an array if all of its elements are the same type, and as a tuple if any of its types aren't the same.
+So if you want an array of a union type instead of a tuple, explicitly annotate it as such:
+```
+local array_of_union: {string | number} = {1, 2, "hello", "hi"}
+```
+And if you want a tuple containing all the same type, annotate that as well:
+```
+local tuple_of_nums: {number, number} = {1, 2}
 ```
 
 ## Maps

--- a/spec/arguments/array_spec.lua
+++ b/spec/arguments/array_spec.lua
@@ -6,12 +6,12 @@ describe("array argument", function()
          print(arg)
       end
 
-      function main()
+      local function main()
          a({"a", 100})
          a(100)
       end
    ]], {
-      { y = 6, msg = 'argument 1: got {string | number}, expected {string}' },
+      { y = 6, msg = 'argument 1: got [1: string, 2: number], expected {string}' },
       { y = 7, msg = 'argument 1: got number, expected {string}' },
    }))
 

--- a/spec/arguments/array_spec.lua
+++ b/spec/arguments/array_spec.lua
@@ -11,7 +11,7 @@ describe("array argument", function()
          a(100)
       end
    ]], {
-      { y = 6, msg = 'argument 1: got [1: string, 2: number], expected {string}' },
+      { y = 6, msg = 'argument 1: got {1: string, 2: number}, expected {string}' },
       { y = 7, msg = 'argument 1: got number, expected {string}' },
    }))
 

--- a/spec/arguments/array_spec.lua
+++ b/spec/arguments/array_spec.lua
@@ -11,7 +11,7 @@ describe("array argument", function()
          a(100)
       end
    ]], {
-      { y = 6, msg = 'argument 1: got {1: string, 2: number}, expected {string}' },
+      { y = 6, msg = 'argument 1: got {string | number} (from {1: string, 2: number}), expected {string}' },
       { y = 7, msg = 'argument 1: got number, expected {string}' },
    }))
 

--- a/spec/assignment/to_array_spec.lua
+++ b/spec/assignment/to_array_spec.lua
@@ -8,7 +8,7 @@ describe("assignment to array", function()
       a = {"a", 100}
    ]], {
       { y = 2, msg = "got number, expected {string}" },
-      { y = 3, msg = "got {1: string, 2: number}, expected {string}" },
+      { y = 3, msg = "got {string | number} (from {1: string, 2: number}), expected {string}" },
    }))
 
    it("check expansion of expression inside array", util.check_type_error([[
@@ -18,7 +18,7 @@ describe("assignment to array", function()
       local a: {string}
       a = { f() }
    ]], {
-      { y = 5, msg = "in assignment: got {1: string, 2: number}, expected {string}" },
+      { y = 5, msg = "in assignment: got {string | number} (from {1: string, 2: number}), expected {string}" },
    }))
 
    it("accept expression", util.check [[

--- a/spec/assignment/to_array_spec.lua
+++ b/spec/assignment/to_array_spec.lua
@@ -8,7 +8,7 @@ describe("assignment to array", function()
       a = {"a", 100}
    ]], {
       { y = 2, msg = "got number, expected {string}" },
-      { y = 3, msg = "got [1: string, 2: number], expected {string}" },
+      { y = 3, msg = "got {1: string, 2: number}, expected {string}" },
    }))
 
    it("check expansion of expression inside array", util.check_type_error([[
@@ -18,7 +18,7 @@ describe("assignment to array", function()
       local a: {string}
       a = { f() }
    ]], {
-      { y = 5, msg = "in assignment: got [1: string, 2: number], expected {string}" },
+      { y = 5, msg = "in assignment: got {1: string, 2: number}, expected {string}" },
    }))
 
    it("accept expression", util.check [[

--- a/spec/assignment/to_array_spec.lua
+++ b/spec/assignment/to_array_spec.lua
@@ -8,7 +8,7 @@ describe("assignment to array", function()
       a = {"a", 100}
    ]], {
       { y = 2, msg = "got number, expected {string}" },
-      { y = 3, msg = "got {string | number}, expected {string}" },
+      { y = 3, msg = "got [1: string, 2: number], expected {string}" },
    }))
 
    it("check expansion of expression inside array", util.check_type_error([[
@@ -18,7 +18,7 @@ describe("assignment to array", function()
       local a: {string}
       a = { f() }
    ]], {
-      { y = 5, msg = "got {string | number}, expected {string}" },
+      { y = 5, msg = "in assignment: got [1: string, 2: number], expected {string}" },
    }))
 
    it("accept expression", util.check [[

--- a/spec/assignment/to_tuple_spec.lua
+++ b/spec/assignment/to_tuple_spec.lua
@@ -6,4 +6,10 @@ describe("assignment to tuple", function()
       local arr = {1, 2, 3, 4}
       t = arr
    ]])
+   it("should error when an array literal is too long", util.check_type_error([[
+      local t: {number, number}
+      t = {1, 2, 3}
+   ]], {
+      { msg = "incompatible length, expected maximum length of 2, got 3", y = 2 },
+   }))
 end)

--- a/spec/assignment/to_tuple_spec.lua
+++ b/spec/assignment/to_tuple_spec.lua
@@ -1,0 +1,9 @@
+local util = require("spec.util")
+
+describe("assignment to tuple", function()
+   it("should not care about an array's length when assigned indirectly", util.check [[
+      local t: {number, number}
+      local arr = {1, 2, 3, 4}
+      t = arr
+   ]])
+end)

--- a/spec/assignment/to_tuple_spec.lua
+++ b/spec/assignment/to_tuple_spec.lua
@@ -1,7 +1,7 @@
 local util = require("spec.util")
 
 describe("assignment to tuple", function()
-   it("should not care about an array's length when assigned indirectly", util.check [[
+   it("should not care about an array's inferred length when assigned indirectly", util.check [[
       local t: {number, number}
       local arr = {1, 2, 3, 4}
       t = arr

--- a/spec/declaration/array_spec.lua
+++ b/spec/declaration/array_spec.lua
@@ -31,7 +31,7 @@ describe("array declarations", function()
       print(x[RED])
    ]])
 
-   pending("indirect only works for numeric keys", util.check_type_error([[
+   it("indirect only works for numeric keys", util.check_type_error([[
       local RED = 1
       local BLUE = 2
       local GREEN: string = (function():string return "hello" end)()
@@ -54,7 +54,7 @@ describe("array declarations", function()
       print(x.GREEN)
    ]])
 
-   pending("indirect works with array-records", util.check [[
+   it("indirect works with array-records", util.check [[
       local RED = 1
       local BLUE = 2
       local x = {

--- a/spec/declaration/array_spec.lua
+++ b/spec/declaration/array_spec.lua
@@ -31,7 +31,7 @@ describe("array declarations", function()
       print(x[RED])
    ]])
 
-   it("indirect only works for numeric keys", util.check_type_error([[
+   pending("indirect only works for numeric keys", util.check_type_error([[
       local RED = 1
       local BLUE = 2
       local GREEN: string = (function():string return "hello" end)()
@@ -45,7 +45,16 @@ describe("array declarations", function()
       { msg = "cannot determine type of table literal" },
    }))
 
-   it("indirect works array-records", util.check [[
+   it("explicit number indeces works array-records", util.check [[
+      local x = {
+         [1] = 2,
+         [2] = 3,
+         GREEN = 4,
+      }
+      print(x.GREEN)
+   ]])
+
+   pending("indirect works array-records", util.check [[
       local RED = 1
       local BLUE = 2
       local x = {

--- a/spec/declaration/array_spec.lua
+++ b/spec/declaration/array_spec.lua
@@ -45,7 +45,7 @@ describe("array declarations", function()
       { msg = "cannot determine type of table literal" },
    }))
 
-   it("explicit number indeces works array-records", util.check [[
+   it("explicit number indices work with array-records", util.check [[
       local x = {
          [1] = 2,
          [2] = 3,
@@ -54,7 +54,7 @@ describe("array declarations", function()
       print(x.GREEN)
    ]])
 
-   pending("indirect works array-records", util.check [[
+   pending("indirect works with array-records", util.check [[
       local RED = 1
       local BLUE = 2
       local x = {

--- a/spec/declaration/tuple_spec.lua
+++ b/spec/declaration/tuple_spec.lua
@@ -28,12 +28,12 @@ describe("tuple declarations", function()
       { y = 1, msg = "in local declaration: c: tuple {1: number, 2: string, 3: number} is too big for tuple {1: number, 2: string}" },
    }))
 
-   it("should work with explicit integer indeces", util.check [[
+   it("should work with explicit integer indices", util.check [[
       local a: {number, string} = { [1] = 10, [2] = "hello" }
       local b: {number, string} = { [2] = "hello", [1] = 10 }
    ]])
 
-   it("should error with explicit integer indeces that are out of range", util.check_type_error([[
+   it("should error with explicit integer indices that are out of range", util.check_type_error([[
       local c: {number, string} = { [-1] = 10 }
    ]], {
       { msg = "in local declaration: c: got {number : number}, expected {1: number, 2: string}" },

--- a/spec/declaration/tuple_spec.lua
+++ b/spec/declaration/tuple_spec.lua
@@ -1,0 +1,12 @@
+local util = require("spec.util")
+
+describe("tuple declarations", function()
+   it("can be simple", util.check [[
+      local x = { 1, "hi" }
+   ]])
+
+   it("can be declared as a nominal type", util.check [[
+      local type Coords = [number, number]
+      local c: Coords = { 1, 2 }
+   ]])
+end)

--- a/spec/declaration/tuple_spec.lua
+++ b/spec/declaration/tuple_spec.lua
@@ -27,4 +27,15 @@ describe("tuple declarations", function()
    ]], {
       { y = 1, msg = "in local declaration: c: tuple {1: number, 2: string, 3: number} is too big for tuple {1: number, 2: string}" },
    }))
+
+   it("should work with explicit integer indeces", util.check [[
+      local a: {number, string} = { [1] = 10, [2] = "hello" }
+      local b: {number, string} = { [2] = "hello", [1] = 10 }
+   ]])
+
+   it("should error with explicit integer indeces that are out of range", util.check_type_error([[
+      local c: {number, string} = { [-1] = 10, [2] = "hello" }
+   ]], {
+
+   }))
 end)

--- a/spec/declaration/tuple_spec.lua
+++ b/spec/declaration/tuple_spec.lua
@@ -6,7 +6,25 @@ describe("tuple declarations", function()
    ]])
 
    it("can be declared as a nominal type", util.check [[
-      local type Coords = [number, number]
+      local type Coords = {number, number}
       local c: Coords = { 1, 2 }
    ]])
+
+   it("should report when an array literal is too long to fit within tuple type", util.check_type_error([[
+      local a: {number, number} = {1, 2, 3}
+   ]], {
+      { y = 1, msg = "in local declaration: a: incompatible length, expected maximum length of 2, got 3" }
+   }))
+
+   it("should report when a tuple has incompatible entries", util.check_type_error([[
+      local b: {number, string} = { 1, false }
+   ]], {
+      { y = 1, msg = "in local declaration: b: in tuple entry 2: got boolean, expected string" },
+   }))
+
+   it("should report when a tuple literal is longer than annotated type", util.check_type_error([[
+     local c: {number, string} = { 1, "hello", 10 }
+   ]], {
+      { y = 1, msg = "in local declaration: c: tuple {1: number, 2: string, 3: number} is too big for tuple {1: number, 2: string}" },
+   }))
 end)

--- a/spec/declaration/tuple_spec.lua
+++ b/spec/declaration/tuple_spec.lua
@@ -33,7 +33,7 @@ describe("tuple declarations", function()
       local b: {number, string} = { [2] = "hello", [1] = 10 }
    ]])
 
-   it("should error with explicit integer indices that are out of range", util.check_type_error([[
+   pending("should error with explicit integer indices that are out of range", util.check_type_error([[
       local c: {number, string} = { [-1] = 10 }
    ]], {
       { msg = "in local declaration: c: got {number : number}, expected {1: number, 2: string}" },

--- a/spec/declaration/tuple_spec.lua
+++ b/spec/declaration/tuple_spec.lua
@@ -34,8 +34,8 @@ describe("tuple declarations", function()
    ]])
 
    it("should error with explicit integer indeces that are out of range", util.check_type_error([[
-      local c: {number, string} = { [-1] = 10, [2] = "hello" }
+      local c: {number, string} = { [-1] = 10 }
    ]], {
-
+      { msg = "in local declaration: c: got {number : number}, expected {1: number, 2: string}" },
    }))
 end)

--- a/spec/inference/emptytable_spec.lua
+++ b/spec/inference/emptytable_spec.lua
@@ -8,7 +8,7 @@ describe("empty table without type annotation", function()
       local ret_value = {heyyyy()}
       table.unpack(ret_value)
    ]], {
-      { msg = "cannot determine type of array elements" },
+      { msg = "cannot determine type of tuple elements" },
    }))
 
    it("has its type determined by its first use", util.check_type_error([[

--- a/spec/operator/index_spec.lua
+++ b/spec/operator/index_spec.lua
@@ -109,4 +109,23 @@ describe("[]", function()
          s:upper()
       ]])
    end)
+   describe("on tuples", function()
+      it("results in the correct type for integer literals", util.check [[
+         local t: {string, number} = {"hi", 1}
+         local str: string = t[1]
+         local num: number = t[2]
+      ]])
+      it("produces a union when indexed with a number variable", util.check [[
+         local t: {string, number} = {"hi", 1}
+         local x: number = 1
+         local var: string | number = t[x]
+      ]])
+      it("errors when a union can't be produced from indexing", util.check_type_error([[
+         local t: {{string}, {number}} = {{"hey"}, {1}}
+         local x: number = 1
+         local var = t[x]
+      ]], {
+         { msg = "tuple cannot be indexed with a variable" },
+      }))
+   end)
 end)

--- a/spec/operator/index_spec.lua
+++ b/spec/operator/index_spec.lua
@@ -125,7 +125,7 @@ describe("[]", function()
          local x: number = 1
          local var = t[x]
       ]], {
-         { msg = "tuple cannot be indexed with a variable" },
+         { msg = "cannot index this tuple with a variable because it would produce a union type that cannot be discriminated at runtime" },
       }))
    end)
 end)

--- a/spec/stdlib/ipairs_spec.lua
+++ b/spec/stdlib/ipairs_spec.lua
@@ -1,0 +1,11 @@
+local util = require("spec.util")
+
+describe("ipairs", function()
+   it("should report when a tuple can't be converted to an array", util.check_type_error([[
+      for i, v in ipairs({{1}, {"a"}}) do
+      end
+   ]], {
+      { msg = [[attempting ipairs loop on tuple that's not a valid array: ({1: {number}, 2: {string "a"}})]] },
+      { msg = [[argument 1: unable to convert tuple {1: {number}, 2: {string "a"}} to array]] },
+   }))
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -6327,12 +6327,19 @@ tl.type_check = function(ast, opts)
                x = node.x,
                typename = "emptytable",
             })
+
+            local function is_positive_int(n)
+               return n and n >= 1 and math.floor(n) == n
+            end
+
             local is_record = false
             local is_array = false
             local is_map = false
+
             local is_tuple = false
-            local array_len = 0
-            local pure_array = true
+            local last_array_idx = 1
+            local largest_array_idx = -1
+
             for i, child in ipairs(children) do
                assert(child.typename == "table_item")
                if child.kname then
@@ -6346,17 +6353,41 @@ tl.type_check = function(ast, opts)
                elseif child.ktype.typename == "number" then
                   is_array = true
                   is_tuple = true
-                  if i == #children and node[i].key_parsed == "implicit" and child.vtype.typename == "tuple" then
 
-                     for j, c in ipairs(child.vtype) do
-                        array_len = array_len + 1
-                        node.type.elements = expand_type(node, node.type.elements, c)
-                        node.type[i + j - 1] = c
+                  if node[i].key_parsed == "implicit" then
+                     if i == #children and child.vtype.typename == "tuple" then
+
+                        for j, c in ipairs(child.vtype) do
+                           node.type.elements = expand_type(node, node.type.elements, c)
+                           node.type[last_array_idx] = c
+                           last_array_idx = last_array_idx + 1
+                        end
+                     else
+                        node.type[last_array_idx] = child.vtype
+                        last_array_idx = last_array_idx + 1
+                        node.type.elements = expand_type(node, node.type.elements, child.vtype)
                      end
                   else
-                     array_len = array_len + 1
-                     node.type[i] = child.vtype
-                     node.type.elements = expand_type(node, node.type.elements, child.vtype)
+                     local n = node[i].key.constnum
+
+                     if not n or not is_positive_int(n) then
+                        is_map = true
+                        node.type.keys = expand_type(node, node.type.keys, child.ktype)
+                        node.type.values = expand_type(node, node.type.values, child.vtype)
+                     elseif n then
+                        if node.type[n] then
+                           node_error(node, "Overwriting index " .. n)
+                        end
+                        node.type[n] = child.vtype
+                        if n > largest_array_idx then
+                           largest_array_idx = n
+                        end
+                        node.type.elements = expand_type(node, node.type.elements, child.vtype)
+                     end
+                  end
+
+                  if last_array_idx > largest_array_idx then
+                     largest_array_idx = last_array_idx
                   end
                   if not node.type.elements then
                      is_array = false
@@ -6383,17 +6414,29 @@ tl.type_check = function(ast, opts)
                   node_error(node, "cannot determine type of table literal")
                end
             elseif is_array then
-               for i = 2, #node.type do
-                  if not is_a(node.type[i], node.type[i - 1]) then
-                     pure_array = false
-                     break
+               local pure_array = true
+               local last_idx = 1
+               for i = 2, largest_array_idx do
+                  if not node.type[i] then
+
+                  else
+                     if not node.type[last_idx] then
+                        last_idx = i
+                     else
+                        if not is_a(node.type[i], node.type[last_idx]) then
+                           pure_array = false
+                           break
+                        end
+                        last_idx = i
+                     end
                   end
                end
+
                if not pure_array then
                   node.type.typename = "tupletable"
                else
                   node.type.typename = "array"
-                  node.type.inferred_len = array_len
+                  node.type.inferred_len = largest_array_idx - 1
                end
             elseif is_record then
                node.type.typename = "record"

--- a/tl.lua
+++ b/tl.lua
@@ -1232,25 +1232,6 @@ local function parse_function_type(ps, i)
    return i, node
 end
 
-local function parse_tupletable_type(ps, i)
-   local t = new_type(ps, i, "tupletable")
-   i = verify_tk(ps, i, "[")
-   local n = 1
-   while true do
-      i, t[n] = parse_type(ps, i)
-      if not t[n] then
-         break
-      end
-      if ps.tokens[i].tk == "," then
-         n = n + 1
-         i = i + 1
-      else
-         break
-      end
-   end
-   return verify_tk(ps, i, "]"), t
-end
-
 local function parse_base_type(ps, i)
    if ps.tokens[i].tk == "string" or
       ps.tokens[i].tk == "boolean" or
@@ -1267,8 +1248,8 @@ local function parse_base_type(ps, i)
       return i + 1, typ
    elseif ps.tokens[i].tk == "function" then
       return parse_function_type(ps, i)
-   elseif ps.tokens[i].tk == "[" then
-      return parse_tupletable_type(ps, i)
+
+
    elseif ps.tokens[i].tk == "{" then
       i = i + 1
       local decl = new_type(ps, i, "array")
@@ -1277,6 +1258,20 @@ local function parse_base_type(ps, i)
       if ps.tokens[i].tk == "}" then
          decl.elements = t
          decl.yend = ps.tokens[i].y
+         i = verify_tk(ps, i, "}")
+      elseif ps.tokens[i].tk == "," then
+         decl.typename = "tupletable"
+         decl[1] = t
+         local n = 2
+         repeat
+            i = i + 1
+            local it
+            i, decl[n] = parse_type(ps, i)
+            if not decl[n] then
+               break
+            end
+            n = n + 1
+         until ps.tokens[i].tk ~= ","
          i = verify_tk(ps, i, "}")
       elseif ps.tokens[i].tk == ":" then
          decl.typename = "map"
@@ -3427,7 +3422,7 @@ local function show_type_base(t, seen)
       for i, v in ipairs(t) do
          table.insert(out, tostring(i) .. ": " .. show(v))
       end
-      return "[" .. table.concat(out, ", ") .. "]"
+      return "{" .. table.concat(out, ", ") .. "}"
    elseif t.typename == "poly" then
       local out = {}
       for _, v in ipairs(t.types) do
@@ -4765,6 +4760,9 @@ tl.type_check = function(ast, opts)
          elseif t1.typename == "tupletable" then
             local arr_len = math.huge
             if t2.inferred_len then
+               if t2.inferred_len > #t1 then
+                  return false, terr(t2, "array is too long to fit into %s", t1)
+               end
                arr_len = t2.inferred_len
             end
             for i = 1, math.min(#t1, arr_len) do
@@ -4824,14 +4822,20 @@ tl.type_check = function(ast, opts)
          if t1.typename == "tupletable" then
             for i = 1, math.min(#t1, #t2) do
                if not is_a(t1[i], t2[i], for_equality) then
-                  return false, terr(t1, "in tuple entry " .. i .. " got %s, expected %s", t1[i], t2[i])
+                  return false, terr(t1, "in tuple entry " .. i .. ": got %s, expected %s", t1[i], t2[i])
                end
             end
             if for_equality and #t1 ~= #t2 then
                return false, terr(t1, "tuples are not the same size")
             end
+            if #t1 > #t2 then
+               return false, terr(t1, "tuple %s is too big for tuple %s", t1, t2)
+            end
             return true
          elseif is_array_type(t1) then
+            if t1.inferred_len and t1.inferred_len > #t2 then
+               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t2) .. ", got " .. tostring(t1.inferred_len))
+            end
             for i = 1, math.min(#t2, t1.inferred_len or math.huge) do
                if not is_a(t2[i], t1.elements, for_equality) then
                   return false, terr(t1, "tuple entry " .. tostring(i) .. " %s does not match array of %s", t2[i], t1.elements)
@@ -5974,6 +5978,7 @@ tl.type_check = function(ast, opts)
                   t.declared_at = node
                   t.assigned_to = var.tk
                end
+               t.inferred_len = nil
                assert(var)
                add_var(var, var.tk, t, var.is_const)
 
@@ -6016,6 +6021,7 @@ tl.type_check = function(ast, opts)
                      t.declared_at = node
                      t.assigned_to = var.tk
                   end
+                  t.inferred_len = nil
                   add_global(var, var.tk, t, var.is_const)
 
                   dismiss_unresolved(var.tk)

--- a/tl.lua
+++ b/tl.lua
@@ -6354,6 +6354,8 @@ tl.type_check = function(ast, opts)
             local is_map = false
 
             local is_tuple = false
+            local is_not_tuple = false
+
             local last_array_idx = 1
             local largest_array_idx = -1
 
@@ -6369,7 +6371,9 @@ tl.type_check = function(ast, opts)
                   table.insert(node.type.field_order, child.kname)
                elseif child.ktype.typename == "number" then
                   is_array = true
-                  is_tuple = true
+                  if not is_not_tuple then
+                     is_tuple = true
+                  end
                   if not node.type.types then
                      node.type.types = {}
                   end
@@ -6390,14 +6394,14 @@ tl.type_check = function(ast, opts)
                   else
                      local n = node[i].key.constnum
 
-                     if not n or not is_positive_int(n) then
-                        is_map = true
-                        node.type.keys = expand_type(node, node.type.keys, child.ktype)
-                        node.type.values = expand_type(node, node.type.values, child.vtype)
+                     if not is_positive_int(n) then
+                        node.type.elements = expand_type(node, node.type.elements, child.vtype)
+                        is_not_tuple = true
                      elseif n then
-                        if node.type.types[n] then
-                           node_error(node, "Overwriting index " .. n)
-                        end
+
+
+
+
                         node.type.types[n] = resolve_tuple(child.vtype)
                         if n > largest_array_idx then
                            largest_array_idx = n
@@ -6434,24 +6438,29 @@ tl.type_check = function(ast, opts)
                   node_error(node, "cannot determine type of table literal")
                end
             elseif is_array then
-               local pure_array = true
-
-               local last_t
-               for _, current_t in pairs(node.type.types) do
-                  if last_t then
-                     if not same_type(last_t, current_t) then
-                        pure_array = false
-                        break
-                     end
-                  end
-                  last_t = current_t
-               end
-
-               if not pure_array then
-                  node.type.typename = "tupletable"
-               else
+               if is_not_tuple then
                   node.type.typename = "array"
                   node.type.inferred_len = largest_array_idx - 1
+               else
+                  local pure_array = true
+
+                  local last_t
+                  for _, current_t in pairs(node.type.types) do
+                     if last_t then
+                        if not same_type(last_t, current_t) then
+                           pure_array = false
+                           break
+                        end
+                     end
+                     last_t = current_t
+                  end
+
+                  if not pure_array then
+                     node.type.typename = "tupletable"
+                  else
+                     node.type.typename = "array"
+                     node.type.inferred_len = largest_array_idx - 1
+                  end
                end
             elseif is_record then
                node.type.typename = "record"
@@ -6459,7 +6468,7 @@ tl.type_check = function(ast, opts)
                node.type.typename = "map"
             elseif is_tuple then
                node.type.typename = "tupletable"
-               if #node.type == 0 then
+               if not node.type.types or #node.type.types == 0 then
                   node_error(node, "cannot determine type of tuple elements")
                end
             end

--- a/tl.lua
+++ b/tl.lua
@@ -1259,12 +1259,12 @@ local function parse_base_type(ps, i)
          i = verify_tk(ps, i, "}")
       elseif ps.tokens[i].tk == "," then
          decl.typename = "tupletable"
-         decl[1] = t
+         decl.types = { t }
          local n = 2
          repeat
             i = i + 1
-            i, decl[n] = parse_type(ps, i)
-            if not decl[n] then
+            i, decl.types[n] = parse_type(ps, i)
+            if not decl.types[n] then
                break
             end
             n = n + 1
@@ -2584,6 +2584,16 @@ local fast_pretty_print_ast_opts = {
    preserve_newlines = true,
 }
 
+local primitive = {
+   ["function"] = "function",
+   ["enum"] = "string",
+   ["boolean"] = "boolean",
+   ["string"] = "string",
+   ["nil"] = "nil",
+   ["number"] = "number",
+   ["thread"] = "thread",
+}
+
 function tl.pretty_print_ast(ast, mode)
    local indent = 0
 
@@ -3080,16 +3090,6 @@ function tl.pretty_print_ast(ast, mode)
       },
    }
 
-   local primitive = {
-      ["function"] = "function",
-      ["enum"] = "string",
-      ["boolean"] = "boolean",
-      ["string"] = "string",
-      ["nil"] = "nil",
-      ["number"] = "number",
-      ["thread"] = "thread",
-   }
-
    local visit_type = {}
    visit_type.cbs = {
       ["string"] = {
@@ -3416,7 +3416,7 @@ local function show_type_base(t, seen)
       return "(" .. table.concat(out, ", ") .. ")"
    elseif t.typename == "tupletable" then
       local out = {}
-      for i, v in ipairs(t) do
+      for i, v in ipairs(t.types) do
          table.insert(out, tostring(i) .. ": " .. show(v))
       end
       return "{" .. table.concat(out, ", ") .. "}"
@@ -4543,6 +4543,15 @@ tl.type_check = function(ast, opts)
       end
       if t1.typename == "array" then
          return same_type(t1.elements, t2.elements)
+      elseif t1.typename == "tupletable" then
+         local all_errs = {}
+         for i = 1, math.min(#t1.types, #t2.types) do
+            local ok, err = same_type(t1.types[i], t2.types[i])
+            if not ok then
+               add_errs_prefixing(err, all_errs, "values", t1)
+            end
+         end
+         return any_errors(all_errs)
       elseif t1.typename == "map" then
          local all_errs = {}
          local k_ok, k_errs = same_type(t1.keys, t2.keys)
@@ -4614,7 +4623,7 @@ tl.type_check = function(ast, opts)
                table.insert(stack, s)
             end
          else
-            if not is_known_table_type(t) then
+            if primitive[t.typename] then
                if not primitives_seen[t.typename] then
                   primitives_seen[t.typename] = true
                   table.insert(ts, t)
@@ -4704,7 +4713,7 @@ tl.type_check = function(ast, opts)
    local expand_type
    local function arraytype_from_tuple(where, tupletype)
 
-      local element_type = a_union(tupletype)
+      local element_type = a_union(tupletype.types)
       local valid, err = is_valid_union(element_type)
       if valid then
          return a_type({
@@ -4715,11 +4724,11 @@ tl.type_check = function(ast, opts)
 
 
       local arr_type = a_type({
-         elements = tupletype[1],
+         elements = tupletype.types[1],
          typename = "array",
       })
-      for i = 2, #tupletype do
-         arr_type = expand_type(where, arr_type, a_type({ elements = tupletype[i], typename = "array" }))
+      for i = 2, #tupletype.types do
+         arr_type = expand_type(where, arr_type, a_type({ elements = tupletype.types[i], typename = "array" }))
          if not arr_type or not arr_type.elements then
             return nil, terr(tupletype, "unable to convert tuple %s to array", tupletype)
          end
@@ -4828,9 +4837,8 @@ tl.type_check = function(ast, opts)
                return true
             end
          elseif t1.typename == "tupletable" then
-            if t2.inferred_len and t2.inferred_len > #t1 then
-
-               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t1) .. ", got " .. tostring(t2.inferred_len))
+            if t2.inferred_len and t2.inferred_len > #t1.types then
+               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t1.types) .. ", got " .. tostring(t2.inferred_len))
             end
             local u, err = arraytype_from_tuple(t1.inferred_at, t1)
             if not u then
@@ -4870,9 +4878,19 @@ tl.type_check = function(ast, opts)
                errs_values = {}
             end
             return combine_errs(errs_keys, errs_values)
-         elseif t1.typename == "array" then
+         elseif t1.typename == "array" or t1.typename == "tupletable" then
+            local elements
+            if t1.typename == "tupletable" then
+               local arr_type = arraytype_from_tuple(t1.inferred_at, t1)
+               if not arr_type then
+                  return false, terr(t1, "Unable to convert tuple %s to map", t1)
+               end
+               elements = arr_type.elements
+            else
+               elements = t1.elements
+            end
             local _, errs_keys = is_a(NUMBER, t2.keys)
-            local _, errs_values = is_a(t1.elements, t2.values)
+            local _, errs_values = is_a(elements, t2.values)
             return combine_errs(errs_keys, errs_values)
          elseif is_record_type(t1) then
             if not is_a(t2.keys, STRING) then
@@ -4889,25 +4907,25 @@ tl.type_check = function(ast, opts)
          end
       elseif t2.typename == "tupletable" then
          if t1.typename == "tupletable" then
-            for i = 1, math.min(#t1, #t2) do
-               if not is_a(t1[i], t2[i], for_equality) then
-                  return false, terr(t1, "in tuple entry " .. tostring(i) .. ": got %s, expected %s", t1[i], t2[i])
+            for i = 1, math.min(#t1.types, #t2.types) do
+               if not is_a(t1.types[i], t2.types[i], for_equality) then
+                  return false, terr(t1, "in tuple entry " .. tostring(i) .. ": got %s, expected %s", t1.types[i], t2.types[i])
                end
             end
-            if for_equality and #t1 ~= #t2 then
+            if for_equality and #t1.types ~= #t2.types then
                return false, terr(t1, "tuples are not the same size")
             end
-            if #t1 > #t2 then
+            if #t1.types > #t2.types then
                return false, terr(t1, "tuple %s is too big for tuple %s", t1, t2)
             end
             return true
          elseif is_array_type(t1) then
-            if t1.inferred_len and t1.inferred_len > #t2 then
-               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t2) .. ", got " .. tostring(t1.inferred_len))
+            if t1.inferred_len and t1.inferred_len > #t2.types then
+               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t2.types) .. ", got " .. tostring(t1.inferred_len))
             end
-            for i = 1, math.min(#t2, t1.inferred_len or math.huge) do
-               if not is_a(t2[i], t1.elements, for_equality) then
-                  return false, terr(t1, "tuple entry " .. tostring(i) .. " %s does not match array of %s", t2[i], t1.elements)
+            for i = 1, math.min(#t2.types, t1.inferred_len or math.huge) do
+               if not is_a(t2.types[i], t1.elements, for_equality) then
+                  return false, terr(t1, "tuple entry " .. tostring(i) .. " %s does not match array of %s", t2.types[i], t1.elements)
                end
             end
             return true
@@ -5517,17 +5535,17 @@ tl.type_check = function(ast, opts)
 
       if a.typename == "tupletable" and is_a(b, NUMBER) then
          if idxnode.constnum then
-            if idxnode.constnum > #a or
+            if idxnode.constnum > #a.types or
                idxnode.constnum < 1 or
                idxnode.constnum ~= math.floor(idxnode.constnum) then
 
                return node_error(idxnode, "index " .. tostring(idxnode.constnum) .. " out of range for tuple %s", a)
             end
-            return a[idxnode.constnum]
+            return a.types[idxnode.constnum]
          else
             local array_type = arraytype_from_tuple(idxnode, a)
             if not array_type then
-               type_error(a, "tuple cannot be indexed with a variable")
+               type_error(a, "cannot index this tuple with a variable because it would produce a union type that cannot be discriminated at runtime")
                return UNKNOWN
             end
             return array_type.elements
@@ -6352,17 +6370,20 @@ tl.type_check = function(ast, opts)
                elseif child.ktype.typename == "number" then
                   is_array = true
                   is_tuple = true
+                  if not node.type.types then
+                     node.type.types = {}
+                  end
 
                   if node[i].key_parsed == "implicit" then
                      if i == #children and child.vtype.typename == "tuple" then
 
                         for j, c in ipairs(child.vtype) do
                            node.type.elements = expand_type(node, node.type.elements, c)
-                           node.type[last_array_idx] = c
+                           node.type.types[last_array_idx] = resolve_tuple(c)
                            last_array_idx = last_array_idx + 1
                         end
                      else
-                        node.type[last_array_idx] = child.vtype
+                        node.type.types[last_array_idx] = resolve_tuple(child.vtype)
                         last_array_idx = last_array_idx + 1
                         node.type.elements = expand_type(node, node.type.elements, child.vtype)
                      end
@@ -6374,10 +6395,10 @@ tl.type_check = function(ast, opts)
                         node.type.keys = expand_type(node, node.type.keys, child.ktype)
                         node.type.values = expand_type(node, node.type.values, child.vtype)
                      elseif n then
-                        if node.type[n] then
+                        if node.type.types[n] then
                            node_error(node, "Overwriting index " .. n)
                         end
-                        node.type[n] = child.vtype
+                        node.type.types[n] = resolve_tuple(child.vtype)
                         if n > largest_array_idx then
                            largest_array_idx = n
                         end
@@ -6414,21 +6435,16 @@ tl.type_check = function(ast, opts)
                end
             elseif is_array then
                local pure_array = true
-               local last_idx = 1
-               for i = 2, largest_array_idx do
-                  if not node.type[i] then
 
-                  else
-                     if not node.type[last_idx] then
-                        last_idx = i
-                     else
-                        if not is_a(node.type[i], node.type[last_idx]) then
-                           pure_array = false
-                           break
-                        end
-                        last_idx = i
+               local last_t
+               for _, current_t in pairs(node.type.types) do
+                  if last_t then
+                     if not same_type(last_t, current_t) then
+                        pure_array = false
+                        break
                      end
                   end
+                  last_t = current_t
                end
 
                if not pure_array then

--- a/tl.lua
+++ b/tl.lua
@@ -4675,7 +4675,6 @@ tl.type_check = function(ast, opts)
       local n_table_types = 0
       local n_function_types = 0
       local n_string_enum = 0
-      local has_primitive = {}
       local has_primitive_string_type = false
       for _, t in ipairs(typ.types) do
          t = resolve_unary(t)

--- a/tl.tl
+++ b/tl.tl
@@ -4596,9 +4596,13 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       return true
    end
 
+   local is_known_table_type: function(t: Type): boolean
+
    local function a_union(types: {Type}): Type
       local ts: {Type} = {}
       local stack: {Type} = {}
+      -- Make things like string | string resolve to string
+      local primitives_seen: {TypeName:boolean} = {}
       local i = 1
       while types[i] or stack[1] do
          local t: Type
@@ -4613,7 +4617,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                table.insert(stack, s)
             end
          else
-            table.insert(ts, t)
+            if not is_known_table_type(t) then
+               if not primitives_seen[t.typename] then
+                  primitives_seen[t.typename] = true
+                  table.insert(ts, t)
+               end
+            else
+               table.insert(ts, t)
+            end
          end
       end
       return a_type {
@@ -4653,8 +4664,71 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       arrayrecord = true,
       tupletable = true,
    }
-   local function is_known_table_type(t: Type): boolean
+   is_known_table_type = function(t: Type): boolean
       return table_types[t.typename]
+   end
+
+   local function resolve_union(typ: Type)
+      assert(typ.typename == "union")
+   end
+
+   local function is_valid_union(typ: Type): boolean, string
+      -- check for limitations in our union support
+      -- due to codegen limitations (we only check with type() so far)
+      local n_table_types = 0
+      local n_function_types = 0
+      local n_string_enum = 0
+      local has_primitive: {TypeName:boolean} = {}
+      local has_primitive_string_type = false
+      for _, t in ipairs(typ.types) do
+         t = resolve_unary(t)
+         if table_types[t.typename] then
+            n_table_types = n_table_types + 1
+            if n_table_types > 1 then
+               return false, "cannot discriminate a union between multiple table types: %s"
+            end
+         elseif t.typename == "function" then
+            n_function_types = n_function_types + 1
+            if n_function_types > 1 then
+               return false, "cannot discriminate a union between multiple function types: %s"
+            end
+         elseif t.typename == "enum" or (t.typename == "string" and not has_primitive_string_type) then
+            n_string_enum = n_string_enum + 1
+            if n_string_enum > 1 then
+               return false, "cannot discriminate a union between multiple string/enum types: %s"
+            end
+            if t.typename == "string" then
+               has_primitive_string_type = true
+            end
+         end
+      end
+      return true
+   end
+
+   local expand_type: function(where: Node, old: Type, new: Type): Type
+   local function arraytype_from_tuple(where: Node, tupletype: Type): Type, {Error}
+      -- first just try a basic union
+      local element_type = a_union(tupletype)
+      local valid, err = is_valid_union(element_type)
+      if valid then
+         return a_type {
+            elements = element_type,
+            typename = "array",
+         }
+      end
+
+      -- failing a basic union, expand the types
+      local arr_type = a_type {
+         elements = tupletype[1],
+         typename = "array",
+      }
+      for i = 2, #tupletype do
+         arr_type = expand_type(where, arr_type, a_type { elements = tupletype[i], typename = "array" })
+         if not arr_type then
+            return nil, terr(tupletype, "unable to convert tuple %s to array", tupletype)
+         end
+      end
+      return arr_type
    end
 
    is_a = function(t1: Type, t2: Type, for_equality: boolean): boolean, {Error}
@@ -4758,17 +4832,17 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                return true
             end
          elseif t1.typename == "tupletable" then
-            local arr_len = math.huge
             if t2.inferred_len then
                if t2.inferred_len > #t1 then
                   return false, terr(t2, "array is too long to fit into %s", t1)
                end
-               arr_len = t2.inferred_len
             end
-            for i = 1, math.min(#t1, arr_len) do
-               if not is_a(t1[i], t2.elements) then
-                  return false, terr(t2, "got %s, expected %s", t1, t2)
-               end
+            local u, err = arraytype_from_tuple(t1.inferred_at, t1)
+            if not u then
+               return false, err
+            end
+            if not is_a(u, t2) then
+               return false, terr(t2, "got %s (from %s), expected %s", u, t1, t2)
             end
             return true
          elseif t1.typename == "map" then
@@ -5440,37 +5514,6 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
-   local function is_valid_union(typ: Type): Type
-      -- check for limitations in our union support
-      -- due to codegen limitations (we only check with type() so far)
-      local n_table_types = 0
-      local n_function_types = 0
-      local n_string_enum = 0
-      for _, t in ipairs(typ.types) do
-         t = resolve_unary(t)
-         if table_types[t.typename] then
-            n_table_types = n_table_types + 1
-            if n_table_types > 1 then
-               type_error(typ, "cannot discriminate a union between multiple table types: %s", typ)
-               break
-            end
-         elseif t.typename == "function" then
-            n_function_types = n_function_types + 1
-            if n_function_types > 1 then
-               type_error(typ, "cannot discriminate a union between multiple function types: %s", typ)
-               break
-            end
-         elseif t.typename == "string" or t.typename == "enum" then
-            n_string_enum = n_string_enum + 1
-            if n_string_enum > 1 then
-               type_error(typ, "cannot discriminate a union between multiple string/enum types: %s", typ)
-               break
-            end
-         end
-      end
-      return typ
-   end
-
    local function type_check_index(node: Node, idxnode: Node, a: Type, b: Type): Type
       local orig_a = a
       local orig_b = b
@@ -5487,10 +5530,11 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
             return a[idxnode.constnum]
          else
-            local u = a_union(a)
-            u.x = idxnode.x
-            u.y = idxnode.y
-            return is_valid_union(u)
+            local array_type = arraytype_from_tuple(idxnode, a)
+            if not array_type then
+               type_error(a, "tuple cannot be indexed with a variable")
+            end
+            return array_type.elements
          end
       elseif is_array_type(a) and is_a(b, NUMBER) then
          return a.elements
@@ -5537,7 +5581,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
-   local function expand_type(where: Node, old: Type, new: Type): Type
+   expand_type = function(where: Node, old: Type, new: Type): Type
       if not old then
          return new
       else
@@ -6180,9 +6224,16 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                      if not (lax and is_unknown(t)) then
                         node_error(exp1, "attempting pairs loop on something that's not a map or record: %s", exp1.e2.type)
                      end
-                  elseif exp1.e1.tk == "ipairs" and not is_array_type(t) then
-                     if not (lax and (is_unknown(t) or t.typename == "emptytable")) then
-                        node_error(exp1, "attempting ipairs loop on something that's not an array: %s", exp1.e2.type)
+                  elseif exp1.e1.tk == "ipairs" then
+                     if t.typename == "tupletable" then
+                        local arr_type = a_union(t)
+                        if not is_valid_union(arr_type) then
+                           node_error(exp1, "attempting ipairs loop on tuple that's not a valid array: %s", exp1.e2.type)
+                        end
+                     elseif not is_array_type(t) then
+                        if not (lax and (is_unknown(t) or t.typename == "emptytable")) then
+                           node_error(exp1, "attempting ipairs loop on something that's not an array: %s", exp1.e2.type)
+                        end
                      end
                   end
                end
@@ -6303,7 +6354,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                      for j, c in ipairs(child.vtype) do
                         array_len = array_len + 1
                         node.type.elements = expand_type(node, node.type.elements, c)
-                        node.type[j] = c
+                        node.type[i+j-1] = c
                      end
                   else
                      array_len = array_len + 1
@@ -6773,7 +6824,13 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end,
          },
          ["union"] = {
-            after = is_valid_union
+            after = function(typ: Type, children: {Type}): Type
+               local valid, err = is_valid_union(typ)
+               if not valid then
+                  type_error(typ, err, typ)
+               end
+               return typ
+            end
          },
       },
       after = {

--- a/tl.tl
+++ b/tl.tl
@@ -1,3 +1,4 @@
+
 local record TypeCheckOptions
    lax: boolean
    filename: string
@@ -706,6 +707,7 @@ local enum TypeName
    "function"
    "array"
    "map"
+   "tupletable"
    "arrayrecord"
    "record"
    "enum"
@@ -772,6 +774,8 @@ local record Type
 
    -- array
    elements: Type
+   -- tuples/array
+   inferred_len: number
 
    -- function
    is_method: boolean
@@ -940,6 +944,9 @@ local record Node
    constnum: number
    conststr: string
 
+   -- table literal
+   array_len: number
+
    -- goto
    label: string
 
@@ -981,7 +988,6 @@ local parse_argument_list: function(ParseState, number): number, Node
 local parse_argument_type_list: function(ParseState, number): number, Type
 local parse_type: function(ParseState, number): number, Type, number
 local parse_newtype: function(ps: ParseState, i: number): number, Node
-
 
 local function fail(ps: ParseState, i: number, msg: string): number
    if not ps.tokens[i] then
@@ -1226,6 +1232,25 @@ local function parse_function_type(ps: ParseState, i: number): number, Type
    return i, node
 end
 
+local function parse_tupletable_type(ps: ParseState, i: number): number, Type
+   local t = new_type(ps, i, "tupletable")
+   i = verify_tk(ps, i, "[")
+   local n = 1
+   while true do
+      i, t[n] = parse_type(ps, i)
+      if not t[n] then
+         break
+      end
+      if ps.tokens[i].tk == "," then
+         n = n + 1
+         i = i + 1
+      else
+         break
+      end
+   end
+   return verify_tk(ps, i, "]"), t
+end
+
 local function parse_base_type(ps: ParseState, i: number): number, Type, number
    if ps.tokens[i].tk == "string"
       or ps.tokens[i].tk == "boolean"
@@ -1242,6 +1267,8 @@ local function parse_base_type(ps: ParseState, i: number): number, Type, number
       return i + 1, typ
    elseif ps.tokens[i].tk == "function" then
       return parse_function_type(ps, i)
+   elseif ps.tokens[i].tk == "[" then
+      return parse_tupletable_type(ps, i)
    elseif ps.tokens[i].tk == "{" then
       i = i + 1
       local decl = new_type(ps, i, "array")
@@ -3088,6 +3115,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
    visit_type.cbs["thread"] = visit_type.cbs["string"]
    visit_type.cbs["array"] = visit_type.cbs["string"]
    visit_type.cbs["map"] = visit_type.cbs["string"]
+   visit_type.cbs["tupletable"] = visit_type.cbs["string"]
    visit_type.cbs["arrayrecord"] = visit_type.cbs["string"]
    visit_type.cbs["record"] = visit_type.cbs["string"]
    visit_type.cbs["enum"] = visit_type.cbs["string"]
@@ -3136,7 +3164,6 @@ end
 
 local ANY = a_type { typename = "any" }
 local NONE = a_type { typename = "none" }
-
 local NIL = a_type { typename = "nil" }
 local NUMBER = a_type { typename = "number" }
 local STRING = a_type { typename = "string" }
@@ -3285,11 +3312,7 @@ local unop_types: {string:{string:Type}} = {
 
 local binop_types: {string:{TypeName:{TypeName:Type}}} = {
    ["+"] = numeric_binop,
-   ["-"] = {
-      ["number"] = {
-         ["number"] = NUMBER,
-      }
-   },
+   ["-"] = numeric_binop,
    ["*"] = numeric_binop,
    ["%"] = numeric_binop,
    ["/"] = numeric_binop,
@@ -3399,6 +3422,12 @@ local function show_type_base(t: Type, seen: {Type:boolean}): string
          table.insert(out, show(v))
       end
       return "(" .. table.concat(out, ", ") .. ")"
+   elseif t.typename == "tupletable" then
+      local out: {string} = {}
+      for i, v in ipairs(t) do
+         table.insert(out, tostring(i) .. ": " .. show(v))
+      end
+      return "[" .. table.concat(out, ", ") .. "]"
    elseif t.typename == "poly" then
       local out: {string} = {}
       for _, v in ipairs(t.types) do
@@ -4622,8 +4651,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    local resolve_unary: function(t: Type): Type = nil
 
+   local table_types: {TypeName:boolean} = {
+      array = true,
+      map = true,
+      record = true,
+      arrayrecord = true,
+      tupletable = true,
+   }
    local function is_known_table_type(t: Type): boolean
-      return (t.typename == "array" or t.typename == "map" or t.typename == "record" or t.typename == "arrayrecord")
+      return table_types[t.typename]
    end
 
    is_a = function(t1: Type, t2: Type, for_equality: boolean): boolean, {Error}
@@ -4726,6 +4762,17 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             if is_a(t1.elements, t2.elements) then
                return true
             end
+         elseif t1.typename == "tupletable" then
+            local arr_len = math.huge
+            if t2.inferred_len then
+               arr_len = t2.inferred_len
+            end
+            for i = 1, math.min(#t1, arr_len) do
+               if not is_a(t1[i], t2.elements) then
+                  return false, terr(t2, "got %s, expected %s", t1, t2)
+               end
+            end
+            return true
          elseif t1.typename == "map" then
             local _, errs_keys = is_a(t1.keys, NUMBER)
             local _, errs_values = is_a(t1.values, t2.elements)
@@ -4772,6 +4819,25 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
             end
             return match_fields_to_map(t1, t2)
+         end
+      elseif t2.typename == "tupletable" then
+         if t1.typename == "tupletable" then
+            for i = 1, math.min(#t1, #t2) do
+               if not is_a(t1[i], t2[i], for_equality) then
+                  return false, terr(t1, "in tuple entry " .. i .. " got %s, expected %s", t1[i], t2[i])
+               end
+            end
+            if for_equality and #t1 ~= #t2 then
+               return false, terr(t1, "tuples are not the same size")
+            end
+            return true
+         elseif is_array_type(t1) then
+            for i = 1, math.min(#t2, t1.inferred_len or math.huge) do
+               if not is_a(t2[i], t1.elements, for_equality) then
+                  return false, terr(t1, "tuple entry " .. tostring(i) .. " %s does not match array of %s", t2[i], t1.elements)
+               end
+            end
+            return true
          end
       elseif t1.typename == "function" and t2.typename == "function" then
          local all_errs = {}
@@ -5370,13 +5436,59 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
+   local function is_valid_union(typ: Type): Type
+      -- check for limitations in our union support
+      -- due to codegen limitations (we only check with type() so far)
+      local n_table_types = 0
+      local n_function_types = 0
+      local n_string_enum = 0
+      for _, t in ipairs(typ.types) do
+         t = resolve_unary(t)
+         if table_types[t.typename] then
+            n_table_types = n_table_types + 1
+            if n_table_types > 1 then
+               type_error(typ, "cannot discriminate a union between multiple table types: %s", typ)
+               break
+            end
+         elseif t.typename == "function" then
+            n_function_types = n_function_types + 1
+            if n_function_types > 1 then
+               type_error(typ, "cannot discriminate a union between multiple function types: %s", typ)
+               break
+            end
+         elseif t.typename == "string" or t.typename == "enum" then
+            n_string_enum = n_string_enum + 1
+            if n_string_enum > 1 then
+               type_error(typ, "cannot discriminate a union between multiple string/enum types: %s", typ)
+               break
+            end
+         end
+      end
+      return typ
+   end
+
    local function type_check_index(node: Node, idxnode: Node, a: Type, b: Type): Type
       local orig_a = a
       local orig_b = b
       a = resolve_unary(a)
       b = resolve_unary(b)
 
-      if is_array_type(a) and is_a(b, NUMBER) then
+      if a.typename == "tupletable" and is_a(b, NUMBER) then
+         if idxnode.constnum then
+            if idxnode.constnum > #a
+               or idxnode.constnum < 1
+               or idxnode.constnum ~= math.floor(idxnode.constnum)
+            then
+               return node_error(idxnode, "index " .. tostring(idxnode.constnum) .. " out of range for tuple %s", a)
+            end
+            return a[idxnode.constnum]
+         else
+            local u = a_union(a)
+            u.x = idxnode.x
+            u.y = idxnode.y
+            return is_valid_union(u)
+         end
+      elseif is_array_type(a) and is_a(b, NUMBER) then
          return a.elements
       elseif a.typename == "emptytable" then
          if a.keys == nil then
@@ -6164,6 +6276,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             local is_record = false
             local is_array = false
             local is_map = false
+            local is_tuple = false
+            local array_len = 0
+            local pure_array = true
             for i, child in ipairs(children) do
                assert(child.typename == "table_item")
                if child.kname then
@@ -6176,16 +6291,20 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   table.insert(node.type.field_order, child.kname)
                elseif child.ktype.typename == "number" then
                   is_array = true
+                  is_tuple = true
                   if i == #children and node[i].key_parsed == "implicit" and child.vtype.typename == "tuple" then
                      -- need to expand last item in an array (e.g { 1, 2, 3, f() })
-                     for _, c in ipairs(child.vtype) do
+                     for j, c in ipairs(child.vtype) do
+                        array_len = array_len + 1
                         node.type.elements = expand_type(node, node.type.elements, c)
+                        node.type[j] = c
                      end
                   else
+                     array_len = array_len + 1
+                     node.type[i] = child.vtype
                      node.type.elements = expand_type(node, node.type.elements, child.vtype)
                   end
                   if not node.type.elements then
-                     node_error(node, "cannot determine type of array elements")
                      is_array = false
                   end
                else
@@ -6194,6 +6313,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   node.type.values = expand_type(node, node.type.values, child.vtype)
                end
             end
+            node.type.inferred_len = array_len
             if is_array and is_map then
                node_error(node, "cannot determine type of table literal")
             elseif is_record and is_array then
@@ -6210,11 +6330,26 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   node_error(node, "cannot determine type of table literal")
                end
             elseif is_array then
-               node.type.typename = "array"
+               for i = 2, #node.type do
+                  if not is_a(node.type[i], node.type[i-1]) then
+                     pure_array = false
+                     break
+                  end
+               end
+               if not pure_array then
+                  node.type.typename = "tupletable"
+               else
+                  node.type.typename = "array"
+               end
             elseif is_record then
                node.type.typename = "record"
             elseif is_map then
                node.type.typename = "map"
+            elseif is_tuple then
+               node.type.typename = "tupletable"
+               if #node.type == 0 then
+                  node_error(node, "cannot determine type of tuple elements")
+               end
             end
          end,
       },
@@ -6632,36 +6767,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end,
          },
          ["union"] = {
-            after = function(typ: Type, children: {Type}): Type
-               -- check for limitations in our union support
-               -- due to codegen limitations (we only check with type() so far)
-               local n_table_types = 0
-               local n_function_types = 0
-               local n_string_enum = 0
-               for _, t in ipairs(typ.types) do
-                  t = resolve_unary(t)
-                  if table_types[t.typename] then
-                     n_table_types = n_table_types + 1
-                     if n_table_types > 1 then
-                        type_error(typ, "cannot discriminate a union between multiple table types: %s", typ)
-                        break
-                     end
-                  elseif t.typename == "function" then
-                     n_function_types = n_function_types + 1
-                     if n_function_types > 1 then
-                        type_error(typ, "cannot discriminate a union between multiple function types: %s", typ)
-                        break
-                     end
-                  elseif t.typename == "string" or t.typename == "enum" then
-                     n_string_enum = n_string_enum + 1
-                     if n_string_enum > 1 then
-                        type_error(typ, "cannot discriminate a union between multiple string/enum types: %s", typ)
-                        break
-                     end
-                  end
-               end
-               return typ
-            end,
+            after = is_valid_union
          },
       },
       after = {
@@ -6673,6 +6779,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       }
    }
 
+   visit_type.cbs["tupletable"] = visit_type.cbs["string"]
    visit_type.cbs["typetype"] = visit_type.cbs["string"]
    visit_type.cbs["nestedtype"] = visit_type.cbs["string"]
    visit_type.cbs["typevar"] = visit_type.cbs["string"]

--- a/tl.tl
+++ b/tl.tl
@@ -757,7 +757,7 @@ local record Type
    -- vararg
    is_va: boolean
 
-   -- poly, union
+   -- poly, union, tupletable
    types: {Type}
 
    -- typetype
@@ -1259,12 +1259,12 @@ local function parse_base_type(ps: ParseState, i: number): number, Type, number
          i = verify_tk(ps, i, "}")
       elseif ps.tokens[i].tk == "," then
          decl.typename = "tupletable"
-         decl[1] = t
+         decl.types = { t }
          local n = 2
          repeat
             i = i + 1
-            i, decl[n] = parse_type(ps, i)
-            if not decl[n] then
+            i, decl.types[n] = parse_type(ps, i)
+            if not decl.types[n] then
                break
             end
             n = n + 1
@@ -2584,6 +2584,16 @@ local fast_pretty_print_ast_opts: PrettyPrintOpts = {
    preserve_newlines = true,
 }
 
+local primitive: {TypeName:string} = {
+   ["function"] = "function",
+   ["enum"] = "string",
+   ["boolean"] = "boolean",
+   ["string"] = "string",
+   ["nil"] = "nil",
+   ["number"] = "number",
+   ["thread"] = "thread",
+}
+
 function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
    local indent = 0
 
@@ -3080,16 +3090,6 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
       },
    }
 
-   local primitive: {TypeName:string} = {
-      ["function"] = "function",
-      ["enum"] = "string",
-      ["boolean"] = "boolean",
-      ["string"] = "string",
-      ["nil"] = "nil",
-      ["number"] = "number",
-      ["thread"] = "thread",
-   }
-
    local visit_type: Visitor<TypeName, Type, Output> = {}
    visit_type.cbs = {
       ["string"] = {
@@ -3416,7 +3416,7 @@ local function show_type_base(t: Type, seen: {Type:boolean}): string
       return "(" .. table.concat(out, ", ") .. ")"
    elseif t.typename == "tupletable" then
       local out: {string} = {}
-      for i, v in ipairs(t) do
+      for i, v in ipairs(t.types) do
          table.insert(out, tostring(i) .. ": " .. show(v))
       end
       return "{" .. table.concat(out, ", ") .. "}"
@@ -4543,6 +4543,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
       if t1.typename == "array" then
          return same_type(t1.elements, t2.elements)
+      elseif t1.typename == "tupletable" then
+         local all_errs = {}
+         for i = 1, math.min(#t1.types, #t2.types) do
+            local ok, err = same_type(t1.types[i], t2.types[i])
+            if not ok then
+               add_errs_prefixing(err, all_errs, "values", t1 as Node)
+            end
+         end
+         return any_errors(all_errs)
       elseif t1.typename == "map" then
          local all_errs = {}
          local k_ok, k_errs = same_type(t1.keys, t2.keys)
@@ -4614,7 +4623,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                table.insert(stack, s)
             end
          else
-            if not is_known_table_type(t) then
+            if primitive[t.typename] then
                if not primitives_seen[t.typename] then
                   primitives_seen[t.typename] = true
                   table.insert(ts, t)
@@ -4704,7 +4713,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    local expand_type: function(where: Node, old: Type, new: Type): Type
    local function arraytype_from_tuple(where: Node, tupletype: Type): Type, {Error}
       -- first just try a basic union
-      local element_type = a_union(tupletype)
+      local element_type = a_union(tupletype.types)
       local valid, err = is_valid_union(element_type)
       if valid then
          return a_type {
@@ -4715,11 +4724,11 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
       -- failing a basic union, expand the types
       local arr_type = a_type {
-         elements = tupletype[1],
+         elements = tupletype.types[1],
          typename = "array",
       }
-      for i = 2, #tupletype do
-         arr_type = expand_type(where, arr_type, a_type { elements = tupletype[i], typename = "array" })
+      for i = 2, #tupletype.types do
+         arr_type = expand_type(where, arr_type, a_type { elements = tupletype.types[i], typename = "array" })
          if not arr_type or not arr_type.elements then
             return nil, terr(tupletype, "unable to convert tuple %s to array", tupletype)
          end
@@ -4828,9 +4837,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                return true
             end
          elseif t1.typename == "tupletable" then
-            if t2.inferred_len and t2.inferred_len > #t1 then
-                  -- return false, terr(t2, "array is too long to fit into %s", t1)
-               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t1) .. ", got " .. tostring(t2.inferred_len))
+            if t2.inferred_len and t2.inferred_len > #t1.types then
+               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t1.types) .. ", got " .. tostring(t2.inferred_len))
             end
             local u, err = arraytype_from_tuple(t1.inferred_at, t1)
             if not u then
@@ -4870,9 +4878,19 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                errs_values = {}
             end
             return combine_errs(errs_keys, errs_values)
-         elseif t1.typename == "array" then
+         elseif t1.typename == "array" or t1.typename == "tupletable" then
+            local elements: Type
+            if t1.typename == "tupletable" then
+               local arr_type = arraytype_from_tuple(t1.inferred_at, t1)
+               if not arr_type then
+                  return false, terr(t1, "Unable to convert tuple %s to map", t1)
+               end
+               elements = arr_type.elements
+            else
+               elements = t1.elements
+            end
             local _, errs_keys = is_a(NUMBER, t2.keys)
-            local _, errs_values = is_a(t1.elements, t2.values)
+            local _, errs_values = is_a(elements, t2.values)
             return combine_errs(errs_keys, errs_values)
          elseif is_record_type(t1) then -- FIXME
             if not is_a(t2.keys, STRING) then
@@ -4889,25 +4907,25 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end
       elseif t2.typename == "tupletable" then
          if t1.typename == "tupletable" then
-            for i = 1, math.min(#t1, #t2) do
-               if not is_a(t1[i], t2[i], for_equality) then
-                  return false, terr(t1, "in tuple entry " .. tostring(i) .. ": got %s, expected %s", t1[i], t2[i])
+            for i = 1, math.min(#t1.types, #t2.types) do
+               if not is_a(t1.types[i], t2.types[i], for_equality) then
+                  return false, terr(t1, "in tuple entry " .. tostring(i) .. ": got %s, expected %s", t1.types[i], t2.types[i])
                end
             end
-            if for_equality and #t1 ~= #t2 then
+            if for_equality and #t1.types ~= #t2.types then
                return false, terr(t1, "tuples are not the same size")
             end
-            if #t1 > #t2 then
+            if #t1.types > #t2.types then
                return false, terr(t1, "tuple %s is too big for tuple %s", t1, t2)
             end
             return true
          elseif is_array_type(t1) then
-            if t1.inferred_len and t1.inferred_len > #t2 then
-               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t2) .. ", got " .. tostring(t1.inferred_len))
+            if t1.inferred_len and t1.inferred_len > #t2.types then
+               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t2.types) .. ", got " .. tostring(t1.inferred_len))
             end
-            for i = 1, math.min(#t2, t1.inferred_len or math.huge) do
-               if not is_a(t2[i], t1.elements, for_equality) then
-                  return false, terr(t1, "tuple entry " .. tostring(i) .. " %s does not match array of %s", t2[i], t1.elements)
+            for i = 1, math.min(#t2.types, t1.inferred_len or math.huge) do
+               if not is_a(t2.types[i], t1.elements, for_equality) then
+                  return false, terr(t1, "tuple entry " .. tostring(i) .. " %s does not match array of %s", t2.types[i], t1.elements)
                end
             end
             return true
@@ -5517,17 +5535,17 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
       if a.typename == "tupletable" and is_a(b, NUMBER) then
          if idxnode.constnum then
-            if idxnode.constnum > #a
+            if idxnode.constnum > #a.types
                or idxnode.constnum < 1
                or idxnode.constnum ~= math.floor(idxnode.constnum)
             then
                return node_error(idxnode, "index " .. tostring(idxnode.constnum) .. " out of range for tuple %s", a)
             end
-            return a[idxnode.constnum]
+            return a.types[idxnode.constnum]
          else
             local array_type = arraytype_from_tuple(idxnode, a)
             if not array_type then
-               type_error(a, "tuple cannot be indexed with a variable")
+               type_error(a, "cannot index this tuple with a variable because it would produce a union type that cannot be discriminated at runtime")
                return UNKNOWN
             end
             return array_type.elements
@@ -6352,17 +6370,20 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                elseif child.ktype.typename == "number" then
                   is_array = true
                   is_tuple = true
+                  if not node.type.types then
+                     node.type.types = {}
+                  end
 
                   if node[i].key_parsed == "implicit" then
                      if i == #children and child.vtype.typename == "tuple" then
                         -- need to expand last item in an array (e.g { 1, 2, 3, f() })
                         for j, c in ipairs(child.vtype) do
                            node.type.elements = expand_type(node, node.type.elements, c)
-                           node.type[last_array_idx] = c
+                           node.type.types[last_array_idx] = resolve_tuple(c)
                            last_array_idx = last_array_idx + 1
                         end
                      else
-                        node.type[last_array_idx] = child.vtype
+                        node.type.types[last_array_idx] = resolve_tuple(child.vtype)
                         last_array_idx = last_array_idx + 1
                         node.type.elements = expand_type(node, node.type.elements, child.vtype)
                      end
@@ -6374,10 +6395,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                         node.type.keys = expand_type(node, node.type.keys, child.ktype)
                         node.type.values = expand_type(node, node.type.values, child.vtype)
                      elseif n then
-                        if node.type[n] then
+                        if node.type.types[n] then
                            node_error(node, "Overwriting index " .. n)
                         end
-                        node.type[n] = child.vtype
+                        node.type.types[n] = resolve_tuple(child.vtype)
                         if n > largest_array_idx then
                            largest_array_idx = n
                         end
@@ -6414,21 +6435,16 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
             elseif is_array then
                local pure_array = true
-               local last_idx = 1
-               for i = 2, largest_array_idx do
-                  if not node.type[i] then
-                     -- continue
-                  else
-                     if not node.type[last_idx] then
-                        last_idx = i
-                     else
-                        if not is_a(node.type[i], node.type[last_idx]) then
-                           pure_array = false
-                           break
-                        end
-                        last_idx = i
+
+               local last_t: Type
+               for _, current_t in pairs(node.type.types as {number:Type}) do
+                  if last_t then
+                     if not same_type(last_t, current_t) then
+                        pure_array = false
+                        break
                      end
                   end
+                  last_t = current_t
                end
 
                if not pure_array then

--- a/tl.tl
+++ b/tl.tl
@@ -1248,8 +1248,6 @@ local function parse_base_type(ps: ParseState, i: number): number, Type, number
       return i + 1, typ
    elseif ps.tokens[i].tk == "function" then
       return parse_function_type(ps, i)
-   -- elseif ps.tokens[i].tk == "[" then
-      -- return parse_tupletable_type(ps, i)
    elseif ps.tokens[i].tk == "{" then
       i = i + 1
       local decl = new_type(ps, i, "array")
@@ -1265,7 +1263,6 @@ local function parse_base_type(ps: ParseState, i: number): number, Type, number
          local n = 2
          repeat
             i = i + 1
-            local it: Type
             i, decl[n] = parse_type(ps, i)
             if not decl[n] then
                break
@@ -4724,7 +4721,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       }
       for i = 2, #tupletype do
          arr_type = expand_type(where, arr_type, a_type { elements = tupletype[i], typename = "array" })
-         if not arr_type then
+         if not arr_type or not arr_type.elements then
             return nil, terr(tupletype, "unable to convert tuple %s to array", tupletype)
          end
       end
@@ -4832,10 +4829,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                return true
             end
          elseif t1.typename == "tupletable" then
-            if t2.inferred_len then
-               if t2.inferred_len > #t1 then
-                  return false, terr(t2, "array is too long to fit into %s", t1)
-               end
+            if t2.inferred_len and t2.inferred_len > #t1 then
+                  -- return false, terr(t2, "array is too long to fit into %s", t1)
+               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t1) .. ", got " .. tostring(t2.inferred_len))
             end
             local u, err = arraytype_from_tuple(t1.inferred_at, t1)
             if not u then
@@ -4896,7 +4892,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          if t1.typename == "tupletable" then
             for i = 1, math.min(#t1, #t2) do
                if not is_a(t1[i], t2[i], for_equality) then
-                  return false, terr(t1, "in tuple entry " .. i .. ": got %s, expected %s", t1[i], t2[i])
+                  return false, terr(t1, "in tuple entry " .. tostring(i) .. ": got %s, expected %s", t1[i], t2[i])
                end
             end
             if for_equality and #t1 ~= #t2 then
@@ -5533,6 +5529,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             local array_type = arraytype_from_tuple(idxnode, a)
             if not array_type then
                type_error(a, "tuple cannot be indexed with a variable")
+               return UNKNOWN
             end
             return array_type.elements
          end
@@ -6226,8 +6223,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                      end
                   elseif exp1.e1.tk == "ipairs" then
                      if t.typename == "tupletable" then
-                        local arr_type = a_union(t)
-                        if not is_valid_union(arr_type) then
+                        local arr_type = arraytype_from_tuple(exp1.e2, t)
+                        if not arr_type then
                            node_error(exp1, "attempting ipairs loop on tuple that's not a valid array: %s", exp1.e2.type)
                         end
                      elseif not is_array_type(t) then
@@ -6370,7 +6367,6 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   node.type.values = expand_type(node, node.type.values, child.vtype)
                end
             end
-            node.type.inferred_len = array_len
             if is_array and is_map then
                node_error(node, "cannot determine type of table literal")
             elseif is_record and is_array then
@@ -6397,6 +6393,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   node.type.typename = "tupletable"
                else
                   node.type.typename = "array"
+                  node.type.inferred_len = array_len
                end
             elseif is_record then
                node.type.typename = "record"

--- a/tl.tl
+++ b/tl.tl
@@ -1232,25 +1232,6 @@ local function parse_function_type(ps: ParseState, i: number): number, Type
    return i, node
 end
 
-local function parse_tupletable_type(ps: ParseState, i: number): number, Type
-   local t = new_type(ps, i, "tupletable")
-   i = verify_tk(ps, i, "[")
-   local n = 1
-   while true do
-      i, t[n] = parse_type(ps, i)
-      if not t[n] then
-         break
-      end
-      if ps.tokens[i].tk == "," then
-         n = n + 1
-         i = i + 1
-      else
-         break
-      end
-   end
-   return verify_tk(ps, i, "]"), t
-end
-
 local function parse_base_type(ps: ParseState, i: number): number, Type, number
    if ps.tokens[i].tk == "string"
       or ps.tokens[i].tk == "boolean"
@@ -1267,8 +1248,8 @@ local function parse_base_type(ps: ParseState, i: number): number, Type, number
       return i + 1, typ
    elseif ps.tokens[i].tk == "function" then
       return parse_function_type(ps, i)
-   elseif ps.tokens[i].tk == "[" then
-      return parse_tupletable_type(ps, i)
+   -- elseif ps.tokens[i].tk == "[" then
+      -- return parse_tupletable_type(ps, i)
    elseif ps.tokens[i].tk == "{" then
       i = i + 1
       local decl = new_type(ps, i, "array")
@@ -1277,6 +1258,20 @@ local function parse_base_type(ps: ParseState, i: number): number, Type, number
       if ps.tokens[i].tk == "}" then
          decl.elements = t
          decl.yend = ps.tokens[i].y
+         i = verify_tk(ps, i, "}")
+      elseif ps.tokens[i].tk == "," then
+         decl.typename = "tupletable"
+         decl[1] = t
+         local n = 2
+         repeat
+            i = i + 1
+            local it: Type
+            i, decl[n] = parse_type(ps, i)
+            if not decl[n] then
+               break
+            end
+            n = n + 1
+         until ps.tokens[i].tk ~= ","
          i = verify_tk(ps, i, "}")
       elseif ps.tokens[i].tk == ":" then
          decl.typename = "map"
@@ -3427,7 +3422,7 @@ local function show_type_base(t: Type, seen: {Type:boolean}): string
       for i, v in ipairs(t) do
          table.insert(out, tostring(i) .. ": " .. show(v))
       end
-      return "[" .. table.concat(out, ", ") .. "]"
+      return "{" .. table.concat(out, ", ") .. "}"
    elseif t.typename == "poly" then
       local out: {string} = {}
       for _, v in ipairs(t.types) do
@@ -4765,6 +4760,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          elseif t1.typename == "tupletable" then
             local arr_len = math.huge
             if t2.inferred_len then
+               if t2.inferred_len > #t1 then
+                  return false, terr(t2, "array is too long to fit into %s", t1)
+               end
                arr_len = t2.inferred_len
             end
             for i = 1, math.min(#t1, arr_len) do
@@ -4824,14 +4822,20 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          if t1.typename == "tupletable" then
             for i = 1, math.min(#t1, #t2) do
                if not is_a(t1[i], t2[i], for_equality) then
-                  return false, terr(t1, "in tuple entry " .. i .. " got %s, expected %s", t1[i], t2[i])
+                  return false, terr(t1, "in tuple entry " .. i .. ": got %s, expected %s", t1[i], t2[i])
                end
             end
             if for_equality and #t1 ~= #t2 then
                return false, terr(t1, "tuples are not the same size")
             end
+            if #t1 > #t2 then
+               return false, terr(t1, "tuple %s is too big for tuple %s", t1, t2)
+            end
             return true
          elseif is_array_type(t1) then
+            if t1.inferred_len and t1.inferred_len > #t2 then
+               return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t2) .. ", got " .. tostring(t1.inferred_len))
+            end
             for i = 1, math.min(#t2, t1.inferred_len or math.huge) do
                if not is_a(t2[i], t1.elements, for_equality) then
                   return false, terr(t1, "tuple entry " .. tostring(i) .. " %s does not match array of %s", t2[i], t1.elements)
@@ -5974,6 +5978,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   t.declared_at = node
                   t.assigned_to = var.tk
                end
+               t.inferred_len = nil
                assert(var)
                add_var(var, var.tk, t, var.is_const)
 
@@ -6016,6 +6021,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                      t.declared_at = node
                      t.assigned_to = var.tk
                   end
+                  t.inferred_len = nil
                   add_global(var, var.tk, t, var.is_const)
 
                   dismiss_unresolved(var.tk)

--- a/tl.tl
+++ b/tl.tl
@@ -6354,6 +6354,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             local is_map = false
 
             local is_tuple = false
+            local is_not_tuple = false
+
             local last_array_idx = 1
             local largest_array_idx = -1
 
@@ -6369,7 +6371,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   table.insert(node.type.field_order, child.kname)
                elseif child.ktype.typename == "number" then
                   is_array = true
-                  is_tuple = true
+                  if not is_not_tuple then
+                     is_tuple = true
+                  end
                   if not node.type.types then
                      node.type.types = {}
                   end
@@ -6390,14 +6394,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   else -- explicit
                      local n = node[i].key.constnum
 
-                     if not n or not is_positive_int(n) then
-                        is_map = true
-                        node.type.keys = expand_type(node, node.type.keys, child.ktype)
-                        node.type.values = expand_type(node, node.type.values, child.vtype)
+                     if not is_positive_int(n) then
+                        node.type.elements = expand_type(node, node.type.elements, child.vtype)
+                        is_not_tuple = true
                      elseif n then
-                        if node.type.types[n] then
-                           node_error(node, "Overwriting index " .. n)
-                        end
+                        -- TODO: Implement warnings
+                        -- if node.type.types[n] then
+                        --    node_error(node, "Overwriting index " .. n)
+                        -- end
                         node.type.types[n] = resolve_tuple(child.vtype)
                         if n > largest_array_idx then
                            largest_array_idx = n
@@ -6434,24 +6438,29 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   node_error(node, "cannot determine type of table literal")
                end
             elseif is_array then
-               local pure_array = true
-
-               local last_t: Type
-               for _, current_t in pairs(node.type.types as {number:Type}) do
-                  if last_t then
-                     if not same_type(last_t, current_t) then
-                        pure_array = false
-                        break
-                     end
-                  end
-                  last_t = current_t
-               end
-
-               if not pure_array then
-                  node.type.typename = "tupletable"
-               else
+               if is_not_tuple then
                   node.type.typename = "array"
                   node.type.inferred_len = largest_array_idx - 1
+               else
+                  local pure_array = true
+
+                  local last_t: Type
+                  for _, current_t in pairs(node.type.types as {number:Type}) do
+                     if last_t then
+                        if not same_type(last_t, current_t) then
+                           pure_array = false
+                           break
+                        end
+                     end
+                     last_t = current_t
+                  end
+
+                  if not pure_array then
+                     node.type.typename = "tupletable"
+                  else
+                     node.type.typename = "array"
+                     node.type.inferred_len = largest_array_idx - 1
+                  end
                end
             elseif is_record then
                node.type.typename = "record"
@@ -6459,7 +6468,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                node.type.typename = "map"
             elseif is_tuple then
                node.type.typename = "tupletable"
-               if #node.type == 0 then
+               if not node.type.types or #node.type.types == 0 then
                   node_error(node, "cannot determine type of tuple elements")
                end
             end

--- a/tl.tl
+++ b/tl.tl
@@ -4675,7 +4675,6 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       local n_table_types = 0
       local n_function_types = 0
       local n_string_enum = 0
-      local has_primitive: {TypeName:boolean} = {}
       local has_primitive_string_type = false
       for _, t in ipairs(typ.types) do
          t = resolve_unary(t)

--- a/tl.tl
+++ b/tl.tl
@@ -6327,12 +6327,19 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                x = node.x,
                typename = "emptytable",
             }
+
+            local function is_positive_int(n: number): boolean
+               return n and n >= 1 and math.floor(n) == n
+            end
+
             local is_record = false
             local is_array = false
             local is_map = false
+
             local is_tuple = false
-            local array_len = 0
-            local pure_array = true
+            local last_array_idx = 1
+            local largest_array_idx = -1
+
             for i, child in ipairs(children) do
                assert(child.typename == "table_item")
                if child.kname then
@@ -6346,17 +6353,41 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                elseif child.ktype.typename == "number" then
                   is_array = true
                   is_tuple = true
-                  if i == #children and node[i].key_parsed == "implicit" and child.vtype.typename == "tuple" then
-                     -- need to expand last item in an array (e.g { 1, 2, 3, f() })
-                     for j, c in ipairs(child.vtype) do
-                        array_len = array_len + 1
-                        node.type.elements = expand_type(node, node.type.elements, c)
-                        node.type[i+j-1] = c
+
+                  if node[i].key_parsed == "implicit" then
+                     if i == #children and child.vtype.typename == "tuple" then
+                        -- need to expand last item in an array (e.g { 1, 2, 3, f() })
+                        for j, c in ipairs(child.vtype) do
+                           node.type.elements = expand_type(node, node.type.elements, c)
+                           node.type[last_array_idx] = c
+                           last_array_idx = last_array_idx + 1
+                        end
+                     else
+                        node.type[last_array_idx] = child.vtype
+                        last_array_idx = last_array_idx + 1
+                        node.type.elements = expand_type(node, node.type.elements, child.vtype)
                      end
-                  else
-                     array_len = array_len + 1
-                     node.type[i] = child.vtype
-                     node.type.elements = expand_type(node, node.type.elements, child.vtype)
+                  else -- explicit
+                     local n = node[i].key.constnum
+
+                     if not n or not is_positive_int(n) then
+                        is_map = true
+                        node.type.keys = expand_type(node, node.type.keys, child.ktype)
+                        node.type.values = expand_type(node, node.type.values, child.vtype)
+                     elseif n then
+                        if node.type[n] then
+                           node_error(node, "Overwriting index " .. n)
+                        end
+                        node.type[n] = child.vtype
+                        if n > largest_array_idx then
+                           largest_array_idx = n
+                        end
+                        node.type.elements = expand_type(node, node.type.elements, child.vtype)
+                     end
+                  end
+
+                  if last_array_idx > largest_array_idx then
+                     largest_array_idx = last_array_idx
                   end
                   if not node.type.elements then
                      is_array = false
@@ -6383,17 +6414,29 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   node_error(node, "cannot determine type of table literal")
                end
             elseif is_array then
-               for i = 2, #node.type do
-                  if not is_a(node.type[i], node.type[i-1]) then
-                     pure_array = false
-                     break
+               local pure_array = true
+               local last_idx = 1
+               for i = 2, largest_array_idx do
+                  if not node.type[i] then
+                     -- continue
+                  else
+                     if not node.type[last_idx] then
+                        last_idx = i
+                     else
+                        if not is_a(node.type[i], node.type[last_idx]) then
+                           pure_array = false
+                           break
+                        end
+                        last_idx = i
+                     end
                   end
                end
+
                if not pure_array then
                   node.type.typename = "tupletable"
                else
                   node.type.typename = "array"
-                  node.type.inferred_len = array_len
+                  node.type.inferred_len = largest_array_idx - 1
                end
             elseif is_record then
                node.type.typename = "record"


### PR DESCRIPTION
Adds a tuple-table type. The main things about this is that it changes how array types are inferred. Previously an array like `{ 1, "foo" }` would be inferred as `{number|string}`, this table now gets inferred as a tuple of the form `[number, string]`. To retain the array type, the inferred tuple is compatible with the array union type. Furthermore, any non-pure array will be inferred as a tuple instead, but can still be annotated as an array of a union.

Type inference of indexing also works with tuples where indexing them with a number literal will produce the correct type or produce an error if the index is out of range. Indexing them with a variable of the type number will produce a union of all the types in the tuple, appropriately erroring if the union contains multiple table types.

I've marked this as a draft as this was inspired by a specific use case and I haven't really considered _every_ implication this could have. My main concerns:

1. I'm not a huge fan of the square brackets syntax `[foo, bar, baz]`, I've also considered that most use cases for tuples with be with more than one element, so curly braces could be used instead. so `{foo, bar}` would be a tuple, `{foo}` would be an array (Edit: as of the most recent commit, this is how it works). Or the language could have a syntax/typedef overhaul and adopt standard generic types like `Array<foo>`, `Map<foo, bar>`, or `Tuple<foo, bar, baz>`. This also requires an overhaul of generics since they would need to accept any type instead of just nominals, and in the case of tuples would need to be variadic, so probably not. Or the Pascal/Ada route could be taken and more keywords could be added with `Array of foo`, `Map of foo, bar`, `Tuple of foo, bar, baz, ...`. These are both _drastic_ changes that I don't even know how I feel, but just suggestions :). (I'm definitely leaning towards `{foo, bar}` since using `[]` for a definition just doesn't _feel_ right in a Lua context)
2. The tests are very incomplete, so definitely don't even consider merging this until they are
3. ~~The current failing tests that weren't just changing error messages to have tuples in them are related to `table.unpack` with a tuple argument, so generics with tuples with have to be taken into consideration.~~ This has been fixed by improving the inference/conversion of tuples to arrays
4. I'm starting to be more familiar with the type-checking part of the codebase but some of the changes this makes I don't think I know the full implications of. In particular to help out with type inference of literals I keep track of the length of the array inferred in the type to make it so the following use case doesn't have a type error: `local my_tuple: [string, number, number] = { "a", 1 }`. But as types get copied around through inference this might have unintended consequences. (Edit: I believe the inferred length of array's is no longer passed around, so hopefully this shouldn't be an issue)

But, this has worked well for my use case of [implementing a neovim colorscheme where colors are defined as tuples of `[fg, bg, extra]`](https://github.com/euclidianAce/dotfiles/blob/master/nvim/teal/euclidian/config/colors.tl) and would love some feedback on it
