### PR TITLE
add support for more gsub function argument return values

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -3936,6 +3936,7 @@ local standard_library = {
                a_type({ typename = "function", args = { STRING, STRING, a_type({ typename = "map", keys = STRING, values = STRING }), NUMBER }, rets = { STRING, NUMBER } }),
                a_type({ typename = "function", args = { STRING, STRING, a_type({ typename = "function", args = { VARARG_STRING }, rets = { STRING } }) }, rets = { STRING, NUMBER } }),
                a_type({ typename = "function", args = { STRING, STRING, a_type({ typename = "function", args = { VARARG_STRING }, rets = { NUMBER } }) }, rets = { STRING, NUMBER } }),
+               a_type({ typename = "function", args = { STRING, STRING, a_type({ typename = "function", args = { VARARG_STRING }, rets = { BOOLEAN } }) }, rets = { STRING, NUMBER } }),
                a_type({ typename = "function", args = { STRING, STRING, a_type({ typename = "function", args = { VARARG_STRING }, rets = {} }) }, rets = { STRING, NUMBER } }),
 
             },

--- a/tl.lua
+++ b/tl.lua
@@ -3935,6 +3935,8 @@ local standard_library = {
                a_type({ typename = "function", args = { STRING, STRING, STRING, NUMBER }, rets = { STRING, NUMBER } }),
                a_type({ typename = "function", args = { STRING, STRING, a_type({ typename = "map", keys = STRING, values = STRING }), NUMBER }, rets = { STRING, NUMBER } }),
                a_type({ typename = "function", args = { STRING, STRING, a_type({ typename = "function", args = { VARARG_STRING }, rets = { STRING } }) }, rets = { STRING, NUMBER } }),
+               a_type({ typename = "function", args = { STRING, STRING, a_type({ typename = "function", args = { VARARG_STRING }, rets = { NUMBER } }) }, rets = { STRING, NUMBER } }),
+               a_type({ typename = "function", args = { STRING, STRING, a_type({ typename = "function", args = { VARARG_STRING }, rets = {} }) }, rets = { STRING, NUMBER } }),
 
             },
          }),

--- a/tl.tl
+++ b/tl.tl
@@ -3935,6 +3935,8 @@ local standard_library: {string:Type} = {
                a_type { typename = "function", args = { STRING, STRING, STRING, NUMBER }, rets = { STRING, NUMBER } },
                a_type { typename = "function", args = { STRING, STRING, a_type { typename = "map", keys = STRING, values = STRING }, NUMBER }, rets = { STRING, NUMBER } },
                a_type { typename = "function", args = { STRING, STRING, a_type { typename = "function", args = { VARARG_STRING }, rets = { STRING } } }, rets = { STRING, NUMBER } },
+               a_type { typename = "function", args = { STRING, STRING, a_type { typename = "function", args = { VARARG_STRING }, rets = { NUMBER } } }, rets = { STRING, NUMBER } },
+               a_type { typename = "function", args = { STRING, STRING, a_type { typename = "function", args = { VARARG_STRING }, rets = {} } }, rets = { STRING, NUMBER } },
                -- FIXME any other modes
             }
          },

--- a/tl.tl
+++ b/tl.tl
@@ -3936,6 +3936,7 @@ local standard_library: {string:Type} = {
                a_type { typename = "function", args = { STRING, STRING, a_type { typename = "map", keys = STRING, values = STRING }, NUMBER }, rets = { STRING, NUMBER } },
                a_type { typename = "function", args = { STRING, STRING, a_type { typename = "function", args = { VARARG_STRING }, rets = { STRING } } }, rets = { STRING, NUMBER } },
                a_type { typename = "function", args = { STRING, STRING, a_type { typename = "function", args = { VARARG_STRING }, rets = { NUMBER } } }, rets = { STRING, NUMBER } },
+               a_type { typename = "function", args = { STRING, STRING, a_type { typename = "function", args = { VARARG_STRING }, rets = { BOOLEAN } } }, rets = { STRING, NUMBER } },
                a_type { typename = "function", args = { STRING, STRING, a_type { typename = "function", args = { VARARG_STRING }, rets = {} } }, rets = { STRING, NUMBER } },
                -- FIXME any other modes
             }


### PR DESCRIPTION
The function argument of gsub can return a string, a number, `nil` or `false`.

This adds support for numbers and `nil`. I don't know how to encode `false` (I didn't want to add BOOLEAN which would incorrectly allow `true` but maybe I should).