### PR TITLE
Implement warnings

### DIFF
--- a/spec/error_reporting/warning_spec.lua
+++ b/spec/error_reporting/warning_spec.lua
@@ -61,4 +61,16 @@ describe("warnings", function()
    ]], {
       { y = 1, msg = "unused argument x: number" }
    }))
+
+   it("should not report that a narrowed variable is unused", util.check_warnings([[
+      local function foo(bar: string | number): string
+         if bar is string then
+            if string.sub(bar, 1, 1) == "#" then
+               bar = string.sub(bar, 2, -1)
+            end
+            bar = tonumber(bar, 16)
+         end
+      end
+      foo()
+   ]], { }))
 end)

--- a/spec/error_reporting/warning_spec.lua
+++ b/spec/error_reporting/warning_spec.lua
@@ -1,0 +1,64 @@
+local util = require("spec.util")
+
+describe("warnings", function()
+   it("reports redefined variables", util.check_warnings([[
+      local a = 1
+      local a = 2
+      print(a)
+   ]], {
+      { y = 2, msg = "redeclaration of variable 'a' (originally declared at 1:13)" },
+   }))
+
+   it("reports redefined variables in for loops", util.check_warnings([[
+      for i = 1, 10 do
+         local i = 15
+         print(i)
+      end
+
+      for k, v in pairs{'a', 'b', 'c'} do
+         local k = 2
+         local v = 'd'
+         print(k, v)
+      end
+   ]], {
+      { y = 2, msg = "redeclaration of variable 'i' (originally declared at 1:11)" },
+      { y = 7, msg = "redeclaration of variable 'k' (originally declared at 6:11)" },
+      { y = 8, msg = "redeclaration of variable 'v' (originally declared at 6:14)" },
+   }))
+
+   it("reports unused variables", util.check_warnings([[
+      local foo = "bar"
+   ]], {
+      { y = 1, msg = [[unused variable foo: string "bar"]] }
+   }))
+
+   it("doesn't report unused variables that start with '_'", util.check_warnings([[
+      local _foo = "bar"
+   ]], { }))
+
+   pending("reports both unused and redefined variables of the same name", util.check_warnings([[
+      local a = 10
+      do
+         local a = 12
+         print(a)
+      end
+   ]], {
+      { y = 3, msg = "redeclaration of variable 'a' (originally declared at 1:13)" },
+      { y = 1, msg = "unused variable 'a'" },
+   }))
+
+   it("reports unused functions as 'function' and not 'variable'", util.check_warnings([[
+      local function foo()
+      end
+   ]], {
+      { y = 1, msg = "unused function foo: function()" }
+   }))
+
+   it("reports unused function arguments as 'argument' and not 'variable'", util.check_warnings([[
+      local function foo(x: number)
+      end
+      foo()
+   ]], {
+      { y = 1, msg = "unused argument x: number" }
+   }))
+end)

--- a/spec/error_reporting/warning_spec.lua
+++ b/spec/error_reporting/warning_spec.lua
@@ -73,4 +73,10 @@ describe("warnings", function()
       end
       foo()
    ]], { }))
+
+   it("should report unused types", util.check_warnings([[
+      local type Foo = number
+   ]], {
+      { y = 1, msg = "unused type Foo: type number" }
+   }))
 end)

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -343,6 +343,31 @@ function util.check_syntax_error(code, syntax_errors)
    end
 end
 
+function util.check_warnings(code, warnings)
+   assert(type(code) == "string")
+   assert(type(warnings) == "table")
+
+   return function()
+      local result = tl.process_string(code)
+      assert.same(#warnings, #result.warnings, "Expected same amount of warnings:")
+      for i, warning in ipairs(warnings) do
+
+         if warning.y then
+            assert.same(warning.y, result.warnings[i].y, "[" .. i .. "] Expected same y location:")
+         end
+         if warning.x then
+            assert.same(warning.x, result.warnings[i].x,  "[" .. i .. "] Expected same x location:")
+         end
+         if warning.msg then
+            assert.match(warning.msg, result.warnings[i].msg, 1, true,  "[" .. i .. "] Expected messages to match:")
+         end
+         if warning.filename then
+            assert.match(warning.filename, result.warnings[i].filename, 1, true,  "[" .. i .. "] Expected filenames to match:")
+         end
+      end
+   end
+end
+
 local function gen(lax, code, expected)
    return function()
       local tokens = tl.lex(code)

--- a/tl
+++ b/tl
@@ -242,7 +242,9 @@ local function report_type_errors(result)
 end
 
 local function report_warnings(result)
-   report_errors("warning", result.warnings)
+   if not args["quiet"] then
+      report_errors("warning", result.warnings)
+   end
 end
 
 local env = nil

--- a/tl
+++ b/tl
@@ -241,6 +241,10 @@ local function report_type_errors(result)
    return not has_type_errors
 end
 
+local function report_warnings(result)
+   report_errors("warning", result.warnings)
+end
+
 local env = nil
 
 local function get_shared_library_ext()
@@ -327,6 +331,7 @@ local function type_check_file(file_name)
    if not ok then
       exit = 1
    end
+   report_warnings(result)
 
    if exit == 0 and tlconfig["quiet"] == false and #args["script"] == 1 then
       local output_file = get_output_filename(file_name)
@@ -789,6 +794,7 @@ for i, files in ipairs(sorted_source_file_arr) do
    end
    local ok = report_type_errors(result)
    if ok then
+      report_warnings(result)
       write_out(result, output_file)
    end
 end

--- a/tl.lua
+++ b/tl.lua
@@ -2218,7 +2218,7 @@ local function parse_variable_declarations(ps, i, node_name)
    if #asgn.vars == 0 then
       return fail(ps, i, "expected a local variable definition")
    end
-   local lhs = asgn.vars[1]
+
 
    i, asgn.decltype = parse_type_list(ps, i, "decltype")
 
@@ -2453,7 +2453,7 @@ local function recurse_type(ast, visit)
    end
 
    if ast.types then
-      for i, child in ipairs(ast.types) do
+      for _, child in ipairs(ast.types) do
          table.insert(xs, recurse_type(child, visit))
       end
    end
@@ -2552,7 +2552,7 @@ visit_type)
          cbs.before_statements(ast, xs)
       end
       xs[2] = recurse_node(ast.thenpart, visit_node, visit_type)
-      for i, e in ipairs(ast.elseifs) do
+      for _, e in ipairs(ast.elseifs) do
          table.insert(xs, recurse_node(e, visit_node, visit_type))
       end
       if ast.elsepart then
@@ -2762,14 +2762,14 @@ function tl.pretty_print_ast(ast, mode)
       increment_indent = nil
    end
 
-   local function add(out, s)
-      table.insert(out, s)
-   end
+
+
+
 
    local function add_string(out, s)
       table.insert(out, s)
       if string.find(s, "\n", 1, true) then
-         for nl in s:gmatch("\n") do
+         for _nl in s:gmatch("\n") do
             out.h = out.h + 1
          end
       end
@@ -2831,8 +2831,8 @@ function tl.pretty_print_ast(ast, mode)
          after = function(node, children)
             local out = { y = node.y, h = 0 }
             local space
-            for i, child in ipairs(children) do
-               add_child(out, children[i], space, indent)
+            for _, child in ipairs(children) do
+               add_child(out, child, space, indent)
                space = "; "
             end
             return out
