### PR TITLE
Allow some array literals in assignment to heterogenous tuples

### DIFF
--- a/spec/assignment/to_tuple_spec.lua
+++ b/spec/assignment/to_tuple_spec.lua
@@ -12,4 +12,8 @@ describe("assignment to tuple", function()
    ]], {
       { msg = "incompatible length, expected maximum length of 2, got 3", y = 2 },
    }))
+   it("should allow an array literal when its length fits the tuple type", util.check([[
+      local t: {number, number, string}
+      t = {1, 2}
+   ]]))
 end)

--- a/spec/declaration/tuple_spec.lua
+++ b/spec/declaration/tuple_spec.lua
@@ -17,16 +17,20 @@ describe("tuple declarations", function()
    }))
 
    it("should report when an array is of incorrect type of a tuple entry", util.check_type_error([[
-      local a: {number, string} = { [-1] = "hi" } -- infers to {string}
-      local b: {number, string} = { "hi" } -- infers to {string}
-      local c: {string, number} = { [-1] = "hi" } -- infers to {string}
-      local d: {string, number} = { "hi" } -- infers to {string}
+      local a: {number, string} = { [-1] = "hi" } -- infers to {string} with a length of 0, which is incompatible with {number, string}
+      local b: {number, string} = { "hi" } -- infers to {string} with a length of 1, which is incompatible with {number, string}
+      local c: {string, number} = { [-1] = "hi" } -- infers to {string} with a length of 0, which should maybe be compatible with {string, number}?
    ]], {
       { y = 1, msg = "in local declaration: a: tuple entry 1 of type number does not match type of array elements, which is string" },
       { y = 2, msg = "in local declaration: b: tuple entry 1 of type number does not match type of array elements, which is string" },
       { y = 3, msg = "in local declaration: c: tuple entry 2 of type number does not match type of array elements, which is string" },
-      { y = 4, msg = "in local declaration: d: tuple entry 2 of type number does not match type of array elements, which is string" },
    }))
+
+   it("should allow array literals that fit within then tuple length", util.check [[
+      local a: {number, string} = { 1 }
+      local b: {boolean, boolean, number} = { false, true }
+      local c: {string, number} = { "hi" }
+   ]])
 
    it("should report when a tuple has incompatible entries", util.check_type_error([[
       local b: {number, string} = { 1, false }
@@ -48,6 +52,7 @@ describe("tuple declarations", function()
    pending("should error with explicit integer indices that are out of range", util.check_type_error([[
       local c: {number, string} = { [-1] = 10 }
    ]], {
-      { msg = "in local declaration: c: got {number : number}, expected {number, string}" },
+      -- Something about the table being a map or about -1 being out of range
+      -- { msg = "in local declaration: c: got {number : number}, expected {number, string}" },
    }))
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -5099,7 +5099,18 @@ tl.type_check = function(ast, opts)
             if t1.inferred_len and t1.inferred_len > #t2.types then
                return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t2.types) .. ", got " .. tostring(t1.inferred_len))
             end
-            for i = 1, #t2.types do
+
+
+
+
+            local len
+            if t1.inferred_len and t1.inferred_len > 0 then
+               len = t1.inferred_len
+            else
+               len = #t2.types
+            end
+
+            for i = 1, len do
                if not is_a(t2.types[i], t1.elements, for_equality) then
                   return false, terr(t1, "tuple entry " .. tostring(i) .. " of type %s does not match type of array elements, which is %s", t2.types[i], t1.elements)
                end

--- a/tl.tl
+++ b/tl.tl
@@ -5099,7 +5099,18 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             if t1.inferred_len and t1.inferred_len > #t2.types then
                return false, terr(t1, "incompatible length, expected maximum length of " .. tostring(#t2.types) .. ", got " .. tostring(t1.inferred_len))
             end
-            for i = 1, #t2.types do
+
+            -- for array literals (which is the only case where inferred_len is defined) only check the entries present
+            -- eg: local t: {number, string} = { 1 }
+            -- should be valid even though { 1 } is inferred as {number}
+            local len: number
+            if t1.inferred_len and t1.inferred_len > 0 then
+               len = t1.inferred_len
+            else
+               len = #t2.types
+            end
+
+            for i = 1, len do
                if not is_a(t2.types[i], t1.elements, for_equality) then
                   return false, terr(t1, "tuple entry " .. tostring(i) .. " of type %s does not match type of array elements, which is %s", t2.types[i], t1.elements)
                end


### PR DESCRIPTION
Previously arrays would outright be incompatible due to the entire tuple
being compared, but since the type of array literals now carry their
length, we now only check up to that length for compatability (provided
that it's positive*)

e.g. Assignments like `local t: {number, string}
= { 1 }` are now valid, where they previously weren't

More formally: One can imagine an array as an infinite tuple of a single
type. To compare an array to a tuple is to truncate the array to a tuple
of matching size, then compare component-wise. If that array has a
known/inferred length, then both tuples can be truncated to that length.

* Arguably "0 length" arrays could be treated as length 1 as the sort of
  'minimum' requirement for an array to match a tuple is at least the
  first element must match