### PR TITLE
Drop old syntax for nested records and enums

### DIFF
--- a/spec/declaration/enum_spec.lua
+++ b/spec/declaration/enum_spec.lua
@@ -96,4 +96,14 @@ describe("enum declaration", function()
       { y = 1, msg = "syntax error: this syntax is no longer valid; use 'global enum t'" },
       { msg = "syntax error" },
    }))
+
+   it("produces a nice error when attempting to nest in a table", util.check_syntax_error([[
+      local t = {
+         Point = enum
+            "hi"
+         end
+      }
+   ]], {
+      { y = 2, msg = "syntax error: this syntax is no longer valid; declare nested enum inside a record" },
+   }))
 end)

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -38,6 +38,17 @@ describe("records", function()
       { msg = "syntax error" },
    }))
 
+   it("produces a nice error when attempting to nest in a table", util.check_syntax_error([[
+      local t = {
+         Point = record
+            x: number
+            y: number
+         end
+      }
+   ]], {
+      { y = 2, msg = "syntax error: this syntax is no longer valid; declare nested record inside a record" },
+   }))
+
    it("can be declared with 'global type'", util.check [[
       global type Point = record
          x: number

--- a/spec/stdlib/require_spec.lua
+++ b/spec/stdlib/require_spec.lua
@@ -164,11 +164,11 @@ describe("require", function()
             return bar
          ]],
          ["bla.tl"] = [[
-            local bla = {
-               subtype = record
+            local type bla = record
+               record subtype
                   xx: number
                end
-            }
+            end
 
             function bla.func(): bla.subtype
                return { xx = 2 }
@@ -386,14 +386,14 @@ describe("require", function()
       -- ok
       util.mock_io(finally, {
          ["box.tl"] = [[
-            local box = {
-               Box = record
+            local record box
+               record Box
                   x: number
                   y: number
                   w: number
                   h: number
                end
-            }
+            end
 
             function box.foo(self: box.Box): string
                return "hello " .. tostring(self.w)

--- a/tl.lua
+++ b/tl.lua
@@ -1117,6 +1117,18 @@ local is_newtype = {
    ["record"] = true,
 }
 
+local SkipFunction = {}
+
+local function failskip(ps, i, msg, skip_fn, starti)
+   local err_ps = {
+      tokens = ps.tokens,
+      errs = {},
+   }
+   local skip_i = skip_fn(err_ps, starti or i)
+   fail(ps, starti or i, msg)
+   return skip_i or (i + 1)
+end
+
 local function parse_table_value(ps, i)
    if is_newtype[ps.tokens[i].tk] then
       return parse_newtype(ps, i)
@@ -2203,12 +2215,7 @@ local function parse_call_or_assignment(ps, i)
       return i, asgn
    end
    if #asgn.vars > 1 then
-      local err_ps = {
-         tokens = ps.tokens,
-         errs = {},
-      }
-      local expi = parse_expression(err_ps, tryi)
-      return fail(ps, expi or i)
+      return failskip(ps, i, nil, parse_expression, tryi)
    end
    if lhs.op and lhs.op.op == "@funcall" and #asgn.vars == 1 then
       return i, lhs

--- a/tl.tl
+++ b/tl.tl
@@ -1066,6 +1066,8 @@ local parse_argument_list: function(ParseState, number): number, Node
 local parse_argument_type_list: function(ParseState, number): number, Type
 local parse_type: function(ParseState, number): number, Type, number
 local parse_newtype: function(ps: ParseState, i: number): number, Node
+local parse_enum_body: function(ps: ParseState, i: number, def: Type, node: Node): number, Node
+local parse_record_body: function(ps: ParseState, i: number, def: Type, node: Node): number, Node
 
 local function fail(ps: ParseState, i: number, msg: string): number
    if not ps.tokens[i] then
@@ -1124,18 +1126,24 @@ local function failskip(ps: ParseState, i: number, msg: string, skip_fn: SkipFun
    return skip_i or (i + 1)
 end
 
-local is_newtype: {string:boolean} = {
-   ["enum"] = true,
-   ["record"] = true,
-}
+local function skip_record(ps: ParseState, i: number): number, Node
+   i = i + 1
+   return parse_record_body(ps, i, {}, {})
+end
 
-local function parse_table_value(ps: ParseState, i: number): number, Node
-   if is_newtype[ps.tokens[i].tk] then
-      return parse_newtype(ps, i)
-   else
-      local i2, node, _ = parse_expression(ps, i)
-      return i2, node
+local function skip_enum(ps: ParseState, i: number): number, Node
+   i = i + 1
+   return parse_enum_body(ps, i, {}, {})
+end
+
+local function parse_table_value(ps: ParseState, i: number): number, Node, number
+   local next_word = ps.tokens[i].tk
+   if next_word == "record" then
+      return failskip(ps, i, "syntax error: this syntax is no longer valid; declare nested record inside a record", skip_record)
+   elseif next_word == "enum" then
+      return failskip(ps, i, "syntax error: this syntax is no longer valid; declare nested enum inside a record", skip_enum)
    end
+   return parse_expression(ps, i)
 end
 
 local function parse_table_item(ps: ParseState, i: number, n: number): number, Node, number
@@ -2057,7 +2065,7 @@ local function parse_nested_type(ps: ParseState, i: number, def: Type, typename:
    return i
 end
 
-local function parse_enum_body(ps: ParseState, i: number, def: Type, node: Node): number, Node
+parse_enum_body = function(ps: ParseState, i: number, def: Type, node: Node): number, Node
    def.enumset = {}
    while not ((not ps.tokens[i]) or ps.tokens[i].tk == "end") do
       local item: Node
@@ -2072,7 +2080,7 @@ local function parse_enum_body(ps: ParseState, i: number, def: Type, node: Node)
    return i, node
 end
 
-local function parse_record_body(ps: ParseState, i: number, def: Type, node: Node): number, Node
+parse_record_body = function(ps: ParseState, i: number, def: Type, node: Node): number, Node
    def.fields = {}
    def.field_order = {}
    if ps.tokens[i].tk == "<" then

--- a/tl.tl
+++ b/tl.tl
@@ -1112,6 +1112,18 @@ local function verify_kind(ps: ParseState, i: number, kind: TokenKind, node_kind
    return fail(ps, i, "syntax error, expected " .. kind)
 end
 
+local type SkipFunction = function(ParseState, number): number, Node
+
+local function failskip(ps: ParseState, i: number, msg: string, skip_fn: SkipFunction, starti: number): number
+   local err_ps: ParseState = {
+      tokens = ps.tokens,
+      errs = {},
+   }
+   local skip_i = skip_fn(err_ps, starti or i)
+   fail(ps, starti or i, msg)
+   return skip_i or (i + 1)
+end
+
 local is_newtype: {string:boolean} = {
    ["enum"] = true,
    ["record"] = true,
@@ -2203,12 +2215,7 @@ local function parse_call_or_assignment(ps: ParseState, i: number): number, Node
       return i, asgn
    end
    if #asgn.vars > 1 then
-      local err_ps: ParseState = {
-         tokens = ps.tokens,
-         errs = {},
-      }
-      local expi = parse_expression(err_ps, tryi)
-      return fail(ps, expi or i)
+      return failskip(ps, i, nil, parse_expression, tryi)
    end
    if lhs.op and lhs.op.op == "@funcall" and #asgn.vars == 1 then
       return i, lhs


### PR DESCRIPTION
This is a remnant from when variable and type definitions were mixed. Let's switch to keeping types (with `local type T = D`, etc.) and variables (with `local V: T = E`) separate.

A run of this branch through `teal-types` showed that no definitions relied on that syntax, and the diff in the `require_spec.lua` tests that used the old syntax that it's easy to change it. (I also added code in the parser to detect and report to the user.)

(As a bonus, there's a new helper `failskip` in the parser which implements `fail` while skipping over a construct.)