@@ -2990,7 +2990,7 @@ function tl.pretty_print_ast(ast, mode)
          end,
       },
       ["break"] = {
-         after = function(node, children)
+         after = function(node, _children)
             local out = { y = node.y, h = 0 }
             table.insert(out, "break")
             return out
@@ -3196,14 +3196,14 @@ function tl.pretty_print_ast(ast, mode)
          end,
       },
       ["variable"] = {
-         after = function(node, children)
+         after = function(node, _children)
             local out = { y = node.y, h = 0 }
             add_string(out, node.tk)
             return out
          end,
       },
       ["newtype"] = {
-         after = function(node, children)
+         after = function(node, _children)
             local out = { y = node.y, h = 0 }
             if is_record_type(node.newtype.def) then
                table.insert(out, print_record_def(node.newtype.def))
@@ -3214,7 +3214,7 @@ function tl.pretty_print_ast(ast, mode)
          end,
       },
       ["goto"] = {
-         after = function(node, children)
+         after = function(node, _children)
             local out = { y = node.y, h = 0 }
             table.insert(out, "goto ")
             table.insert(out, node.label)
@@ -3222,7 +3222,7 @@ function tl.pretty_print_ast(ast, mode)
          end,
       },
       ["label"] = {
-         after = function(node, children)
+         after = function(node, _children)
             local out = { y = node.y, h = 0 }
             table.insert(out, "::")
             table.insert(out, node.label)
@@ -3235,7 +3235,7 @@ function tl.pretty_print_ast(ast, mode)
    local visit_type = {}
    visit_type.cbs = {
       ["string"] = {
-         after = function(typ, children)
+         after = function(typ, _children)
             local out = { y = typ.y, h = 0 }
             table.insert(out, primitive[typ.typename] or "table")
             return out
@@ -3563,7 +3563,7 @@ local function show_type_base(t, seen)
       return "(" .. table.concat(out, ", ") .. ")"
    elseif t.typename == "tupletable" then
       local out = {}
-      for i, v in ipairs(t.types) do
+      for _, v in ipairs(t.types) do
          table.insert(out, show(v))
       end
       return "{" .. table.concat(out, ", ") .. "}"
@@ -3698,10 +3698,12 @@ local Variable = {}
 
 
 
+
+
 local function fill_field_order(t)
    if t.typename == "record" then
       t.field_order = {}
-      for k, v in pairs(t.fields) do
+      for k in pairs(t.fields) do
          table.insert(t.field_order, k)
       end
       table.sort(t.field_order)
@@ -3717,20 +3719,20 @@ local function require_module(module_name, lax, env, result)
    end
    modules[module_name] = UNKNOWN
 
-   local found, fd, tried = tl.search_module(module_name, true)
+   local found, fd = tl.search_module(module_name, true)
    if found and (lax or found:match("tl$")) then
       fd:close()
-      local _result, err = tl.process(found, env, result)
-      assert(_result, err)
+      local found_result, err = tl.process(found, env, result)
+      assert(found_result, err)
 
-      if not _result.type then
-         _result.type = BOOLEAN
+      if not found_result.type then
+         found_result.type = BOOLEAN
       end
 
-      loaded[found] = _result
-      modules[module_name] = _result.type
+      loaded[found] = found_result
+      modules[module_name] = found_result.type
 
-      return _result.type, true
+      return found_result.type, true
    end
 
    return UNKNOWN, found ~= nil
@@ -4215,10 +4217,11 @@ local function add_compat53_entries(program, used_set)
       n = n + 1
    end
 
-   for i, name in ipairs(used_list) do
-      local mod, fn = name:match("([^.]*)%.(.*)")
-      local errs = {}
-      local text
+   for _, name in ipairs(used_list) do
+
+
+
+
       local code = compat53_code_cache[name]
       if not code then
 
@@ -4332,8 +4335,6 @@ tl.type_check = function(ast, opts)
       warnings = {},
    }
 
-   local stdlib_compat53 = get_stdlib_compat53(lax)
-
    local st = { opts.env.globals }
 
    local all_needs_compat53 = {}
@@ -4350,6 +4351,7 @@ tl.type_check = function(ast, opts)
             if i == 1 and scope[name].needs_compat53 then
                all_needs_compat53[name] = true
             end
+            scope[name].used = true
             return scope[name]
          end
       end
@@ -4535,7 +4537,7 @@ tl.type_check = function(ast, opts)
    end
 
    local function node_error(node, msg, ...)
-      local ok = type_error(node, msg, ...)
+      type_error(node, msg, ...)
       node.type = INVALID
       return node.type
    end
@@ -4561,6 +4563,7 @@ tl.type_check = function(ast, opts)
       else
          st[#st][var] = { t = valtype, is_const = is_const, is_narrowed = is_narrowing, declared_at = node }
       end
+      return st[#st][var]
    end
 
    local CompareTypes = {}
@@ -4594,7 +4597,7 @@ tl.type_check = function(ast, opts)
       if not src then
          return
       end
-      for i, err in ipairs(src) do
+      for _, err in ipairs(src) do
          err.msg = prefix .. err.msg
 
 
@@ -4627,7 +4630,7 @@ tl.type_check = function(ast, opts)
                table.insert(fielderrs, error_in_type(f, "unknown field " .. k))
             end
          else
-            local match, errs = cmp(f, t2k)
+            local __, errs = cmp(f, t2k)
             add_errs_prefixing(errs, fielderrs, "record field doesn't match: " .. k .. ": ")
          end
       end
@@ -4709,7 +4712,7 @@ tl.type_check = function(ast, opts)
          elseif t1.typevals and t2.typevals and #t1.typevals == #t2.typevals then
             local all_errs = {}
             for i = 1, #t1.typevals do
-               local ok, errs = same_type(t2.typevals[i], t1.typevals[i])
+               local _, errs = same_type(t2.typevals[i], t1.typevals[i])
                add_errs_prefixing(errs, all_errs, "type parameter <" .. show_type(t1.typevals[i]) .. ">: ", t1)
             end
             if #all_errs == 0 then
@@ -4793,7 +4796,7 @@ tl.type_check = function(ast, opts)
             arg_check(same_type, t1.args[i], t2.args[i], t1, i, all_errs)
          end
          for i = 1, #t1.rets do
-            local ok, errs = same_type(t1.rets[i], t2.rets[i])
+            local _, errs = same_type(t1.rets[i], t2.rets[i])
             add_errs_prefixing(errs, all_errs, "return " .. i, t1)
          end
          return any_errors(all_errs)
@@ -4895,9 +4898,9 @@ tl.type_check = function(ast, opts)
       return known_table_types[t.typename]
    end
 
-   local function resolve_union(typ)
-      assert(typ.typename == "union")
-   end
+
+
+
 
    local function is_valid_union(typ)
 
@@ -5214,7 +5217,7 @@ tl.type_check = function(ast, opts)
                nrets = nrets - 1
             end
             for i = 1, nrets do
-               local ok, errs = is_a(t1.rets[i], t2.rets[i])
+               local _, errs = is_a(t1.rets[i], t2.rets[i])
                add_errs_prefixing(errs, all_errs, "return " .. i .. ": ")
             end
          end
@@ -5267,14 +5270,33 @@ tl.type_check = function(ast, opts)
          return
       end
 
-      local match, match_errs = is_a(t1, t2)
+      local _, match_errs = is_a(t1, t2)
       add_errs_prefixing(match_errs, errors, "in " .. context .. ": " .. (name and (name .. ": ") or ""), node)
    end
 
    local function close_types(vars)
-      for name, var in pairs(vars) do
+      for _, var in pairs(vars) do
          if var.t.typename == "typetype" then
             var.t.closed = true
+         end
+      end
+   end
+
+   local function check_for_unused_vars(vars)
+      for name, var in pairs(vars) do
+         if var.declared_at and
+            not var.used and
+            name:sub(1, 1) ~= "_" then
+
+            node_warning(
+var.declared_at,
+"unused %s %s: %s",
+var.is_func_arg and "argument" or
+            var.t.typename == "function" and "function" or
+            "variable",
+name,
+show_type(var.t))
+
          end
       end
    end
@@ -5305,6 +5327,7 @@ tl.type_check = function(ast, opts)
          end
       end
       close_types(st[#st])
+      check_for_unused_vars(st[#st])
       table.remove(st)
    end
 
@@ -5635,7 +5658,7 @@ tl.type_check = function(ast, opts)
 
    local function add_function_definition_for_recursion(node)
       local args = {}
-      for i, arg in ipairs(node.args) do
+      for _, arg in ipairs(node.args) do
          table.insert(args, arg.type)
       end
 
@@ -5655,7 +5678,7 @@ tl.type_check = function(ast, opts)
                node_error(node, "no visible label '" .. name .. "' for goto")
             end
          end
-         for name, types in pairs(unresolved.t.nominals) do
+         for _, types in pairs(unresolved.t.nominals) do
             for _, typ in ipairs(types) do
                assert(typ.x)
                assert(typ.y)
@@ -6227,7 +6250,7 @@ tl.type_check = function(ast, opts)
          before = function()
             begin_scope()
          end,
-         after = function(node, children)
+         after = function(node, _children)
 
             if #st == 2 then
                fail_unresolved()
@@ -6244,7 +6267,7 @@ tl.type_check = function(ast, opts)
          before = function(node)
             add_var(node.var, node.var.tk, node.value.newtype, node.var.is_const)
          end,
-         after = function(node, children)
+         after = function(node, _children)
             dismiss_unresolved(node.var.tk)
             node.type = NONE
          end,
@@ -6253,7 +6276,7 @@ tl.type_check = function(ast, opts)
          before = function(node)
             add_global(node.var, node.var.tk, node.value.newtype, node.var.is_const)
          end,
-         after = function(node, children)
+         after = function(node, _children)
             local existing, existing_is_const = find_global(node.var.tk)
             local var = node.var
             if existing then
@@ -6396,7 +6419,7 @@ tl.type_check = function(ast, opts)
          end,
       },
       ["do"] = {
-         after = function(node, children)
+         after = function(node, _children)
             node.type = NONE
          end,
       },
@@ -6405,13 +6428,13 @@ tl.type_check = function(ast, opts)
             begin_scope()
             apply_facts(node.exp, node.exp.facts)
          end,
-         after = function(node, children)
+         after = function(node, _children)
             end_scope()
             node.type = NONE
          end,
       },
       ["elseif"] = {
-         before = function(node)
+         before = function(_node)
             end_scope()
             begin_scope()
          end,
@@ -6423,7 +6446,7 @@ tl.type_check = function(ast, opts)
             f = facts_and(f, node.exp.facts, node)
             apply_facts(node.exp, f)
          end,
-         after = function(node, children)
+         after = function(node, _children)
             node.type = NONE
          end,
       },
@@ -6437,7 +6460,7 @@ tl.type_check = function(ast, opts)
             end
             apply_facts(node, f)
          end,
-         after = function(node, children)
+         after = function(node, _children)
             node.type = NONE
          end,
       },
@@ -6450,7 +6473,7 @@ tl.type_check = function(ast, opts)
             begin_scope()
             apply_facts(node.exp, node.exp.facts)
          end,
-         after = function(node, children)
+         after = function(node, _children)
             end_scope()
             node.type = NONE
          end,
@@ -6472,7 +6495,7 @@ tl.type_check = function(ast, opts)
          end,
       },
       ["goto"] = {
-         after = function(node, children)
+         after = function(node, _children)
             if not find_var_type("::" .. node.label .. "::") then
                local unresolved = st[#st]["@unresolved"] and st[#st]["@unresolved"].t
                if not unresolved then
@@ -6490,7 +6513,7 @@ tl.type_check = function(ast, opts)
 
             widen_all_unions()
          end,
-         after = function(node, children)
+         after = function(node, _children)
 
             end_scope()
             node.type = NONE
@@ -6543,7 +6566,7 @@ tl.type_check = function(ast, opts)
                end
             end
          end,
-         after = function(node, children)
+         after = function(node, _children)
             end_scope()
             node.type = NONE
          end,
@@ -6553,7 +6576,7 @@ tl.type_check = function(ast, opts)
             begin_scope()
             add_var(node.var, node.var.tk, NUMBER)
          end,
-         after = function(node, children)
+         after = function(node, _children)
             end_scope()
             node.type = NONE
          end,
@@ -6654,7 +6677,7 @@ tl.type_check = function(ast, opts)
                   if node[i].key_parsed == "implicit" then
                      if i == #children and child.vtype.typename == "tuple" then
 
-                        for j, c in ipairs(child.vtype) do
+                        for _, c in ipairs(child.vtype) do
                            node.type.elements = expand_type(node, node.type.elements, c)
                            node.type.types[last_array_idx] = resolve_tuple(c)
                            last_array_idx = last_array_idx + 1
@@ -6671,9 +6694,6 @@ tl.type_check = function(ast, opts)
                         node.type.elements = expand_type(node, node.type.elements, child.vtype)
                         is_not_tuple = true
                      elseif n then
-                        if node.type.types[n] then
-                           node_warning(node, "Overwriting table index %d", n)
-                        end
                         node.type.types[n] = resolve_tuple(child.vtype)
                         if n > largest_array_idx then
                            largest_array_idx = n
@@ -6766,7 +6786,7 @@ tl.type_check = function(ast, opts)
          end,
       },
       ["local_function"] = {
-         before = function(node)
+         before = function(_node)
             begin_scope()
          end,
          before_statements = function(node)
@@ -6777,7 +6797,7 @@ tl.type_check = function(ast, opts)
             end_function_scope()
             local rets = get_rets(children[3])
 
-            add_var(nil, node.name.tk, a_type({
+            add_var(node, node.name.tk, a_type({
                typename = "function",
                args = children[2],
                rets = rets,
@@ -6786,7 +6806,7 @@ tl.type_check = function(ast, opts)
          end,
       },
       ["global_function"] = {
-         before = function(node)
+         before = function(_node)
             begin_scope()
          end,
          before_statements = function(node)
@@ -6804,7 +6824,7 @@ tl.type_check = function(ast, opts)
          end,
       },
       ["record_function"] = {
-         before = function(node)
+         before = function(_node)
             begin_scope()
          end,
          before_statements = function(node, children)
@@ -6853,14 +6873,14 @@ tl.type_check = function(ast, opts)
                end
             end
          end,
-         after = function(node, children)
+         after = function(node, _children)
             end_function_scope()
 
             node.type = NONE
          end,
       },
       ["function"] = {
-         before = function(node)
+         before = function(_node)
             begin_scope()
          end,
          before_statements = function(node)
@@ -6880,7 +6900,7 @@ tl.type_check = function(ast, opts)
          end,
       },
       ["cast"] = {
-         after = function(node, children)
+         after = function(node, _children)
             node.type = node.casttype
          end,
       },
@@ -6890,7 +6910,7 @@ tl.type_check = function(ast, opts)
          end,
       },
       ["op"] = {
-         before = function(node)
+         before = function(_node)
             begin_scope()
          end,
          before_e2 = function(node)
@@ -7025,7 +7045,7 @@ tl.type_check = function(ast, opts)
          end,
       },
       ["variable"] = {
-         after = function(node, children)
+         after = function(node, _children)
             if node.tk == "..." then
                local va_sentinel = find_var_type("@is_va")
                if not va_sentinel or va_sentinel.typename == "nil" then
@@ -7046,7 +7066,7 @@ tl.type_check = function(ast, opts)
          end,
       },
       ["argument"] = {
-         after = function(node, children)
+         after = function(node, _children)
             local t = node.decltype
             if not t then
                t = a_type({ typename = "unknown" })
@@ -7056,16 +7076,16 @@ tl.type_check = function(ast, opts)
             end
             check_typevars(node, t)
             node.type = t
-            add_var(node, node.tk, t)
+            add_var(node, node.tk, t).is_func_arg = true
          end,
       },
       ["identifier"] = {
-         after = function(node, children)
+         after = function(node, _children)
             node.type = NONE
          end,
       },
       ["newtype"] = {
-         after = function(node, children)
+         after = function(node, _children)
             node.type = node.newtype
          end,
       },
@@ -7078,7 +7098,7 @@ tl.type_check = function(ast, opts)
    visit_node.cbs["argument_list"] = visit_node.cbs["variables"]
 
    visit_node.cbs["string"] = {
-      after = function(node, children)
+      after = function(node, _children)
          node.type = a_type({
             y = node.y,
             x = node.x,
@@ -7094,7 +7114,7 @@ tl.type_check = function(ast, opts)
    visit_node.cbs["..."] = visit_node.cbs["variable"]
 
    visit_node.after = {
-      after = function(node, children)
+      after = function(node, _children)
          assert(type(node.type) == "table", node.kind .. " did not produce a type")
          assert(type(node.type.typename) == "string", node.kind .. " type does not have a typename")
          return node.type
@@ -7104,21 +7124,21 @@ tl.type_check = function(ast, opts)
    local visit_type = {
       cbs = {
          ["string"] = {
-            after = function(typ, children)
+            after = function(typ, _children)
                return typ
             end,
          },
          ["function"] = {
-            before = function(typ, children)
+            before = function(_typ, _children)
                begin_scope()
             end,
-            after = function(typ, children)
+            after = function(typ, _children)
                end_scope()
                return typ
             end,
          },
          ["record"] = {
-            before = function(typ, children)
+            before = function(typ, _children)
                begin_scope()
                for name, typ2 in pairs(typ.fields) do
                   if typ2.typename == "typetype" then
@@ -7127,9 +7147,9 @@ tl.type_check = function(ast, opts)
                   end
                end
             end,
-            after = function(typ, children)
+            after = function(typ, _children)
                end_scope()
-               for name, typ2 in pairs(typ.fields) do
+               for _, typ2 in pairs(typ.fields) do
                   if typ2.typename == "nestedtype" then
                      typ2.typename = "typetype"
                   end
@@ -7138,7 +7158,7 @@ tl.type_check = function(ast, opts)
             end,
          },
          ["typearg"] = {
-            after = function(typ, children)
+            after = function(typ, _children)
                add_var(nil, typ.typearg, a_type({
                   y = typ.y,
                   x = typ.x,
@@ -7149,7 +7169,7 @@ tl.type_check = function(ast, opts)
             end,
          },
          ["nominal"] = {
-            after = function(typ, children)
+            after = function(typ, _children)
                local t = find_type(typ.names, true)
                if t then
                   if t.typename == "typearg" then
@@ -7174,7 +7194,7 @@ tl.type_check = function(ast, opts)
             end,
          },
          ["union"] = {
-            after = function(typ, children)
+            after = function(typ, _children)
                local valid, err = is_valid_union(typ)
                if not valid then
                   type_error(typ, err, typ)
@@ -7184,7 +7204,7 @@ tl.type_check = function(ast, opts)
          },
       },
       after = {
-         after = function(typ, children, ret)
+         after = function(typ, _children, ret)
             assert(type(ret) == "table", typ.typename .. " did not produce a type")
             assert(type(ret.typename) == "string", "type node does not have a typename")
             return ret
@@ -7219,6 +7239,7 @@ tl.type_check = function(ast, opts)
    recurse_node(ast, visit_node, visit_type)
 
    close_types(st[1])
+   check_for_unused_vars(st[1])
 
    clear_redundant_errors(errors)
 
@@ -7244,7 +7265,7 @@ tl.process = function(filename, env, result, preload_modules)
       return nil, "could not read " .. filename .. ": " .. err
    end
 
-   local basename, extension = filename:match("(.*)%.([a-z]+)$")
+   local _, extension = filename:match("(.*)%.([a-z]+)$")
    extension = extension and extension:lower()
 
    local is_lua
@@ -7283,7 +7304,7 @@ filename)
 
    local tokens, errs = tl.lex(input)
    if errs then
-      for i, err in ipairs(errs) do
+      for _, err in ipairs(errs) do
          table.insert(result.syntax_errors, {
             y = err.y,
             x = err.x,
@@ -7293,7 +7314,7 @@ filename)
       end
    end
 
-   local i, program = tl.parse_program(tokens, result.syntax_errors, filename)
+   local _, program = tl.parse_program(tokens, result.syntax_errors, filename)
    if #result.syntax_errors > 0 then
       return result
    end
@@ -7358,7 +7379,7 @@ local function tl_package_loader(module_name)
             return ret
          end
       else
-         error("Internal Compiler Error: Teal generator produced invalid Lua. Please report a bug at https://github.com/teal-language/tl")
+         error("Internal Compiler Error: Teal generator produced invalid Lua. Please report a bug at https://github.com/teal-language/tl\n\n" .. err)
       end
    end
    return table.concat(tried, "\n\t")
@@ -7375,7 +7396,7 @@ end
 tl.load = function(input, chunkname, mode, env)
    local tokens = tl.lex(input)
    local errs = {}
-   local i, program = tl.parse_program(tokens, errs, chunkname)
+   local _, program = tl.parse_program(tokens, errs, chunkname)
    if #errs > 0 then
       return nil, (chunkname or "") .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg
    end

--- a/tl.lua
+++ b/tl.lua
@@ -5286,6 +5286,7 @@ tl.type_check = function(ast, opts)
       for name, var in pairs(vars) do
          if var.declared_at and
             not var.used and
+            not var.is_narrowed and
             name:sub(1, 1) ~= "_" then
 
             node_warning(

--- a/tl.lua
+++ b/tl.lua
@@ -48,6 +48,7 @@ local tl = {Env = {}, Result = {}, Error = {}, }
 
 
 
+
 local Result = tl.Result
 local Env = tl.Env
 local Error = tl.Error
@@ -1611,15 +1612,15 @@ do
          if ps.tokens[i].kind == "string" or ps.tokens[i].kind == "{" then
             local op = new_operator(ps.tokens[i], 2, "@funcall")
             local args = new_node(ps.tokens, i, "expression_list")
-            local arg
+            local argument
             if ps.tokens[i].kind == "string" then
-               arg = new_node(ps.tokens, i)
-               arg.conststr = unquote(ps.tokens[i].tk)
+               argument = new_node(ps.tokens, i)
+               argument.conststr = unquote(ps.tokens[i].tk)
                i = i + 1
             else
-               i, arg = parse_table_literal(ps, i)
+               i, argument = parse_table_literal(ps, i)
             end
-            table.insert(args, arg)
+            table.insert(args, argument)
             e1 = { y = t1.y, x = t1.x, kind = "op", op = op, e1 = e1, e2 = args }
          elseif ps.tokens[i].tk == "(" then
             local op = new_operator(ps.tokens[i], 2, "@funcall")
@@ -3696,6 +3697,7 @@ local Variable = {}
 
 
 
+
 local function fill_field_order(t)
    if t.typename == "record" then
       t.field_order = {}
@@ -4327,6 +4329,7 @@ tl.type_check = function(ast, opts)
       syntax_errors = {},
       type_errors = {},
       unknowns = {},
+      warnings = {},
    }
 
    local stdlib_compat53 = get_stdlib_compat53(lax)
@@ -4335,11 +4338,24 @@ tl.type_check = function(ast, opts)
 
    local all_needs_compat53 = {}
 
+   local warnings = result.warnings or {}
    local errors = result.type_errors or {}
    local unknowns = result.unknowns or {}
    local module_type
 
    local function find_var(name)
+      for i = #st, 1, -1 do
+         local scope = st[i]
+         if scope[name] then
+            if i == 1 and scope[name].needs_compat53 then
+               all_needs_compat53[name] = true
+            end
+            return scope[name]
+         end
+      end
+   end
+
+   local function find_var_type(name)
       if name == "_G" then
 
          local globals = {}
@@ -4358,16 +4374,9 @@ tl.type_check = function(ast, opts)
             fields = globals,
          }), false
       end
-      for i = #st, 1, -1 do
-         local scope = st[i]
-         if scope[name] then
-            if i == 1 and scope[name].needs_compat53 then
-               all_needs_compat53[name] = true
-            end
-            local typ = scope[name].t
-
-            return typ, scope[name].is_const
-         end
+      local var = find_var(name)
+      if var then
+         return var.t, var.is_const
       end
    end
 
@@ -4396,7 +4405,7 @@ tl.type_check = function(ast, opts)
       local orig_t = t
       local clear_tk = false
       if t.typename == "typevar" then
-         local tv = find_var(t.typevar)
+         local tv = find_var_type(t.typevar)
          if tv then
             t = tv
             clear_tk = true
@@ -4425,7 +4434,7 @@ tl.type_check = function(ast, opts)
    end
 
    local function find_type(names, accept_typearg)
-      local typ = find_var(names[1])
+      local typ = find_var_type(names[1])
       if not typ then
          return nil
       end
@@ -4516,6 +4525,15 @@ tl.type_check = function(ast, opts)
       end
    end
 
+   local function node_warning(node, fmt, ...)
+      table.insert(warnings, {
+         y = node.y,
+         x = node.x,
+         msg = fmt:format(...),
+         filename = filename,
+      })
+   end
+
    local function node_error(node, msg, ...)
       local ok = type_error(node, msg, ...)
       node.type = INVALID
@@ -4541,15 +4559,15 @@ tl.type_check = function(ast, opts)
          st[#st][var].is_narrowed = true
          st[#st][var].t = valtype
       else
-         st[#st][var] = { t = valtype, is_const = is_const, is_narrowed = is_narrowing }
+         st[#st][var] = { t = valtype, is_const = is_const, is_narrowed = is_narrowing, declared_at = node }
       end
    end
 
    local CompareTypes = {}
 
    local function compare_typevars(t1, t2, comp)
-      local tv1 = find_var(t1.typevar)
-      local tv2 = find_var(t2.typevar)
+      local tv1 = find_var_type(t1.typevar)
+      local tv2 = find_var_type(t2.typevar)
       if t1.typevar == t2.typevar then
          local has_t1 = not not tv1
          local has_t2 = not not tv2
@@ -4558,7 +4576,7 @@ tl.type_check = function(ast, opts)
          end
       end
       local function cmp(k, v, a, b)
-         if find_var(k) then
+         if find_var_type(k) then
             return comp(a, b)
          else
             add_var(nil, k, resolve_typevars(v))
@@ -4866,7 +4884,7 @@ tl.type_check = function(ast, opts)
 
    local resolve_unary = nil
 
-   local table_types = {
+   local known_table_types = {
       array = true,
       map = true,
       record = true,
@@ -4874,7 +4892,7 @@ tl.type_check = function(ast, opts)
       tupletable = true,
    }
    is_known_table_type = function(t)
-      return table_types[t.typename]
+      return known_table_types[t.typename]
    end
 
    local function resolve_union(typ)
@@ -5071,8 +5089,9 @@ tl.type_check = function(ast, opts)
             end
             return true
          elseif t1.typename == "map" then
-            local _, errs_keys = is_a(t1.keys, NUMBER)
-            local _, errs_values = is_a(t1.values, t2.elements)
+            local _, errs_keys, errs_values
+            _, errs_keys = is_a(t1.keys, NUMBER)
+            _, errs_values = is_a(t1.values, t2.elements)
             return combine_errs(errs_keys, errs_values)
          end
       elseif t2.typename == "record" then
@@ -5106,8 +5125,9 @@ tl.type_check = function(ast, opts)
          end
       elseif t2.typename == "map" then
          if t1.typename == "map" then
-            local _, errs_keys = is_a(t1.keys, t2.keys)
-            local _, errs_values = is_a(t2.values, t1.values)
+            local _, errs_keys, errs_values
+            _, errs_keys = is_a(t1.keys, t2.keys)
+            _, errs_values = is_a(t2.values, t1.values)
             if t2.values.typename == "any" then
                errs_values = {}
             end
@@ -5123,8 +5143,9 @@ tl.type_check = function(ast, opts)
             else
                elements = t1.elements
             end
-            local _, errs_keys = is_a(NUMBER, t2.keys)
-            local _, errs_values = is_a(elements, t2.values)
+            local _, errs_keys, errs_values
+            _, errs_keys = is_a(NUMBER, t2.keys)
+            _, errs_values = is_a(elements, t2.values)
             return combine_errs(errs_keys, errs_values)
          elseif is_record_type(t1) then
             if not is_a(t2.keys, STRING) then
@@ -5310,15 +5331,15 @@ tl.type_check = function(ast, opts)
          math.min(#args, #f.args)
 
          for a = 1, nargs do
-            local arg = args[a]
+            local argument = args[a]
             local farg = f.args[a] or (va and f.args[#f.args])
-            if arg == nil then
+            if argument == nil then
                if farg.is_va then
                   break
                end
             else
                local at = node.e2 and node.e2[a] or node
-               if not arg_check(is_a, arg, farg, at, (a + argdelta), errs) then
+               if not arg_check(is_a, argument, farg, at, (a + argdelta), errs) then
                   ok = false
                   break
                end
@@ -5329,10 +5350,10 @@ tl.type_check = function(ast, opts)
 
 
             for a = 1, #args do
-               local arg = args[a]
+               local argument = args[a]
                local farg = f.args[a] or (va and f.args[#f.args])
-               if arg.typename == "emptytable" then
-                  infer_var(arg, resolve_typevars(farg), node.e2[a])
+               if argument.typename == "emptytable" then
+                  infer_var(argument, resolve_typevars(farg), node.e2[a])
                end
             end
 
@@ -5478,7 +5499,7 @@ tl.type_check = function(ast, opts)
       tbl = resolve_unary(tbl)
       local type_description = tbl.typename
       if tbl.typename == "string" or tbl.typename == "enum" then
-         tbl = find_var("string")
+         tbl = find_var_type("string")
       end
 
       if lax and (is_unknown(tbl) or tbl.typename == "typevar") then
@@ -5585,7 +5606,7 @@ tl.type_check = function(ast, opts)
          return
       end
       if t.typename == "typevar" then
-         if not find_var(t.typevar) then
+         if not find_var_type(t.typevar) then
             node_error(node, "unknown type variable " .. t.typevar)
          end
          return
@@ -5894,7 +5915,7 @@ tl.type_check = function(ast, opts)
 
    local function find_in_scope(exp)
       if exp.kind == "variable" then
-         local t = find_var(exp.tk)
+         local t = find_var_type(exp.tk)
          if t.def then
             if not t.def.closed and not t.closed then
                return t.def
@@ -6083,7 +6104,7 @@ tl.type_check = function(ast, opts)
 
          local out = {}
          for v, fs in pairs(join_facts({ f1 })) do
-            local realtype = find_var(v)
+            local realtype = find_var_type(v)
             if realtype then
                realtype = resolve_unary(realtype)
                local ok, u = sum_facts(fs)
@@ -6277,6 +6298,18 @@ tl.type_check = function(ast, opts)
                   t.assigned_to = var.tk
                end
                t.inferred_len = nil
+
+               do
+                  local old_var = find_var(var.tk)
+                  if old_var then
+                     if old_var.declared_at then
+                        node_warning(var, "redeclaration of variable '%s' (originally declared at %d:%d)", var.tk, old_var.declared_at.y, old_var.declared_at.x)
+                     else
+                        node_warning(var, "redeclaration of variable '%s'", var.tk)
+                     end
+                  end
+               end
+
                assert(var)
                add_var(var, var.tk, t, var.is_const)
 
@@ -6339,7 +6372,7 @@ tl.type_check = function(ast, opts)
                end
                if varnode.kind == "variable" then
                   if widen_back_var(varnode.tk) then
-                     vartype = find_var(varnode.tk)
+                     vartype = find_var_type(varnode.tk)
                   end
                end
                if vartype then
@@ -6440,7 +6473,7 @@ tl.type_check = function(ast, opts)
       },
       ["goto"] = {
          after = function(node, children)
-            if not find_var("::" .. node.label .. "::") then
+            if not find_var_type("::" .. node.label .. "::") then
                local unresolved = st[#st]["@unresolved"] and st[#st]["@unresolved"].t
                if not unresolved then
                   unresolved = { typename = "unresolved", labels = {}, nominals = {} }
@@ -6518,7 +6551,7 @@ tl.type_check = function(ast, opts)
       ["fornum"] = {
          before = function(node)
             begin_scope()
-            add_var(nil, node.var.tk, NUMBER)
+            add_var(node.var, node.var.tk, NUMBER)
          end,
          after = function(node, children)
             end_scope()
@@ -6527,7 +6560,7 @@ tl.type_check = function(ast, opts)
       },
       ["return"] = {
          after = function(node, children)
-            local rets = assert(find_var("@return"))
+            local rets = assert(find_var_type("@return"))
             local nrets = #rets
             local vatype
             if nrets > 0 then
@@ -6638,10 +6671,9 @@ tl.type_check = function(ast, opts)
                         node.type.elements = expand_type(node, node.type.elements, child.vtype)
                         is_not_tuple = true
                      elseif n then
-
-
-
-
+                        if node.type.types[n] then
+                           node_warning(node, "Overwriting table index %d", n)
+                        end
                         node.type.types[n] = resolve_tuple(child.vtype)
                         if n > largest_array_idx then
                            largest_array_idx = n
@@ -6995,14 +7027,14 @@ tl.type_check = function(ast, opts)
       ["variable"] = {
          after = function(node, children)
             if node.tk == "..." then
-               local va_sentinel = find_var("@is_va")
+               local va_sentinel = find_var_type("@is_va")
                if not va_sentinel or va_sentinel.typename == "nil" then
                   node.type = UNKNOWN
                   node_error(node, "cannot use '...' outside a vararg function")
                end
             end
 
-            node.type, node.is_const = find_var(node.tk)
+            node.type, node.is_const = find_var_type(node.tk)
             if node.type == nil then
                node.type = a_type({ typename = "unknown" })
                if lax then
@@ -7130,7 +7162,7 @@ tl.type_check = function(ast, opts)
                   end
                else
                   local name = typ.names[1]
-                  local unresolved = find_var("@unresolved")
+                  local unresolved = find_var_type("@unresolved")
                   if not unresolved then
                      unresolved = { typename = "unresolved", labels = {}, nominals = {} }
                      add_var(nil, "@unresolved", unresolved)
@@ -7241,6 +7273,7 @@ filename)
       return env.loaded[filename]
    end
    result = {
+      warnings = result and result.warnings or {},
       syntax_errors = result and result.syntax_errors or {},
       type_errors = result and result.type_errors or {},
       unknowns = result and result.unknowns or {},
@@ -7274,7 +7307,7 @@ filename)
       end
    end
 
-   local error, unknown
+   local err, unknown
    local opts = {
       lax = is_lua,
       filename = filename,
@@ -7282,7 +7315,7 @@ filename)
       result = result,
       skip_compat53 = env.skip_compat53,
    }
-   error, unknown, result.type = tl.type_check(program, opts)
+   err, unknown, result.type = tl.type_check(program, opts)
 
    result.ast = program
    result.env = env

--- a/tl.lua
+++ b/tl.lua
@@ -5294,6 +5294,7 @@ var.declared_at,
 "unused %s %s: %s",
 var.is_func_arg and "argument" or
             var.t.typename == "function" and "function" or
+            is_type(var.t) and "type" or
             "variable",
 name,
 show_type(var.t))

--- a/tl.tl
+++ b/tl.tl
@@ -5286,6 +5286,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       for name, var in pairs(vars) do
          if var.declared_at
             and not var.used
+            and not var.is_narrowed
             and name:sub(1, 1) ~= "_"
          then
             node_warning(

--- a/tl.tl
+++ b/tl.tl
@@ -2218,7 +2218,7 @@ local function parse_variable_declarations(ps: ParseState, i: number, node_name:
    if #asgn.vars == 0 then
       return fail(ps, i, "expected a local variable definition")
    end
-   local lhs: Node = asgn.vars[1]
+   -- local lhs: Node = asgn.vars[1]
 
    i, asgn.decltype = parse_type_list(ps, i, "decltype")
 
@@ -2424,7 +2424,7 @@ local function visit_before<K,N,T>(ast: N, kind: K, visit: Visitor<K,N,T>): T
    end
 end
 
-local function visit_after<K,N,T>(ast: N, kind: K, visit: Visitor<K, N,T>, xs: {T}): T
+local function visit_after<K,N,T>(ast: N, kind: K, visit: Visitor<K,N,T>, xs: {T}): T
    if visit.after and visit.after.before then
       visit.after.before(ast, xs)
    end
@@ -2453,7 +2453,7 @@ local function recurse_type<T>(ast: Type, visit: Visitor<TypeName, Type, T>): T
    end
 
    if ast.types then
-      for i, child in ipairs(ast.types) do
+      for _, child in ipairs(ast.types) do
          table.insert(xs, recurse_type(child, visit))
       end
    end
@@ -2552,7 +2552,7 @@ local function recurse_node<T>(ast: Node,
          cbs.before_statements(ast, xs)
       end
       xs[2] = recurse_node(ast.thenpart, visit_node, visit_type)
-      for i, e in ipairs(ast.elseifs) do
+      for _, e in ipairs(ast.elseifs) do
          table.insert(xs, recurse_node(e, visit_node, visit_type))
       end
       if ast.elsepart then
@@ -2762,14 +2762,14 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
       increment_indent = nil
    end
 
-   local function add(out: Output, s: string)
-      table.insert(out, s)
-   end
+   -- local function add(out: Output, s: string)
+      -- table.insert(out, s)
+   -- end
 
    local function add_string(out: Output, s: string)
       table.insert(out, s)
       if string.find(s, "\n", 1, true) then
-         for nl in s:gmatch("\n") do
+         for _nl in s:gmatch("\n") do
             out.h = out.h + 1
          end
       end
@@ -2831,8 +2831,8 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
          after = function(node: Node, children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
             local space: string
-            for i, child in ipairs(children) do
-               add_child(out, children[i], space, indent)
+            for _, child in ipairs(children) do
+               add_child(out, child, space, indent)
                space = "; "
             end
             return out
@@ -2990,7 +2990,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
          end,
       },
       ["break"] = {
-         after = function(node: Node, children: {Output}): Output
+         after = function(node: Node, _children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
             table.insert(out, "break")
             return out
@@ -3196,14 +3196,14 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
          end,
       },
       ["variable"] = {
-         after = function(node: Node, children: {Output}): Output
+         after = function(node: Node, _children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
             add_string(out, node.tk)
             return out
          end,
       },
       ["newtype"] = {
-         after = function(node: Node, children: {Output}): Output
+         after = function(node: Node, _children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
             if is_record_type(node.newtype.def) then
                table.insert(out, print_record_def(node.newtype.def))
@@ -3214,7 +3214,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
          end,
       },
       ["goto"] = {
-         after = function(node: Node, children: {Output}): Output
+         after = function(node: Node, _children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
             table.insert(out, "goto ")
             table.insert(out, node.label)
@@ -3222,7 +3222,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
          end,
       },
       ["label"] = {
-         after = function(node: Node, children: {Output}): Output
+         after = function(node: Node, _children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
             table.insert(out, "::")
             table.insert(out, node.label)
@@ -3235,7 +3235,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
    local visit_type: Visitor<TypeName, Type, Output> = {}
    visit_type.cbs = {
       ["string"] = {
-         after = function(typ: Type, children: {Output}): Output
+         after = function(typ: Type, _children: {Output}): Output
             local out: Output = { y = typ.y, h = 0 }
             table.insert(out, primitive[typ.typename] or "table")
             return out
@@ -3563,7 +3563,7 @@ local function show_type_base(t: Type, seen: {Type:boolean}): string
       return "(" .. table.concat(out, ", ") .. ")"
    elseif t.typename == "tupletable" then
       local out: {string} = {}
-      for i, v in ipairs(t.types) do
+      for _, v in ipairs(t.types) do
          table.insert(out, show(v))
       end
       return "{" .. table.concat(out, ", ") .. "}"
@@ -3696,12 +3696,14 @@ local record Variable
    narrowed_from: Type
    is_narrowed: boolean
    declared_at: Node
+   is_func_arg: boolean
+   used: boolean
 end
 
 local function fill_field_order(t: Type)
    if t.typename == "record" then
       t.field_order = {}
-      for k, v in pairs(t.fields) do
+      for k in pairs(t.fields) do
          table.insert(t.field_order, k)
       end
       table.sort(t.field_order)
@@ -3717,20 +3719,20 @@ local function require_module(module_name: string, lax: boolean, env: Env, resul
    end
    modules[module_name] = UNKNOWN
 
-   local found, fd, tried = tl.search_module(module_name, true)
+   local found, fd = tl.search_module(module_name, true)
    if found and (lax or found:match("tl$") as boolean) then
       fd:close()
-      local _result, err: Result, string = tl.process(found, env, result)
-      assert(_result, err)
+      local found_result, err: Result, string = tl.process(found, env, result)
+      assert(found_result, err)
 
-      if not _result.type then
-         _result.type = BOOLEAN
+      if not found_result.type then
+         found_result.type = BOOLEAN
       end
 
-      loaded[found] = _result
-      modules[module_name] = _result.type
+      loaded[found] = found_result
+      modules[module_name] = found_result.type
 
-      return _result.type, true
+      return found_result.type, true
    end
 
    return UNKNOWN, found ~= nil
@@ -4215,10 +4217,11 @@ local function add_compat53_entries(program: Node, used_set: {string: boolean})
       n = n + 1
    end
 
-   for i, name in ipairs(used_list) do
-      local mod, fn = name:match("([^.]*)%.(.*)")
-      local errs = {}
-      local text: string
+   for _, name in ipairs(used_list) do
+      -- None of these are used?
+      -- local mod, fn = name:match("([^.]*)%.(.*)")
+      -- local errs = {}
+      -- local text: string
       local code: Node = compat53_code_cache[name]
       if not code then
          -- TODO generic support for individual functions
@@ -4332,8 +4335,6 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       warnings = {},
    }
 
-   local stdlib_compat53 = get_stdlib_compat53(lax)
-
    local st: {{string:Variable}} = { opts.env.globals }
 
    local all_needs_compat53 = {}
@@ -4350,6 +4351,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             if i == 1 and scope[name].needs_compat53 then
                all_needs_compat53[name] = true
             end
+            scope[name].used = true
             return scope[name]
          end
       end
@@ -4535,7 +4537,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    end
 
    local function node_error(node: Node, msg: string, ...:Type): Type
-      local ok = type_error(node as Type, msg, ...)
+      type_error(node as Type, msg, ...)
       node.type = INVALID
       return node.type
    end
@@ -4548,7 +4550,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       table.insert(unknowns, { y = node.y, x = node.x, msg = name, filename = filename })
    end
 
-   local function add_var(node: Node, var: string, valtype: Type, is_const: boolean, is_narrowing: boolean)
+   local function add_var(node: Node, var: string, valtype: Type, is_const: boolean, is_narrowing: boolean): Variable
       if lax and node and is_unknown(valtype) and (var ~= "self" and var ~= "...") then
          add_unknown(node, var)
       end
@@ -4561,6 +4563,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       else
          st[#st][var] = { t = valtype, is_const = is_const, is_narrowed = is_narrowing, declared_at = node }
       end
+      return st[#st][var]
    end
 
    local type CompareTypes = function(Type, Type, boolean): boolean, {Error}
@@ -4594,7 +4597,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       if not src then
          return
       end
-      for i, err in ipairs(src) do
+      for _, err in ipairs(src) do
          err.msg = prefix .. err.msg
 
          -- node.y may be nil because of `typ as Node` casts and not all types have .y set
@@ -4627,7 +4630,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                table.insert(fielderrs, error_in_type(f, "unknown field " .. k))
             end
          else
-            local match, errs = cmp(f, t2k)
+            local __, errs = cmp(f, t2k)
             add_errs_prefixing(errs, fielderrs, "record field doesn't match: " .. k .. ": ")
          end
       end
@@ -4709,7 +4712,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          elseif t1.typevals and t2.typevals and #t1.typevals == #t2.typevals then
             local all_errs = {}
             for i = 1, #t1.typevals do
-               local ok, errs = same_type(t2.typevals[i], t1.typevals[i])
+               local _, errs = same_type(t2.typevals[i], t1.typevals[i])
                add_errs_prefixing(errs, all_errs, "type parameter <" .. show_type(t1.typevals[i]) .. ">: ", t1 as Node)
             end
             if #all_errs == 0 then
@@ -4793,7 +4796,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             arg_check(same_type, t1.args[i], t2.args[i], t1 as Node, i, all_errs)
          end
          for i = 1, #t1.rets do
-            local ok, errs = same_type(t1.rets[i], t2.rets[i])
+            local _, errs = same_type(t1.rets[i], t2.rets[i])
             add_errs_prefixing(errs, all_errs, "return " .. i, t1 as Node)
          end
          return any_errors(all_errs)
@@ -4895,9 +4898,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       return known_table_types[t.typename]
    end
 
-   local function resolve_union(typ: Type)
-      assert(typ.typename == "union")
-   end
+   -- local function resolve_union(typ: Type)
+      -- assert(typ.typename == "union")
+   -- end
 
    local function is_valid_union(typ: Type): boolean, string
       -- check for limitations in our union support
@@ -5214,7 +5217,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                nrets = nrets - 1
             end
             for i = 1, nrets do
-               local ok, errs = is_a(t1.rets[i], t2.rets[i])
+               local _, errs = is_a(t1.rets[i], t2.rets[i])
                add_errs_prefixing(errs, all_errs, "return " .. i .. ": ")
             end
          end
@@ -5267,14 +5270,33 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          return
       end
 
-      local match, match_errs = is_a(t1, t2)
+      local _, match_errs = is_a(t1, t2)
       add_errs_prefixing(match_errs, errors, "in " .. context .. ": ".. (name and (name .. ": ") or ""), node)
    end
 
    local function close_types(vars: {string:Variable})
-      for name, var in pairs(vars) do
+      for _, var in pairs(vars) do
          if var.t.typename == "typetype" then
             var.t.closed = true
+         end
+      end
+   end
+
+   local function check_for_unused_vars(vars: {string:Variable})
+      for name, var in pairs(vars) do
+         if var.declared_at
+            and not var.used
+            and name:sub(1, 1) ~= "_"
+         then
+            node_warning(
+               var.declared_at,
+               "unused %s %s: %s",
+               var.is_func_arg and "argument"
+                  or var.t.typename == "function" and "function"
+                  or "variable",
+               name,
+               show_type(var.t)
+            )
          end
       end
    end
@@ -5305,6 +5327,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end
       end
       close_types(st[#st])
+      check_for_unused_vars(st[#st])
       table.remove(st)
    end
 
@@ -5635,7 +5658,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    local function add_function_definition_for_recursion(node: Node)
       local args = {}
-      for i, arg in ipairs(node.args) do
+      for _, arg in ipairs(node.args) do
          table.insert(args, arg.type)
       end
 
@@ -5655,7 +5678,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                node_error(node, "no visible label '" .. name .. "' for goto")
             end
          end
-         for name, types in pairs(unresolved.t.nominals) do
+         for _, types in pairs(unresolved.t.nominals) do
             for _, typ in ipairs(types) do
                assert(typ.x)
                assert(typ.y)
@@ -6227,7 +6250,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          before = function()
             begin_scope()
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             -- if at the top level
             if #st == 2 then
                fail_unresolved()
@@ -6244,7 +6267,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          before = function(node: Node)
             add_var(node.var, node.var.tk, node.value.newtype, node.var.is_const)
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             dismiss_unresolved(node.var.tk)
             node.type = NONE
          end,
@@ -6253,7 +6276,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          before = function(node: Node)
             add_global(node.var, node.var.tk, node.value.newtype, node.var.is_const)
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             local existing, existing_is_const = find_global(node.var.tk)
             local var = node.var
             if existing then
@@ -6396,7 +6419,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["do"] = {
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             node.type = NONE
          end,
       },
@@ -6405,13 +6428,13 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             begin_scope()
             apply_facts(node.exp, node.exp.facts)
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             end_scope()
             node.type = NONE
          end,
       },
       ["elseif"] = {
-         before = function(node: Node)
+         before = function(_node: Node)
             end_scope()
             begin_scope()
          end,
@@ -6423,7 +6446,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             f = facts_and(f, node.exp.facts, node)
             apply_facts(node.exp, f)
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             node.type = NONE
          end,
       },
@@ -6437,7 +6460,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
             apply_facts(node, f)
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             node.type = NONE
          end,
       },
@@ -6450,7 +6473,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             begin_scope()
             apply_facts(node.exp, node.exp.facts)
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             end_scope()
             node.type = NONE
          end,
@@ -6472,7 +6495,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["goto"] = {
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             if not find_var_type("::" .. node.label .. "::") then
                local unresolved = st[#st]["@unresolved"] and st[#st]["@unresolved"].t
                if not unresolved then
@@ -6490,7 +6513,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             -- widen all narrowed variables because we don't calculate a fixpoint yet
             widen_all_unions()
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             -- only end scope after checking `until`, `statements` in repeat body has is_return == true
             end_scope()
             node.type = NONE
@@ -6543,7 +6566,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
             end
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             end_scope()
             node.type = NONE
          end,
@@ -6553,7 +6576,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             begin_scope()
             add_var(node.var, node.var.tk, NUMBER)
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             end_scope()
             node.type = NONE
          end,
@@ -6654,7 +6677,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   if node[i].key_parsed == "implicit" then
                      if i == #children and child.vtype.typename == "tuple" then
                         -- need to expand last item in an array (e.g { 1, 2, 3, f() })
-                        for j, c in ipairs(child.vtype) do
+                        for _, c in ipairs(child.vtype) do
                            node.type.elements = expand_type(node, node.type.elements, c)
                            node.type.types[last_array_idx] = resolve_tuple(c)
                            last_array_idx = last_array_idx + 1
@@ -6671,9 +6694,6 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                         node.type.elements = expand_type(node, node.type.elements, child.vtype)
                         is_not_tuple = true
                      elseif n then
-                        if node.type.types[n] then
-                           node_warning(node, "Overwriting table index %d", n)
-                        end
                         node.type.types[n] = resolve_tuple(child.vtype)
                         if n > largest_array_idx then
                            largest_array_idx = n
@@ -6766,7 +6786,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["local_function"] = {
-         before = function(node: Node)
+         before = function(_node: Node)
             begin_scope()
          end,
          before_statements = function(node: Node)
@@ -6777,7 +6797,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end_function_scope()
             local rets = get_rets(children[3])
 
-            add_var(nil, node.name.tk, a_type {
+            add_var(node, node.name.tk, a_type {
                typename = "function",
                args = children[2],
                rets = rets,
@@ -6786,7 +6806,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["global_function"] = {
-         before = function(node: Node)
+         before = function(_node: Node)
             begin_scope()
          end,
          before_statements = function(node: Node)
@@ -6804,7 +6824,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["record_function"] = {
-         before = function(node: Node)
+         before = function(_node: Node)
             begin_scope()
          end,
          before_statements = function(node: Node, children: {Type})
@@ -6853,14 +6873,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
             end
          end,
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             end_function_scope()
 
             node.type = NONE
          end,
       },
       ["function"] = {
-         before = function(node: Node)
+         before = function(_node: Node)
             begin_scope()
          end,
          before_statements = function(node: Node)
@@ -6880,7 +6900,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["cast"] = {
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             node.type = node.casttype
          end
       },
@@ -6890,7 +6910,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["op"] = {
-         before = function(node: Node)
+         before = function(_node: Node)
             begin_scope()
          end,
          before_e2 = function(node: Node)
@@ -7025,7 +7045,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["variable"] = {
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             if node.tk == "..." then
                local va_sentinel = find_var_type("@is_va")
                if not va_sentinel or va_sentinel.typename == "nil" then
@@ -7046,7 +7066,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["argument"] = {
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             local t = node.decltype
             if not t then
                t = a_type { typename = "unknown" }
@@ -7056,16 +7076,16 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
             check_typevars(node, t)
             node.type = t
-            add_var(node, node.tk, t)
+            add_var(node, node.tk, t).is_func_arg = true
          end,
       },
       ["identifier"] = {
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             node.type = NONE -- type is resolved elsewhere
          end,
       },
       ["newtype"] = {
-         after = function(node: Node, children: {Type}): Type
+         after = function(node: Node, _children: {Type}): Type
             node.type = node.newtype
          end,
       }
@@ -7078,7 +7098,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    visit_node.cbs["argument_list"] = visit_node.cbs["variables"]
 
    visit_node.cbs["string"] = {
-      after = function(node: Node, children: {Type}): Type
+      after = function(node: Node, _children: {Type}): Type
          node.type = a_type {
             y = node.y,
             x = node.x,
@@ -7094,7 +7114,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    visit_node.cbs["..."] = visit_node.cbs["variable"]
 
    visit_node.after = {
-      after = function(node: Node, children: {Type}): Type
+      after = function(node: Node, _children: {Type}): Type
          assert(type(node.type) == "table", node.kind .. " did not produce a type")
          assert(type(node.type.typename) == "string", node.kind .. " type does not have a typename")
          return node.type
@@ -7104,21 +7124,21 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    local visit_type: Visitor<TypeName,Type,Type> = {
       cbs = {
          ["string"] = {
-            after = function(typ: Type, children: {Type}): Type
+            after = function(typ: Type, _children: {Type}): Type
                return typ
             end,
          },
          ["function"] = {
-            before = function(typ: Type, children: {Type})
+            before = function(_typ: Type, _children: {Type})
                begin_scope()
             end,
-            after = function(typ: Type, children: {Type}): Type
+            after = function(typ: Type, _children: {Type}): Type
                end_scope()
                return typ
             end,
          },
          ["record"] = {
-            before = function(typ: Type, children: {Type})
+            before = function(typ: Type, _children: {Type})
                begin_scope()
                for name, typ2 in pairs(typ.fields) do
                   if typ2.typename == "typetype" then
@@ -7127,9 +7147,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   end
                end
             end,
-            after = function(typ: Type, children: {Type}): Type
+            after = function(typ: Type, _children: {Type}): Type
                end_scope()
-               for name, typ2 in pairs(typ.fields) do
+               for _, typ2 in pairs(typ.fields) do
                   if typ2.typename == "nestedtype" then
                      typ2.typename = "typetype"
                   end
@@ -7138,7 +7158,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end,
          },
          ["typearg"] = {
-            after = function(typ: Type, children: {Type}): Type
+            after = function(typ: Type, _children: {Type}): Type
                add_var(nil, typ.typearg, a_type {
                   y = typ.y,
                   x = typ.x,
@@ -7149,7 +7169,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end,
          },
          ["nominal"] = {
-            after = function(typ: Type, children: {Type}): Type
+            after = function(typ: Type, _children: {Type}): Type
                local t = find_type(typ.names, true)
                if t then
                   if t.typename == "typearg" then
@@ -7174,7 +7194,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end,
          },
          ["union"] = {
-            after = function(typ: Type, children: {Type}): Type
+            after = function(typ: Type, _children: {Type}): Type
                local valid, err = is_valid_union(typ)
                if not valid then
                   type_error(typ, err, typ)
@@ -7184,7 +7204,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          },
       },
       after = {
-         after = function(typ: Type, children: {Type}, ret: Type): Type
+         after = function(typ: Type, _children: {Type}, ret: Type): Type
             assert(type(ret) == "table", typ.typename .. " did not produce a type")
             assert(type(ret.typename) == "string", "type node does not have a typename")
             return ret
@@ -7219,6 +7239,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    recurse_node(ast, visit_node, visit_type)
 
    close_types(st[1])
+   check_for_unused_vars(st[1])
 
    clear_redundant_errors(errors)
 
@@ -7244,7 +7265,7 @@ tl.process = function(filename: string, env: Env, result: Result, preload_module
       return nil, "could not read " .. filename .. ": " .. err
    end
 
-   local basename, extension = filename:match("(.*)%.([a-z]+)$")
+   local _, extension = filename:match("(.*)%.([a-z]+)$")
    extension = extension and extension:lower()
 
    local is_lua: boolean
@@ -7283,7 +7304,7 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
 
    local tokens, errs = tl.lex(input)
    if errs then
-      for i, err in ipairs(errs) do
+      for _, err in ipairs(errs) do
          table.insert(result.syntax_errors, {
             y = err.y,
             x = err.x,
@@ -7293,7 +7314,7 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
       end
    end
 
-   local i, program = tl.parse_program(tokens, result.syntax_errors, filename)
+   local _, program = tl.parse_program(tokens, result.syntax_errors, filename)
    if #result.syntax_errors > 0 then
       return result
    end
@@ -7358,7 +7379,7 @@ local function tl_package_loader(module_name: string): any
             return ret
          end
       else
-         error("Internal Compiler Error: Teal generator produced invalid Lua. Please report a bug at https://github.com/teal-language/tl")
+         error("Internal Compiler Error: Teal generator produced invalid Lua. Please report a bug at https://github.com/teal-language/tl\n\n" .. err)
       end
    end
    return table.concat(tried, "\n\t")
@@ -7375,7 +7396,7 @@ end
 tl.load = function(input: string, chunkname: string, mode: LoadMode, env: {any:any}): LoadFunction, string
    local tokens = tl.lex(input)
    local errs: {Error} = {}
-   local i, program = tl.parse_program(tokens, errs, chunkname)
+   local _, program = tl.parse_program(tokens, errs, chunkname)
    if #errs > 0 then
       return nil, (chunkname or "") .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg
    end

--- a/tl.tl
+++ b/tl.tl
@@ -5294,6 +5294,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                "unused %s %s: %s",
                var.is_func_arg and "argument"
                   or var.t.typename == "function" and "function"
+                  or is_type(var.t) and "type"
                   or "variable",
                name,
                show_type(var.t)

--- a/tl.tl
+++ b/tl.tl
@@ -37,6 +37,7 @@ local record tl
       syntax_errors: {Error}
       type_errors: {Error}
       unknowns: {Error}
+      warnings: {Error}
       env: Env
    end
 
@@ -1611,15 +1612,15 @@ do
          if ps.tokens[i].kind == "string" or ps.tokens[i].kind == "{" then
             local op: Operator = new_operator(ps.tokens[i], 2, "@funcall")
             local args = new_node(ps.tokens, i, "expression_list")
-            local arg: Node
+            local argument: Node
             if ps.tokens[i].kind == "string" then
-               arg = new_node(ps.tokens, i)
-               arg.conststr = unquote(ps.tokens[i].tk)
+               argument = new_node(ps.tokens, i)
+               argument.conststr = unquote(ps.tokens[i].tk)
                i = i + 1
             else
-               i, arg = parse_table_literal(ps, i)
+               i, argument = parse_table_literal(ps, i)
             end
-            table.insert(args, arg)
+            table.insert(args, argument)
             e1 = { y = t1.y, x = t1.x, kind = "op", op = op, e1 = e1, e2 = args }
          elseif ps.tokens[i].tk == "(" then
             local op: Operator = new_operator(ps.tokens[i], 2, "@funcall")
@@ -3694,6 +3695,7 @@ local record Variable
    needs_compat53: boolean
    narrowed_from: Type
    is_narrowed: boolean
+   declared_at: Node
 end
 
 local function fill_field_order(t: Type)
@@ -4327,6 +4329,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       syntax_errors = {},
       type_errors = {},
       unknowns = {},
+      warnings = {},
    }
 
    local stdlib_compat53 = get_stdlib_compat53(lax)
@@ -4335,11 +4338,24 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    local all_needs_compat53 = {}
 
+   local warnings: {Error} = result.warnings or {}
    local errors: {Error} = result.type_errors or {}
    local unknowns: {Error} = result.unknowns or {}
    local module_type: Type
 
-   local function find_var(name: string): Type, boolean
+   local function find_var(name: string): Variable
+      for i = #st, 1, -1 do
+         local scope = st[i]
+         if scope[name] then
+            if i == 1 and scope[name].needs_compat53 then
+               all_needs_compat53[name] = true
+            end
+            return scope[name]
+         end
+      end
+   end
+
+   local function find_var_type(name: string): Type, boolean
       if name == "_G" then
          -- this is a static approximation of _G
          local globals: {string:Type} = {}
@@ -4358,16 +4374,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             fields = globals,
          }, false
       end
-      for i = #st, 1, -1 do
-         local scope = st[i]
-         if scope[name] then
-            if i == 1 and scope[name].needs_compat53 then
-               all_needs_compat53[name] = true
-            end
-            local typ = scope[name].t
-
-            return typ, scope[name].is_const
-         end
+      local var = find_var(name)
+      if var then
+         return var.t, var.is_const
       end
    end
 
@@ -4396,7 +4405,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       local orig_t = t
       local clear_tk = false
       if t.typename == "typevar" then
-         local tv = find_var(t.typevar)
+         local tv = find_var_type(t.typevar)
          if tv then
             t = tv
             clear_tk = true
@@ -4425,7 +4434,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    end
 
    local function find_type(names: {string}, accept_typearg: boolean): Type
-      local typ = find_var(names[1])
+      local typ = find_var_type(names[1])
       if not typ then
          return nil
       end
@@ -4516,6 +4525,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
+   local function node_warning(node: Node, fmt: string, ...: any)
+      table.insert(warnings, {
+         y = node.y,
+         x = node.x,
+         msg = fmt:format(...),
+         filename = filename,
+      })
+   end
+
    local function node_error(node: Node, msg: string, ...:Type): Type
       local ok = type_error(node as Type, msg, ...)
       node.type = INVALID
@@ -4541,15 +4559,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          st[#st][var].is_narrowed = true
          st[#st][var].t = valtype
       else
-         st[#st][var] = { t = valtype, is_const = is_const, is_narrowed = is_narrowing }
+         st[#st][var] = { t = valtype, is_const = is_const, is_narrowed = is_narrowing, declared_at = node }
       end
    end
 
    local type CompareTypes = function(Type, Type, boolean): boolean, {Error}
 
    local function compare_typevars(t1: Type, t2: Type, comp: CompareTypes): boolean, {Error}
-      local tv1 = find_var(t1.typevar)
-      local tv2 = find_var(t2.typevar)
+      local tv1 = find_var_type(t1.typevar)
+      local tv2 = find_var_type(t2.typevar)
       if t1.typevar == t2.typevar then
          local has_t1 = not not tv1
          local has_t2 = not not tv2
@@ -4558,7 +4576,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end
       end
       local function cmp(k: string, v: Type, a: Type, b: Type): boolean, {Error}
-         if find_var(k) then
+         if find_var_type(k) then
             return comp(a, b)
          else
             add_var(nil, k, resolve_typevars(v))
@@ -4866,7 +4884,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    local resolve_unary: function(t: Type): Type = nil
 
-   local table_types: {TypeName:boolean} = {
+   local known_table_types: {TypeName:boolean} = {
       array = true,
       map = true,
       record = true,
@@ -4874,7 +4892,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       tupletable = true,
    }
    is_known_table_type = function(t: Type): boolean
-      return table_types[t.typename]
+      return known_table_types[t.typename]
    end
 
    local function resolve_union(typ: Type)
@@ -5071,8 +5089,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
             return true
          elseif t1.typename == "map" then
-            local _, errs_keys = is_a(t1.keys, NUMBER)
-            local _, errs_values = is_a(t1.values, t2.elements)
+            local _, errs_keys, errs_values: any, {Error}, {Error}
+            _, errs_keys = is_a(t1.keys, NUMBER)
+            _, errs_values = is_a(t1.values, t2.elements)
             return combine_errs(errs_keys, errs_values)
          end
       elseif t2.typename == "record" then
@@ -5106,8 +5125,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end
       elseif t2.typename == "map" then
          if t1.typename == "map" then
-            local _, errs_keys = is_a(t1.keys, t2.keys)
-            local _, errs_values = is_a(t2.values, t1.values)
+            local _, errs_keys, errs_values: any, {Error}, {Error}
+            _, errs_keys = is_a(t1.keys, t2.keys)
+            _, errs_values = is_a(t2.values, t1.values)
             if t2.values.typename == "any" then -- special-case hack for {any:any}
                errs_values = {}
             end
@@ -5123,8 +5143,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             else
                elements = t1.elements
             end
-            local _, errs_keys = is_a(NUMBER, t2.keys)
-            local _, errs_values = is_a(elements, t2.values)
+            local _, errs_keys, errs_values: any, {Error}, {Error}
+            _, errs_keys = is_a(NUMBER, t2.keys)
+            _, errs_values = is_a(elements, t2.values)
             return combine_errs(errs_keys, errs_values)
          elseif is_record_type(t1) then -- FIXME
             if not is_a(t2.keys, STRING) then
@@ -5310,15 +5331,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                        or math.min(#args, #f.args)
 
          for a = 1, nargs do
-            local arg = args[a]
+            local argument = args[a]
             local farg = f.args[a] or (va and f.args[#f.args])
-            if arg == nil then
+            if argument == nil then
                if farg.is_va then
                   break
                end
             else
                local at = node.e2 and node.e2[a] or node
-               if not arg_check(is_a, arg, farg, at, (a + argdelta), errs) then
+               if not arg_check(is_a, argument, farg, at, (a + argdelta), errs) then
                   ok = false
                   break
                end
@@ -5329,10 +5350,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
             -- resolve inference of emptytables used as arguments
             for a = 1, #args do
-               local arg = args[a]
+               local argument = args[a]
                local farg = f.args[a] or (va and f.args[#f.args])
-               if arg.typename == "emptytable" then
-                  infer_var(arg, resolve_typevars(farg), node.e2[a])
+               if argument.typename == "emptytable" then
+                  infer_var(argument, resolve_typevars(farg), node.e2[a])
                end
             end
 
@@ -5478,7 +5499,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       tbl = resolve_unary(tbl)
       local type_description = tbl.typename
       if tbl.typename == "string" or tbl.typename == "enum" then
-         tbl = find_var("string") -- simulate string metatable
+         tbl = find_var_type("string") -- simulate string metatable
       end
 
       if lax and (is_unknown(tbl) or tbl.typename == "typevar") then
@@ -5585,7 +5606,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          return
       end
       if t.typename == "typevar" then
-         if not find_var(t.typevar) then
+         if not find_var_type(t.typevar) then
             node_error(node, "unknown type variable " .. t.typevar)
          end
          return
@@ -5894,7 +5915,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    local function find_in_scope(exp: Node): Type
       if exp.kind == "variable" then
-         local t = find_var(exp.tk)
+         local t = find_var_type(exp.tk)
          if t.def then
             if not t.def.closed and not t.closed then
                return t.def
@@ -6083,7 +6104,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
          local out: {Fact} = {}
          for v, fs in pairs(join_facts({f1})) do
-            local realtype = find_var(v)
+            local realtype = find_var_type(v)
             if realtype then
                realtype = resolve_unary(realtype)
                local ok, u = sum_facts(fs) -- is this correct?
@@ -6277,6 +6298,18 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   t.assigned_to = var.tk
                end
                t.inferred_len = nil
+
+               do
+                  local old_var = find_var(var.tk)
+                  if old_var then
+                     if old_var.declared_at then
+                        node_warning(var, "redeclaration of variable '%s' (originally declared at %d:%d)", var.tk, old_var.declared_at.y, old_var.declared_at.x)
+                     else
+                        node_warning(var, "redeclaration of variable '%s'", var.tk)
+                     end
+                  end
+               end
+
                assert(var)
                add_var(var, var.tk, t, var.is_const)
 
@@ -6339,7 +6372,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
                if varnode.kind == "variable" then
                   if widen_back_var(varnode.tk) then
-                     vartype = find_var(varnode.tk)
+                     vartype = find_var_type(varnode.tk)
                   end
                end
                if vartype then
@@ -6440,7 +6473,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       },
       ["goto"] = {
          after = function(node: Node, children: {Type}): Type
-            if not find_var("::" .. node.label .. "::") then
+            if not find_var_type("::" .. node.label .. "::") then
                local unresolved = st[#st]["@unresolved"] and st[#st]["@unresolved"].t
                if not unresolved then
                   unresolved = { typename = "unresolved", labels = {}, nominals = {} }
@@ -6518,7 +6551,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       ["fornum"] = {
          before = function(node: Node)
             begin_scope()
-            add_var(nil, node.var.tk, NUMBER)
+            add_var(node.var, node.var.tk, NUMBER)
          end,
          after = function(node: Node, children: {Type}): Type
             end_scope()
@@ -6527,7 +6560,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       },
       ["return"] = {
          after = function(node: Node, children: {Type}): Type
-            local rets = assert(find_var("@return"))
+            local rets = assert(find_var_type("@return"))
             local nrets = #rets
             local vatype: Type
             if nrets > 0 then
@@ -6638,10 +6671,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                         node.type.elements = expand_type(node, node.type.elements, child.vtype)
                         is_not_tuple = true
                      elseif n then
-                        -- TODO: Implement warnings
-                        -- if node.type.types[n] then
-                        --    node_error(node, "Overwriting index " .. n)
-                        -- end
+                        if node.type.types[n] then
+                           node_warning(node, "Overwriting table index %d", n)
+                        end
                         node.type.types[n] = resolve_tuple(child.vtype)
                         if n > largest_array_idx then
                            largest_array_idx = n
@@ -6995,14 +7027,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       ["variable"] = {
          after = function(node: Node, children: {Type}): Type
             if node.tk == "..." then
-               local va_sentinel = find_var("@is_va")
+               local va_sentinel = find_var_type("@is_va")
                if not va_sentinel or va_sentinel.typename == "nil" then
                   node.type = UNKNOWN
                   node_error(node, "cannot use '...' outside a vararg function")
                end
             end
 
-            node.type, node.is_const = find_var(node.tk)
+            node.type, node.is_const = find_var_type(node.tk)
             if node.type == nil then
                node.type = a_type { typename = "unknown" }
                if lax then
@@ -7130,7 +7162,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   end
                else
                   local name = typ.names[1]
-                  local unresolved = find_var("@unresolved")
+                  local unresolved = find_var_type("@unresolved")
                   if not unresolved then
                      unresolved = { typename = "unresolved", labels = {}, nominals = {} }
                      add_var(nil, "@unresolved", unresolved)
@@ -7241,6 +7273,7 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
       return env.loaded[filename]
    end
    result = {
+      warnings = result and result.warnings or {},
       syntax_errors = result and result.syntax_errors or {},
       type_errors = result and result.type_errors or {},
       unknowns = result and result.unknowns or {},
@@ -7274,7 +7307,7 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
       end
    end
 
-   local error, unknown: {Error}, {Error}
+   local err, unknown: {Error}, {Error}
    local opts: TypeCheckOptions = {
       lax = is_lua,
       filename = filename,
@@ -7282,7 +7315,7 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
       result = result,
       skip_compat53 = env.skip_compat53,
    }
-   error, unknown, result.type = tl.type_check(program, opts)
+   err, unknown, result.type = tl.type_check(program, opts)
 
    result.ast = program
    result.env = env


### PR DESCRIPTION
A basic start on a warning system. Currently the only warnings implemented are for unused locals whose names aren't prefixed with an underscore (Stolen from Erlang, but I know there are other languages that ignore _ in similar manners, but not exactly in the same way), and redefined locals. So
```
local x = 10
print("hello world")
```
produces the result
```
$ tl check foo.tl
========================================
1 warning:
foo.tl:1:7: unused variable x: number
========================================
Type checked foo.tl
0 errors detected -- you can use:

   tl run foo.tl

       to run foo.tl as a program

   tl gen foo.tl

       to generate foo.lua

```
and editing it to
```
local _x = 10
print("hello world")
```
produces no warnings.

Additionally, unused arguments and unused functions will be annotated as such
```
local function foo()
end
```
results in
```
$ tl check foo.tl
========================================
1 warning:
foo.tl:1:1: unused function foo: function()
```
and
```
local function foo(x: number)
end
foo(10)
```
results in
```
$ tl check foo.tl
========================================
1 warning:
foo.tl:1:20: unused argument x: number
```

and
```
local a = 10
local a = 12
```
results in
```
$ tl check foo.tl
========================================
2 warnings:
foo.tl:2:7: redeclaration of variable 'a' (originally declared at 1:7)
foo.tl:2:7: unused variable a: number
```

Additionally, these types of warnings are very nice for a language server/linter

### Internal changes
 -  `node_warning` function that acts similarly to `node_error`
 -  add `warnings: {Error}` field to `Result`
 - `find_var` now returns the `Variable` that was found and `find_var_type` uses `find_var` and returns the type and `is_const` to replace the old behavior of `find_var`
 - adds fields to `Variable`
    - `declared_at: Node`
    - `used: boolean` - whenever a `Variable` is fetched using `find_var` this is set to `true`, when a scope is being closed, it checks this field for all the variables in it and generates warnings for unused ones 
    - `is_func_arg: boolean` - this one I'm not so sure is necessary, but was the easiest way to implement it. Maybe it could be useful for other things?
 - I went through `tl.tl` and eliminated all the warnings generated, hence the large diff :laughing: