### PR TITLE
Metamethods

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -105,7 +105,7 @@ precedence, see below.
 
 *  newtype ::= ‘record’ recordbody | ‘enum’ enumbody | type
 
-*  recordbody ::= [typeargs] [‘{’ type ‘}’] {Name ‘=’ newtype} {recordkey ‘:’ type} ‘end’
+*  recordbody ::= [typeargs] [‘{’ type ‘}’] {Name ‘=’ newtype} {[‘metamethod’] recordkey ‘:’ type} ‘end’
 
 *  recordkey ::= Name | ‘[’ LiteralString ‘]’
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -421,7 +421,7 @@ where the record type is defined:
 
 ```
 function Point.new(x: number, y: number): Point
-   local self: Point = setmetatable({}, { __index = Point })
+   local self = setmetatable({} as Point, { __index = Point })
    self.x = x or 0
    self.y = y or 0
    return self

--- a/spec/call/string_method_spec.lua
+++ b/spec/call/string_method_spec.lua
@@ -35,10 +35,12 @@ describe("string method call", function()
    end)
    describe("chained", function()
       it("pass", util.gen([[
+
          print(("xy"):rep(12):sub(1,3))
          print(("%s"):format"%s":format(2))
          print(("%s b"):format"a":upper())
       ]], [[
+         local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) and require('compat53.module'); local string = _tl_compat53 and _tl_compat53.string or string
          print(("xy"):rep(12):sub(1,3))
          print(("%s"):format("%s"):format(2))
          print(("%s b"):format("a"):upper())

--- a/spec/compat/lua_versions_spec.lua
+++ b/spec/compat/lua_versions_spec.lua
@@ -1,0 +1,104 @@
+local tl = require("tl")
+local util = require("spec.util")
+
+describe("Lua version compatibility", function()
+   if _VERSION == "Lua 5.1" or _VERSION == "Lua 5.2" then
+      it("generates compat code for // operator", util.gen([[
+         function hello(n: number): number
+            return 9
+         end
+
+         local x = 124 // 3
+         local x = hello(12) // hello(hello(12) // 12)
+      ]], [[
+         function hello(n)
+            return 9
+         end
+
+         local x = math.floor(124 / 3)
+         local x = math.floor(hello(12) / hello(math.floor(hello(12) / 12)))
+      ]]))
+
+      it("generates compat code for bitwise operators", util.gen([[
+
+
+         local c = 0xcafebabe
+         local x = 2 & (c >> ~4 | 0xff)
+      ]], [[
+         local bit32 = bit32 or require('bit32')
+
+         local c = 0xcafebabe
+         local x = bit32.band(2, (bit32.bor(bit32.rshift(c, bit32.bnot(4)), 0xff)))
+      ]]))
+
+      it("generates compat code for bitwise unary operator metamethods", util.gen([[
+
+         local type Rec = record
+            x: number
+            metamethod __bnot: function(Rec): number
+         end
+
+         local rec_mt: metatable<Rec> = {
+            __bnot = function(self: Rec): number
+               return -self.x
+            end
+         }
+
+         local r = setmetatable({} as Rec, rec_mt)
+
+         print((~r) * 2)
+      ]], [[
+         local _tl_mt = function(m, s, a, b)    return (getmetatable(s == 1 and a or b)[m](a, b)) end
+         local Rec = {}
+
+
+
+
+         local rec_mt = {
+            __bnot = function(self)
+               return -self.x
+            end,
+         }
+
+         local r = setmetatable({}, rec_mt)
+
+         print((_tl_mt("__bnot", 1, r)) * 2)
+      ]]))
+
+      it("generates compat code for bitwise binary operator metamethods", util.gen([[
+
+         local type Rec = record
+            x: number
+            metamethod __shl: function(Rec, Rec): number
+         end
+
+         local rec_mt: metatable<Rec> = {
+            __shl = function(a: Rec, b: Rec): number
+               return a.x + b.x
+            end
+         }
+
+         local r = setmetatable({} as Rec, rec_mt)
+         local s = setmetatable({} as Rec, rec_mt)
+
+         print(r << s)
+      ]], [[
+         local _tl_mt = function(m, s, a, b)    return (getmetatable(s == 1 and a or b)[m](a, b)) end
+         local Rec = {}
+
+
+
+
+         local rec_mt = {
+            __shl = function(a, b)
+               return a.x + b.x
+            end,
+         }
+
+         local r = setmetatable({}, rec_mt)
+         local s = setmetatable({}, rec_mt)
+
+         print(_tl_mt("__shl", 1, r, s))
+      ]]))
+   end
+end)

--- a/spec/declaration/record_method_spec.lua
+++ b/spec/declaration/record_method_spec.lua
@@ -164,10 +164,10 @@ describe("record method", function()
                __index: Point
             end
 
-            Point.__index = Point as Point
+            Point.__index = Point
 
             function Point.new(x: number, y: number): Point
-               local self: Point = setmetatable({}, Point as METATABLE)
+               local self = setmetatable({} as Point, Point as metatable<Point>)
 
                self.x = x or 0
                self.y = y or 0
@@ -217,7 +217,10 @@ describe("record method", function()
    end)
 
    it("record method assignment must match record type", util.check_type_error([[
-      local foo_mt: METATABLE = {}
+      local type Foo = record
+         x: string
+      end
+      local foo_mt: metatable<Foo> = {}
       foo_mt.__tostring = function()
          return "hello"
       end
@@ -234,12 +237,12 @@ describe("record method", function()
                y: number
             end
 
-            local PointMetatable: METATABLE = {
+            local PointMetatable: metatable<Point> = {
                __index = Point
             }
 
             function Point.new(x: number, y: number): Point
-               local self = setmetatable({}, PointMetatable) as Point
+               local self = setmetatable({} as Point, PointMetatable)
 
                self.x = x or 0
                self.y = y or 0

--- a/spec/metamethods/add_spec.lua
+++ b/spec/metamethods/add_spec.lua
@@ -1,0 +1,49 @@
+local util = require("spec.util")
+
+describe("binary metamethod __add", function()
+   it("can be set on a record", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __call: function(Rec, string, number): string
+         metamethod __add: function(Rec, Rec): Rec
+      end
+
+      local rec_mt: metatable<Rec>
+      rec_mt = {
+         __call = function(self: Rec, s: string, n: number): string
+            return tostring(self.x + n) .. s
+         end,
+         __add = function(a: Rec, b: Rec): Rec
+            local res = setmetatable({} as Rec, rec_mt)
+            res.x = a.x + b.x
+            return res
+         end
+      }
+
+      local r = setmetatable({ x = 10 } as Rec, rec_mt)
+      local s = setmetatable({ x = 20 } as Rec, rec_mt)
+
+      print((r + s).x)
+      print(r("!!!", 34))
+   ]])
+
+   it("can be used via the second argument", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __add: function(number, Rec): Rec
+      end
+
+      local rec_mt: metatable<Rec>
+      rec_mt = {
+         __add = function(a: number, b: Rec): Rec
+            local res = setmetatable({} as Rec, rec_mt)
+            res.x = a + b.x
+            return res
+         end
+      }
+
+      local s = setmetatable({ y = 20 } as Rec, rec_mt)
+
+      print((10 + s).x)
+   ]])
+end)

--- a/spec/metamethods/bnot_spec.lua
+++ b/spec/metamethods/bnot_spec.lua
@@ -1,0 +1,37 @@
+local util = require("spec.util")
+
+describe("unary metamethod __bnot", function()
+   it("can be set on a record", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __bnot: function(Rec): string
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __bnot = function(self: Rec): string
+            return tostring(self.x)
+         end
+      }
+
+      local r = setmetatable({} as Rec, rec_mt)
+
+      print((~r):upper())
+   ]])
+
+   it("can return arbitrary types", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __bnot: function(Rec): Rec
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __bnot = function(self: Rec): Rec
+            return self
+         end
+      }
+
+      local r = setmetatable({} as Rec, rec_mt)
+
+      print((~r).x)
+   ]])
+end)

--- a/spec/metamethods/call_spec.lua
+++ b/spec/metamethods/call_spec.lua
@@ -1,0 +1,85 @@
+local util = require("spec.util")
+
+describe("metamethod __call", function()
+   it("can be set on a record", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __call: function(Rec, string, number): string
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __call = function(self: Rec, s: string, n: number): string
+            return tostring(self.x + n) .. s
+         end
+      }
+
+      local r = setmetatable({} as Rec, rec_mt)
+
+      r.x = 12
+      print(r("!!!", 34))
+   ]])
+
+   it("can type check arguments and argument count skips self", util.check_type_error([[
+      local type Rec = record
+         x: number
+         metamethod __call: function(Rec, string, number): string
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __call = function(self: Rec, s: string, n: number): string
+            return tostring(self.x + n) .. s
+         end
+      }
+
+      local r = setmetatable({} as Rec, rec_mt)
+
+      r.x = 12
+      print(r("!!!", r))
+   ]], {
+      { msg = "argument 2: got Rec, expected number" },
+   }))
+
+   it("cannot be typechecked if the metamethod is not defined in the record", util.check_type_error([[
+      local type Rec = record
+         x: number
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __call = function(self: Rec, s: string): string
+            return tostring(self.x) .. s
+         end
+      }
+
+      -- this is not sufficient to tell the compiler that r supports __call,
+      -- because setmetatable is a dynamic operation.
+      local r = setmetatable({} as Rec, rec_mt)
+
+      r.x = 12
+      print(r("!!!"))
+   ]], {
+      { msg = "not a function" }
+   }))
+
+   -- this is failing because the definition and implementations are not being cross-checked
+   -- this causes the test to output an error on line 15, because the call doesn't match the
+   -- metamethod definition inside Rec.
+   pending("record definition and implementations must match their types", util.check_type_error([[
+      local type Rec = record
+         x: number
+         metamethod __call: function(Rec, number, number): string
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __call = function(self: Rec, s: string): string
+            return tostring(self.x) .. s
+         end
+      }
+
+      local r = setmetatable({} as Rec, rec_mt)
+
+      r.x = 12
+      print(r("!!!"))
+   ]], {
+      { y = 7, msg = "in assignment: argument 2: got string, expected number" }
+   }))
+end)

--- a/spec/metamethods/idiv_spec.lua
+++ b/spec/metamethods/idiv_spec.lua
@@ -1,0 +1,44 @@
+local util = require("spec.util")
+
+describe("binary metamethod __idiv", function()
+   it("can be set on a record", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __idiv: function(Rec, Rec): Rec
+      end
+
+      local rec_mt: metatable<Rec>
+      rec_mt = {
+         __idiv = function(a: Rec, b: Rec): Rec
+            local res = setmetatable({} as Rec, rec_mt)
+            res.x = a.x // b.x
+            return res
+         end
+      }
+
+      local r = setmetatable({ x = 10 } as Rec, rec_mt)
+      local s = setmetatable({ y = 20 } as Rec, rec_mt)
+
+      print((r // s).x)
+   ]])
+
+   it("can be used via the second argument", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __idiv: function(number, Rec): Rec
+      end
+
+      local rec_mt: metatable<Rec>
+      rec_mt = {
+         __idiv = function(a: number, b: Rec): Rec
+            local res = setmetatable({} as Rec, rec_mt)
+            res.x = a // b.x
+            return res
+         end
+      }
+
+      local s = setmetatable({ y = 20 } as Rec, rec_mt)
+
+      print((10 // s).x)
+   ]])
+end)

--- a/spec/metamethods/len_spec.lua
+++ b/spec/metamethods/len_spec.lua
@@ -1,0 +1,37 @@
+local util = require("spec.util")
+
+describe("unary metamethod __len", function()
+   it("can be set on a record", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __len: function(Rec): string
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __len = function(self: Rec): string
+            return tostring(self.x)
+         end
+      }
+
+      local r = setmetatable({} as Rec, rec_mt)
+
+      print((#r):upper())
+   ]])
+
+   it("can return arbitrary types", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __len: function(Rec): Rec
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __len = function(self: Rec): Rec
+            return self
+         end
+      }
+
+      local r = setmetatable({} as Rec, rec_mt)
+
+      print((#r).x)
+   ]])
+end)

--- a/spec/metamethods/unm_spec.lua
+++ b/spec/metamethods/unm_spec.lua
@@ -1,0 +1,37 @@
+local util = require("spec.util")
+
+describe("unary metamethod __unm", function()
+   it("can be set on a record", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __unm: function(Rec): string
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __unm = function(self: Rec): string
+            return tostring(self.x)
+         end
+      }
+
+      local r = setmetatable({} as Rec, rec_mt)
+
+      print((-r):upper())
+   ]])
+
+   it("can return arbitrary types", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __unm: function(Rec): Rec
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __unm = function(self: Rec): Rec
+            return self
+         end
+      }
+
+      local r = setmetatable({} as Rec, rec_mt)
+
+      print((-r).x)
+   ]])
+end)

--- a/tl.tl
+++ b/tl.tl
@@ -3519,6 +3519,12 @@ local unop_types: {string:{string:Type}} = {
    },
 }
 
+local unop_to_metamethod: {string:string} = {
+   ["#"] = "__len",
+   ["-"] = "__unm",
+   ["~"] = "__bnot",
+}
+
 local binop_types: {string:{TypeName:{TypeName:Type}}} = {
    ["+"] = numeric_binop,
    ["-"] = numeric_binop,
@@ -3592,6 +3598,25 @@ local binop_types: {string:{TypeName:{TypeName:Type}}} = {
          ["enum"] = STRING,
       }
    },
+}
+
+local binop_to_metamethod: {string:string} = {
+   ["+"] = "__add",
+   ["-"] = "__sub",
+   ["*"] = "__mul",
+   ["/"] = "__div",
+   ["%"] = "__mod",
+   ["^"] = "__pow",
+   ["//"] = "__idiv",
+   ["&"] = "__band",
+   ["|"] = "__bor",
+   ["~"] = "__bxor",
+   ["<<"] = "__shl",
+   [">>"] = "__shr",
+   [".."] = "__concat",
+   ["=="] = "__eq",
+   ["<"] = "__lt",
+   ["<="] = "__le",
 }
 
 --local show_type: function(Type): string
@@ -3932,7 +3957,7 @@ local standard_library: {string:Type} = {
             ["__call"] = a_type { typename = "function", args = VARARG { ALPHA, ANY }, rets = VARARG { ANY } },
             ["__gc"] = a_type { typename = "function", args = { ALPHA }, rets = {} },
             ["__index"] = ANY, -- FIXME: function | table | anything with an __index metamethod
-            ["__len"] = a_type { typename = "function", args = { ALPHA }, rets = { NUMBER } },
+            ["__len"] = a_type { typename = "function", args = { ALPHA }, rets = { ANY } },
             ["__mode"] = a_type { typename = "enum", enumset = { ["k"] = true, ["v"] = true, ["kv"] = true, } },
             ["__newindex"] = ANY, -- FIXME: function | table | anything with a __newindex metamethod
             ["__pairs"] = a_type { typeargs = { ARG_ALPHA, ARG_BETA }, typename = "function", args = { a_type { typename = "map", keys = ALPHA, values = BETA } }, rets = {
@@ -3940,24 +3965,24 @@ local standard_library: {string:Type} = {
             } },
             ["__tostring"] = a_type { typename = "function", args = { ALPHA }, rets = { STRING } },
             ["__name"] = STRING,
-            ["__add"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__sub"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__mul"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__div"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__idiv"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__mod"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__pow"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__unm"] = a_type { typename = "function", args = { ALPHA }, rets = { ANY } },
-            ["__band"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__bor"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__bxor"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__bnot"] = a_type { typename = "function", args = { ALPHA }, rets = { ANY } },
-            ["__shl"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__shr"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__concat"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
-            ["__eq"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { BOOLEAN } },
-            ["__lt"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { BOOLEAN } },
-            ["__le"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { BOOLEAN } },
+            ["__add"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__sub"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__mul"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__div"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__idiv"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__mod"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__pow"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__unm"] = a_type { typename = "function", args = { ANY }, rets = { ANY } },
+            ["__band"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__bor"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__bxor"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__bnot"] = a_type { typename = "function", args = { ANY }, rets = { ANY } },
+            ["__shl"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__shr"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__concat"] = a_type { typename = "function", args = { ANY, ANY }, rets = { ANY } },
+            ["__eq"] = a_type { typename = "function", args = { ANY, ANY }, rets = { BOOLEAN } },
+            ["__lt"] = a_type { typename = "function", args = { ANY, ANY }, rets = { BOOLEAN } },
+            ["__le"] = a_type { typename = "function", args = { ANY, ANY }, rets = { BOOLEAN } },
          },
       },
    },
@@ -4289,20 +4314,18 @@ local function add_compat53_entries(program: Node, used_set: {string: boolean})
    end
 
    for _, name in ipairs(used_list) do
-      local code: Node = compat53_code_cache[name]
-      if not code then
-         -- TODO generic support for individual functions
-         if name == "table.unpack" then
-            load_code(name, "local _tl_table_unpack = unpack or table.unpack")
-         elseif name == "bit32" then
-            load_code(name, "local bit32 = bit32 or require('bit32')")
-         else
-            if not compat53_loaded then
-               load_code("compat53", "local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) and require('compat53.module')")
-               compat53_loaded = true
-            end
-            load_code(name, (("local $NAME = _tl_compat53 and _tl_compat53.$NAME or $NAME"):gsub("$NAME", name)))
+      if name == "table.unpack" then
+         load_code(name, "local _tl_table_unpack = unpack or table.unpack")
+      elseif name == "bit32" then
+         load_code(name, "local bit32 = bit32 or require('bit32')")
+      elseif name == "mt" then
+         load_code(name, "local _tl_mt = function(m, s, a, b) return (getmetatable(s == 1 and a or b)[m](a, b) end")
+      else
+         if not compat53_loaded then
+            load_code("compat53", "local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) and require('compat53.module')")
+            compat53_loaded = true
          end
+         load_code(name, (("local $NAME = _tl_compat53 and _tl_compat53.$NAME or $NAME"):gsub("$NAME", name)))
       end
    end
    program.y = 1
@@ -4354,6 +4377,18 @@ local function convert_node_to_compat_call(node: Node, mod_name: string, fn_name
    node.e2 = { y = node.y, x = node.x, kind = "argument_list" }
    node.e2[1] = e1
    node.e2[2] = e2
+end
+
+local function convert_node_to_compat_mt_call(node: Node, mt_name: string, which_self: number, e1: Node, e2: Node)
+   node.op.op = "@funcall"
+   node.op.arity = 2
+   node.op.prec = 100
+   node.e1 = { y = node.y, x = node.x, kind = "identifier", tk = "_tl_mt" }
+   node.e2 = { y = node.y, x = node.x, kind = "argument_list" }
+   node.e2[1] = { y = node.y, x = node.x, kind = "string", tk = "\"" .. mt_name .. "\"" }
+   node.e2[2] = { y = node.y, x = node.x, kind = "number", tk = tostring(which_self) }
+   node.e2[3] = e1
+   node.e2[4] = e2
 end
 
 local function init_globals(lax: boolean): {string:Variable}
@@ -7099,8 +7134,12 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                a = ua
                local types_op = unop_types[node.op.op]
                node.type = types_op[a.typename]
+               local metamethod: Type
                if not node.type then
-                  if lax and is_unknown(a) then
+                  metamethod = a.meta_fields and a.meta_fields[unop_to_metamethod[node.op.op] or ""]
+                  if metamethod then
+                     node.type = resolve_unary(type_check_function_call(node, metamethod, {a}, false, 0))
+                  elseif lax and is_unknown(a) then
                      node.type = UNKNOWN
                   else
                      node_error(node, "cannot use operator '" .. node.op.op:gsub("%%", "%%%%") .. "' on type %s", orig_a)
@@ -7108,8 +7147,13 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
 
                if node.op.op == "~" and (_VERSION == "Lua 5.1" or _VERSION == "Lua 5.2") then
-                  all_needs_compat53["bit32"] = true
-                  convert_node_to_compat_call(node, "bit32", "bnot", node.e1)
+                  if metamethod then
+                     all_needs_compat53["mt"] = true
+                     convert_node_to_compat_mt_call(node, unop_to_metamethod[node.op.op], 1, node.e1)
+                  else
+                     all_needs_compat53["bit32"] = true
+                     convert_node_to_compat_call(node, "bit32", "bnot", node.e1)
+                  end
                end
 
             elseif node.op.arity == 2 and binop_types[node.op.op] then
@@ -7121,8 +7165,17 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                b = ub
                local types_op = binop_types[node.op.op]
                node.type = types_op[a.typename] and types_op[a.typename][b.typename]
+               local metamethod: Type
+               local meta_self = 1
                if not node.type then
-                  if lax and (is_unknown(a) or is_unknown(b)) then
+                  metamethod = a.meta_fields and a.meta_fields[binop_to_metamethod[node.op.op] or ""]
+                  if not metamethod then
+                     metamethod = b.meta_fields and b.meta_fields[binop_to_metamethod[node.op.op] or ""]
+                     meta_self = 2
+                  end
+                  if metamethod then
+                     node.type = resolve_unary(type_check_function_call(node, metamethod, {a, b}, false, 0))
+                  elseif lax and (is_unknown(a) or is_unknown(b)) then
                      node.type = UNKNOWN
                   else
                      node_error(node, "cannot use operator '" .. node.op.op:gsub("%%", "%%%%") .. "' for types %s and %s", orig_a, orig_b)
@@ -7130,11 +7183,21 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
 
                if node.op.op == "//" and (_VERSION == "Lua 5.1" or _VERSION == "Lua 5.2") then
-                  local div: Node = { y = node.y, x = node.x, kind = "op", op = an_operator(node, 2, "/"), e1 = node.e1, e2 = node.e2 }
-                  convert_node_to_compat_call(node, "math", "floor", div)
+                  if metamethod then
+                     all_needs_compat53["mt"] = true
+                     convert_node_to_compat_mt_call(node, "__idiv", meta_self, node.e1, node.e2)
+                  else
+                     local div: Node = { y = node.y, x = node.x, kind = "op", op = an_operator(node, 2, "/"), e1 = node.e1, e2 = node.e2 }
+                     convert_node_to_compat_call(node, "math", "floor", div)
+                  end
                elseif bit_operators[node.op.op] and (_VERSION == "Lua 5.1" or _VERSION == "Lua 5.2") then
-                  all_needs_compat53["bit32"] = true
-                  convert_node_to_compat_call(node, "bit32", bit_operators[node.op.op], node.e1, node.e2)
+                  if metamethod then
+                     all_needs_compat53["mt"] = true
+                     convert_node_to_compat_mt_call(node, binop_to_metamethod[node.op.op], meta_self, node.e1, node.e2)
+                  else
+                     all_needs_compat53["bit32"] = true
+                     convert_node_to_compat_call(node, "bit32", bit_operators[node.op.op], node.e1, node.e2)
+                  end
                end
             else
                error("unknown node op " .. node.op.op)

--- a/tl.tl
+++ b/tl.tl
@@ -849,6 +849,8 @@ local record Type
    typeargs: {Type}
    fields: {string: Type}
    field_order: {string}
+   meta_fields: {string: Type}
+   meta_field_order: {string}
 
    -- array
    elements: Type
@@ -2087,6 +2089,31 @@ parse_enum_body = function(ps: ParseState, i: number, def: Type, node: Node): nu
    return i, node
 end
 
+local metamethod_names: {string:boolean} = {
+   ["__add"] = true,
+   ["__sub"] = true,
+   ["__mul"] = true,
+   ["__div"] = true,
+   ["__mod"] = true,
+   ["__pow"] = true,
+   ["__unm"] = true,
+   ["__idiv"] = true,
+   ["__band"] = true,
+   ["__bor"] = true,
+   ["__bxor"] = true,
+   ["__bnot"] = true,
+   ["__shl"] = true,
+   ["__shr"] = true,
+   ["__concat"] = true,
+   ["__len"] = true,
+   ["__eq"] = true,
+   ["__lt"] = true,
+   ["__le"] = true,
+   ["__index"] = true,
+   ["__newindex"] = true,
+   ["__call"] = true,
+}
+
 parse_record_body = function(ps: ParseState, i: number, def: Type, node: Node): number, Node
    def.fields = {}
    def.field_order = {}
@@ -2132,6 +2159,12 @@ parse_record_body = function(ps: ParseState, i: number, def: Type, node: Node): 
       elseif ps.tokens[i].tk == "enum" and ps.tokens[i+1].tk ~= ":" then
          i = parse_nested_type(ps, i, def, "enum", parse_enum_body)
       else
+         local is_metamethod = false
+         if ps.tokens[i].tk == "metamethod" and ps.tokens[i+1].tk ~= ":" then
+            is_metamethod = true
+            i = i + 1
+         end
+
          local v: Node
          if ps.tokens[i].tk == "[" then
             i, v = parse_literal(ps, i+1)
@@ -2146,8 +2179,9 @@ parse_record_body = function(ps: ParseState, i: number, def: Type, node: Node): 
          if not v then
             return fail(ps, i, "expected a variable name")
          end
+
          if ps.tokens[i].tk == ":" then
-            i = verify_tk(ps, i, ":")
+            i = i + 1
             local t: Type
             i, t = parse_type(ps, i)
             if not t then
@@ -2155,14 +2189,27 @@ parse_record_body = function(ps: ParseState, i: number, def: Type, node: Node): 
             end
 
             local field_name = v.conststr or v.tk
-            if not def.fields[field_name] then
-               def.fields[field_name] = t
-               table.insert(def.field_order, field_name)
+            local fields = def.fields
+            local field_order = def.field_order
+            if is_metamethod then
+               if not def.meta_fields then
+                  def.meta_fields = {}
+                  def.meta_field_order = {}
+               end
+               fields = def.meta_fields
+               field_order = def.meta_field_order
+               if not metamethod_names[field_name] then
+                  fail(ps, i - 1, "not a valid metamethod: " .. field_name)
+               end
+            end
+            if not fields[field_name] then
+               fields[field_name] = t
+               table.insert(field_order, field_name)
             else
-               local prev_t = def.fields[field_name]
+               local prev_t = fields[field_name]
                if t.typename == "function" and prev_t.typename == "function" then
-                  def.fields[field_name] = new_type(ps, iv, "poly")
-                  def.fields[field_name].types = { prev_t, t }
+                  fields[field_name] = new_type(ps, iv, "poly")
+                  fields[field_name].types = { prev_t, t }
                elseif t.typename == "function" and prev_t.typename == "poly" then
                   table.insert(prev_t.types, t)
                else
@@ -3347,7 +3394,7 @@ local THREAD = a_type { typename = "thread" }
 local INVALID = a_type { typename = "invalid" }
 local UNKNOWN = a_type { typename = "unknown" }
 local NOMINAL_FILE = a_type { typename = "nominal", names = {"FILE"} }
-local NOMINAL_METATABLE = a_type { typename = "nominal", names = {"METATABLE"} }
+local NOMINAL_METATABLE_OF_ALPHA = a_type { typename = "nominal", names = {"metatable"}, typevals = { ALPHA } }
 
 local OS_DATE_TABLE = a_type {
    typename = "record",
@@ -3778,7 +3825,7 @@ local standard_library: {string:Type} = {
    ["collectgarbage"] = a_type { typename = "function", args = { STRING }, rets = { a_type { typename = "union", types = { BOOLEAN, NUMBER } }, NUMBER, NUMBER } },
    ["dofile"] = a_type { typename = "function", args = { OPT_STRING }, rets = VARARG { ANY } },
    ["error"] = a_type { typename = "function", args = { STRING, NUMBER }, rets = {} },
-   ["getmetatable"] = a_type { typename = "function", args = { ANY }, rets = { NOMINAL_METATABLE } },
+   ["getmetatable"] = a_type { typename = "function", typeargs = { ARG_ALPHA }, args = { ALPHA }, rets = { NOMINAL_METATABLE_OF_ALPHA } },
    ["ipairs"] = a_type { typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA }, rets = {
       a_type { typename = "function", args = {}, rets = { NUMBER, ALPHA } },
    } },
@@ -3841,7 +3888,7 @@ local standard_library: {string:Type} = {
          a_type { typename = "function", args = VARARG { STRING, ANY }, rets = { NUMBER } },
       }
    },
-   ["setmetatable"] = a_type { typeargs = { ARG_ALPHA }, typename = "function", args = { ALPHA, NOMINAL_METATABLE }, rets = { ALPHA } },
+   ["setmetatable"] = a_type { typeargs = { ARG_ALPHA }, typename = "function", args = { ALPHA, NOMINAL_METATABLE_OF_ALPHA }, rets = { ALPHA } },
    ["tonumber"] = a_type { typename = "function", args = { ANY, NUMBER }, rets = { NUMBER } },
    ["tostring"] = a_type { typename = "function", args = { ANY }, rets = { STRING } },
    ["type"] = a_type { typename = "function", args = { ANY }, rets = { STRING } },
@@ -3876,42 +3923,41 @@ local standard_library: {string:Type} = {
          },
       },
    },
-   ["METATABLE"] = a_type {
+   ["metatable"] = a_type {
       typename = "typetype",
       def = a_type {
          typename = "record",
+         typeargs = { ARG_ALPHA },
          fields = {
-            ["__call"] = FUNCTION,
-            ["__gc"] = a_type { typename = "function", args = { ANY }, rets = {} },
+            ["__call"] = a_type { typename = "function", args = VARARG { ALPHA, ANY }, rets = VARARG { ANY } },
+            ["__gc"] = a_type { typename = "function", args = { ALPHA }, rets = {} },
             ["__index"] = ANY, -- FIXME: function | table | anything with an __index metamethod
-            ["__len"] = a_type { typename = "function", args = { ANY }, rets = { NUMBER } },
+            ["__len"] = a_type { typename = "function", args = { ALPHA }, rets = { NUMBER } },
             ["__mode"] = a_type { typename = "enum", enumset = { ["k"] = true, ["v"] = true, ["kv"] = true, } },
             ["__newindex"] = ANY, -- FIXME: function | table | anything with a __newindex metamethod
             ["__pairs"] = a_type { typeargs = { ARG_ALPHA, ARG_BETA }, typename = "function", args = { a_type { typename = "map", keys = ALPHA, values = BETA } }, rets = {
                   a_type { typename = "function", args = {}, rets = { ALPHA, BETA } },
             } },
-            ["__tostring"] = a_type { typename = "function", args = { ANY }, rets = { STRING } },
+            ["__tostring"] = a_type { typename = "function", args = { ALPHA }, rets = { STRING } },
             ["__name"] = STRING,
-
-            -- TODO complete...
-            ["__add"] = FUNCTION,
-            ["__sub"] = FUNCTION,
-            ["__mul"] = FUNCTION,
-            ["__div"] = FUNCTION,
-            ["__idiv"] = FUNCTION,
-            ["__mod"] = FUNCTION,
-            ["__pow"] = FUNCTION,
-            ["__unm"] = FUNCTION,
-            ["__band"] = FUNCTION,
-            ["__bor"] = FUNCTION,
-            ["__bxor"] = FUNCTION,
-            ["__bnot"] = FUNCTION,
-            ["__shl"] = FUNCTION,
-            ["__shr"] = FUNCTION,
-            ["__concat"] = FUNCTION,
-            ["__eq"] = FUNCTION,
-            ["__lt"] = FUNCTION,
-            ["__le"] = FUNCTION,
+            ["__add"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__sub"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__mul"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__div"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__idiv"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__mod"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__pow"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__unm"] = a_type { typename = "function", args = { ALPHA }, rets = { ANY } },
+            ["__band"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__bor"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__bxor"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__bnot"] = a_type { typename = "function", args = { ALPHA }, rets = { ANY } },
+            ["__shl"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__shr"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__concat"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { ANY } },
+            ["__eq"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { BOOLEAN } },
+            ["__lt"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { BOOLEAN } },
+            ["__le"] = a_type { typename = "function", args = { ALPHA, ANY }, rets = { BOOLEAN } },
          },
       },
    },
@@ -4210,7 +4256,7 @@ fill_field_order(OS_DATE_TABLE)
 fill_field_order(DEBUG_GETINFO_TABLE)
 
 NOMINAL_FILE.found = standard_library["FILE"]
-NOMINAL_METATABLE.found = standard_library["METATABLE"]
+NOMINAL_METATABLE_OF_ALPHA.found = standard_library["metatable"]
 
 local compat53_code_cache: {string:Node} = {}
 
@@ -5377,6 +5423,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       table.remove(st)
    end
 
+   local unknown_dots: {string:boolean} = {}
+
+   local function add_unknown_dot(node: Node, name: string)
+      if not unknown_dots[name] then
+         unknown_dots[name] = true
+         add_unknown(node, name)
+      end
+   end
+
    local type_check_function_call: function(Node, Type, {Type}, boolean, number): Type
    do
       local function try_match_func_args(node: Node, f: Type, args: {Type}, is_method: boolean, argdelta: number): Type, {Error}
@@ -5458,9 +5513,20 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
          if lax and is_unknown(func) then
             func = a_type { typename = "function", args = VARARG { UNKNOWN }, rets = VARARG { UNKNOWN } }
+            if node.e1.op and node.e1.op.op == ":" and node.e1.e1.kind == "variable" then
+               add_unknown_dot(node, node.e1.e1.tk .. "." .. node.e1.e2.tk)
+            end
          end
 
          func = resolve_unary(func)
+
+         if func.typename ~= "function" and func.typename ~= "poly" then
+            if func.meta_fields and func.meta_fields["__call"] then
+               table.insert(args, 1, func)
+               func = func.meta_fields["__call"]
+               is_method = true
+            end
+         end
 
          args = args or {}
          local poly: Type = func.typename == "poly" and func or { types = { func } }
@@ -5540,15 +5606,6 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          local ret = check_call(node, func, args, is_method, argdelta)
          end_scope()
          return ret
-      end
-   end
-
-   local unknown_dots: {string:boolean} = {}
-
-   local function add_unknown_dot(node: Node, name: string)
-      if not unknown_dots[name] then
-         unknown_dots[name] = true
-         add_unknown(node, name)
       end
    end
 
@@ -6273,20 +6330,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          table.insert(rets, 1, BOOLEAN)
          return rets
       elseif node.e1.op and node.e1.op.op == ":" then
-         local func = node.e1.type
-         if func.typename == "function" or func.typename == "poly" then
-            table.insert(b, 1, node.e1.e1.type)
-            return type_check_function_call(node, func, b, true)
-         else
-            if lax and (is_unknown(func)) then
-               if node.e1.e1.kind == "variable" then
-                  add_unknown_dot(node, node.e1.e1.tk .. "." .. node.e1.e2.tk)
-               end
-               return VARARG { UNKNOWN }
-            else
-               return INVALID
-            end
-         end
+         table.insert(b, 1, node.e1.e1.type)
+         return type_check_function_call(node, a, b, true)
       else
          return type_check_function_call(node, a, b, false, argdelta)
       end


### PR DESCRIPTION
Add support for metamethod declarations as part of record definitions, which teaches the Teal type checker about supported operations for that record type.

```lua
local type Rec = record
   x: number
   metamethod __call: function(Rec, string, number): string
   metamethod __add: function(Rec, Rec): Rec
end

local rec_mt: metatable<Rec>
rec_mt = {
   __call = function(self: Rec, s: string, n: number): string
      return tostring(self.x * n) .. s
   end,
   __add = function(a: Rec, b: Rec): Rec
      local res = setmetatable({} as Rec, rec_mt)
      res.x = a.x + b.x
      return res
   end,
}

local r = setmetatable({ x = 10 } as Rec, rec_mt)
local s = setmetatable({ x = 20 } as Rec, rec_mt)

r.x = 12
print(r("!!!", 1000)) -- prints 12000!!!
print((r + s).x)      -- prints 32
```

As you can see, this does _not_ attach metatables to records, you still need to use `setmetatable`.

The metatable type was renamed from `METATABLE` to `metatable<T>`. Also note that it does not yet check that the metatable definition is consistent with the type definitions from the record (that's a TODO). When type checking, the definitions from the `record` are the ones that count.

Operator metamethods for `//` and bitwise ops are supported even when running on top of Lua 5.1 :rocket: 
