### PR TITLE
do not emit a warning when localizing a global

### DIFF
--- a/spec/error_reporting/warning_spec.lua
+++ b/spec/error_reporting/warning_spec.lua
@@ -30,6 +30,18 @@ describe("warnings", function()
          { y = 10, msg = "redeclaration of variable 'v' (originally declared at 7:17)" },
       }))
 
+      it("does not report localized globals", util.check_warnings([[
+         global x = 9
+
+         do
+            local x = x
+            print(x)
+         end
+
+         local os = os
+         print(os)
+      ]], { }))
+
       it("reports unused variables", util.check_warnings([[
          local foo = "bar"
       ]], {

--- a/tl.lua
+++ b/tl.lua
@@ -6380,6 +6380,14 @@ show_type(var.t))
       return UNKNOWN
    end
 
+
+   local function is_localizing_a_variable(node, i)
+      return node.exps and
+      node.exps[i] and
+      node.exps[i].kind == "variable" and
+      node.exps[i].tk == node.vars[i].tk
+   end
+
    local visit_node = {}
 
    visit_node.cbs = {
@@ -6461,7 +6469,7 @@ show_type(var.t))
 
                do
                   local old_var = find_var(var.tk, true)
-                  if old_var then
+                  if old_var and not is_localizing_a_variable(node, i) then
                      redeclaration_warning(var, old_var)
                   end
                end

--- a/tl.tl
+++ b/tl.tl
@@ -6380,6 +6380,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       return UNKNOWN
    end
 
+   -- is the i-th assignment in a local declaration of the form `x = x` ?
+   local function is_localizing_a_variable(node: Node, i: number): boolean
+      return node.exps
+         and node.exps[i]
+         and node.exps[i].kind == "variable"
+         and node.exps[i].tk == node.vars[i].tk
+   end
+
    local visit_node: Visitor<NodeKind, Node, Type> = {}
 
    visit_node.cbs = {
@@ -6461,7 +6469,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
                do
                   local old_var <const> = find_var(var.tk, true)
-                  if old_var then
+                  if old_var and not is_localizing_a_variable(node, i) then
                      redeclaration_warning(var, old_var)
                   end
                end


### PR DESCRIPTION
Localizing globals is a common Lua pattern (for better or worse...)
so let's not emit a warning when we detect that it is happening.

For simplicity, I don't check that the variable being aliased with
the same name is really a global, but that shouldn't matter.

This does not check that the dynamic _value_ is the same, only that the static
_name_ is the same. Therefore, people shouldn't do this to localize the
standard library: `local os = require("os")` but instead do this `local os =
os` (though it's often not needed because the Teal compat53 code generator
already does that for the standard library modules in use).

See #285.