### PR TITLE
Rework tests to not use lfs.link + refactor temp file creation

### DIFF
--- a/.busted
+++ b/.busted
@@ -1,5 +1,6 @@
 return {
-  default = {
-    lpath = "./?.lua";
-  }
+   default = {
+      lpath = "./?.lua;"
+         .. (require("lfs").currentdir()) .. "/?.lua;";
+   }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -6,11 +6,7 @@ insert_final_newline     = true
 trim_trailing_whitespace = true
 charset                  = utf-8
 
-[*.lua]
-indent_style             = space
-indent_size              = 3
-
-[*.tl]
+[{*.lua,*.tl,tl,.busted}]
 indent_style             = space
 indent_size              = 3
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 tl.lua.1
 tl.lua.2
 tl.lua.bak
+/luarocks
+/lua
+/lua_modules
+/.luarocks

--- a/spec/cli/check_spec.lua
+++ b/spec/cli/check_spec.lua
@@ -3,21 +3,21 @@ local util = require("spec.util")
 describe("tl check", function()
    describe("on .tl files", function()
       it("reports 0 errors and code 0 on success", function()
-         local name = util.write_tmp_file(finally, "add.tl", [[
+         local name = util.write_tmp_file(finally, [[
             local function add(a: number, b: number): number
                return a + b
             end
 
             print(add(10, 20))
          ]])
-         local pd = io.popen("./tl check " .. name, "r")
+         local pd = io.popen(util.tl_cmd("check", name), "r")
          local output = pd:read("*a")
          util.assert_popen_close(true, "exit", 0, pd:close())
          assert.match("0 errors detected", output, 1, true)
       end)
 
       it("reports number of errors in stderr and code 1 on type errors", function()
-         local name = util.write_tmp_file(finally, "add.tl", [[
+         local name = util.write_tmp_file(finally, [[
             local function add(a: number, b: number): number
                return a + b
             end
@@ -32,7 +32,7 @@ describe("tl check", function()
       end)
 
       it("reports errors in multiple files", function()
-         local name1 = util.write_tmp_file(finally, "add.tl", [[
+         local name1 = util.write_tmp_file(finally, [[
             local function add(a: number, b: number): number
                return a + b
             end
@@ -40,7 +40,7 @@ describe("tl check", function()
             print(add("string", 20))
             print(add(10, true))
          ]])
-         local name2 = util.write_tmp_file(finally, "foo.tl", [[
+         local name2 = util.write_tmp_file(finally, [[
             local function add(a: number, b: number): number
                return a + b
             end
@@ -48,30 +48,30 @@ describe("tl check", function()
             print(add("string", 20))
             print(add(10, true))
          ]])
-         local pd = io.popen("./tl check " .. name1 .. " " .. name2 .. " 2>&1 1>/dev/null", "r")
+         local pd = io.popen(util.tl_cmd("check", name1, name2) .. " 2>&1 1>/dev/null", "r")
          local output = pd:read("*a")
          util.assert_popen_close(nil, "exit", 1, pd:close())
-         assert.match("add.tl:", output, 1, true)
-         assert.match("foo.tl:", output, 1, true)
+         assert.match(name1 .. ":", output, 1, true)
+         assert.match(name2 .. ":", output, 1, true)
       end)
 
       it("reports number of errors in stderr and code 1 on syntax errors", function()
-         local name = util.write_tmp_file(finally, "add.tl", [[
+         local name = util.write_tmp_file(finally, [[
             print(add("string", 20))))))
          ]])
-         local pd = io.popen("./tl check " .. name .. " 2>&1 1>/dev/null", "r")
+         local pd = io.popen(util.tl_cmd("check", name) .. "2>&1 1>/dev/null", "r")
          local output = pd:read("*a")
          util.assert_popen_close(nil, "exit", 1, pd:close())
          assert.match("1 syntax error:", output, 1, true)
       end)
 
       it("reports use of unknowns as errors in stderr and returns code 1", function()
-         local name = util.write_tmp_file(finally, "add.tl", [[
+         local name = util.write_tmp_file(finally, [[
             local function unk(x, y): number, number
                return a + b
             end
          ]])
-         local pd = io.popen("./tl check " .. name .. " 2>&1 1>/dev/null", "r")
+         local pd = io.popen(util.tl_cmd("check", name) .. "2>&1 1>/dev/null", "r")
          local output = pd:read("*a")
          util.assert_popen_close(nil, "exit", 1, pd:close())
          assert.match("2 errors:", output, 1, true)
@@ -82,46 +82,46 @@ describe("tl check", function()
 
    describe("on .lua files", function()
       it("reports 0 errors and code 0 on success", function()
-         local name = util.write_tmp_file(finally, "add.lua", [[
+         local name = util.write_tmp_file(finally, [[
             local function add(a: number, b: number): number
                return a + b
             end
 
             print(add(10, 20))
-         ]])
-         local pd = io.popen("./tl check " .. name, "r")
+         ]], "lua")
+         local pd = io.popen(util.tl_cmd("check", name), "r")
          local output = pd:read("*a")
          util.assert_popen_close(true, "exit", 0, pd:close())
          assert.match("0 errors detected", output, 1, true)
       end)
 
       it("reports number of errors in stderr and code 1 on type errors", function()
-         local name = util.write_tmp_file(finally, "add.lua", [[
+         local name = util.write_tmp_file(finally, [[
             local function add(a: number, b: number): number
                return a + b
             end
 
             print(add("string", 20))
             print(add(10, true))
-         ]])
-         local pd = io.popen("./tl check " .. name .. " 2>&1 1>/dev/null", "r")
+         ]], "lua")
+         local pd = io.popen(util.tl_cmd("check", name) .. " 2>&1 1>/dev/null", "r")
          local output = pd:read("*a")
          util.assert_popen_close(nil, "exit", 1, pd:close())
          assert.match("2 errors:", output, 1, true)
       end)
 
       it("reports number of errors in stderr and code 1 on syntax errors", function()
-         local name = util.write_tmp_file(finally, "add.lua", [[
+         local name = util.write_tmp_file(finally, [[
             print(add("string", 20))))))
-         ]])
-         local pd = io.popen("./tl check " .. name .. " 2>&1 1>/dev/null", "r")
+         ]], "lua")
+         local pd = io.popen(util.tl_cmd("check", name) .. "2>&1 1>/dev/null", "r")
          local output = pd:read("*a")
          util.assert_popen_close(nil, "exit", 1, pd:close())
          assert.match("1 syntax error:", output, 1, true)
       end)
 
       it("reports unknowns variables in stderr and code 0 if no errors", function()
-         local name = util.write_tmp_file(finally, "add.lua", [[
+         local name = util.write_tmp_file(finally, [[
             local function add(a: number, b: number): number
                return a + b
             end
@@ -129,8 +129,8 @@ describe("tl check", function()
             local function sub(x, y): number
                return x + y
             end
-         ]])
-         local pd = io.popen("./tl check " .. name .. " 2>&1 1>/dev/null", "r")
+         ]], "lua")
+         local pd = io.popen(util.tl_cmd("check", name) .. " 2>&1 1>/dev/null", "r")
          local output = pd:read("*a")
          util.assert_popen_close(true, "exit", 0, pd:close())
          assert.match("2 unknown variables:", output, 1, true)

--- a/spec/cli/include_dir_spec.lua
+++ b/spec/cli/include_dir_spec.lua
@@ -2,7 +2,7 @@ local util = require("spec.util")
 
 describe("-I --include-dir argument", function()
    it("adds a directory to package.path", function()
-      local name = util.write_tmp_file(finally, "foo.tl", [[
+      local name = util.write_tmp_file(finally, [[
          require("add")
          local x: number = add(1, 2)
 
@@ -10,15 +10,16 @@ describe("-I --include-dir argument", function()
       ]])
 
       local pd = io.popen("./tl -I spec check " .. name, "r")
+      local pd = io.popen(util.tl_cmd("check", "-I", "spec", name), "r")
       local output = pd:read("*a")
       util.assert_popen_close(true, "exit", 0, pd:close())
       assert.match("0 errors detected", output, 1, true)
    end)
    it("adds a directory to package.cpath", function()
-      local name = util.write_tmp_file(finally, "foo.lua", [[
+      local name = util.write_tmp_file(finally, [[
          print(package.cpath:match("spec/cli/") ~= nil)
       ]])
-      local pd = io.popen("./tl run -I spec/cli/ " .. name, "r")
+      local pd = io.popen(util.tl_cmd("run", "-I", "spec/cli/", name), "r")
       local output = pd:read("*a")
       util.assert_popen_close(true, "exit", 0, pd:close())
       util.assert_line_by_line([[

--- a/spec/cli/output_spec.lua
+++ b/spec/cli/output_spec.lua
@@ -10,7 +10,7 @@ describe("-o --output", function()
          },
          generated_files = { "foo.lua" },
          cmd = "gen",
-         args = "bar/foo.tl",
+         args = { "bar/foo.tl" },
          popen = {
             status = true,
             exit = "exit",
@@ -23,7 +23,7 @@ describe("-o --output", function()
          dir_structure = {a={b={c={["foo.tl"] = [[print 'hey']]}}}},
          generated_files = { "foo.lua" },
          cmd = "gen",
-         args = "a/b/c/foo.tl",
+         args = { "a/b/c/foo.tl" },
          popen = {
             status = true,
             exit = "exit",
@@ -33,7 +33,7 @@ describe("-o --output", function()
    end)
    it("should write to the given filename", function()
       util.run_mock_project(finally, {
-         args = "foo.tl -o my_output_file.lua",
+         args = { "foo.tl", "-o", "my_output_file.lua" },
          dir_structure = { ["foo.tl"] = [[print 'hey']] },
          generated_files = { "my_output_file.lua" },
          cmd = "gen",
@@ -46,7 +46,7 @@ describe("-o --output", function()
    end)
    it("should write to the given filename in a directory", function()
       util.run_mock_project(finally, {
-         args = "foo.tl -o a/b/c/d.lua",
+         args = { "foo.tl", "-o", "a/b/c/d.lua" },
          dir_structure = {
             ["foo.tl"] = [[print 'hey']],
             a={b={c={}}},
@@ -64,7 +64,7 @@ describe("-o --output", function()
    end)
    it("should gracefully error when the output directory doesn't exist", function()
       util.run_mock_project(finally, {
-         args = "foo.tl -o a/b/c/d.lua",
+         args = { "foo.tl", "-o", "a/b/c/d.lua" },
          dir_structure = {
             ["foo.tl"] = [[print 'hey']],
          },

--- a/spec/cli/preload_spec.lua
+++ b/spec/cli/preload_spec.lua
@@ -2,32 +2,33 @@ local util = require("spec.util")
 
 describe("-l --preload argument", function()
    it("exports globals from a module", function()
-      local name = util.write_tmp_file(finally, "foo.tl", [[
+      local name = util.write_tmp_file(finally, [[
          print(add(10, 20))
       ]])
 
       local pd = io.popen("./tl -l spec.add check " .. name, "r")
+      local pd = io.popen(util.tl_cmd("check", "-l", "spec.add", name), "r")
       local output = pd:read("*a")
       util.assert_popen_close(true, "exit", 0, pd:close())
       assert.match("0 errors detected", output, 1, true)
    end)
    it("reports error in stderr and code 1 when a module cannot be found", function ()
-      local name = util.write_tmp_file(finally, "foo.tl", [[
+      local name = util.write_tmp_file(finally, [[
          print(add(10, 20))
       ]])
 
-      local pd = io.popen("./tl -l module_that_doesnt_exist check " .. name .. " 2>&1 1>/dev/null", "r")
+      local pd = io.popen(util.tl_cmd("check", "-l", "module_that_doesnt_exist", name) .. " 2>&1 1>/dev/null", "r")
       local output = pd:read("*a")
       util.assert_popen_close(nil, "exit", 1, pd:close())
       assert.match("Error:", output, 1, true)
     end)
     it("can be used more than once", function ()
-      local name = util.write_tmp_file(finally, "foo.tl", [[
+      local name = util.write_tmp_file(finally, [[
          print(add(10, 20))
          print(subtract(20, 10))
       ]])
 
-      local pd = io.popen("./tl -l spec.add --preload spec.subtract check " .. name, "r")
+      local pd = io.popen(util.tl_cmd("check", "-l", "spec.add", "--preload",  "spec.subtract", name), "r")
       local output = pd:read("*a")
       util.assert_popen_close(true, "exit", 0, pd:close())
       assert.match("0 errors detected", output, 1, true)

--- a/spec/cli/quiet_spec.lua
+++ b/spec/cli/quiet_spec.lua
@@ -4,17 +4,17 @@ describe("-q --quiet flag", function()
    setup(util.chdir_setup)
    teardown(util.chdir_teardown)
    it("silences stdout when running tl check", function()
-      local name = util.write_tmp_file(finally, "foo.tl", [[
+      local name = util.write_tmp_file(finally, [[
          local x: number = 123
       ]])
 
-      local pd = io.popen("./tl -q check " .. name, "r")
+      local pd = io.popen(util.tl_cmd("check", "-q", name), "r")
       local output = pd:read("*a")
       util.assert_popen_close(true, "exit", 0, pd:close())
       assert.match("", output, 1, true)
    end)
    it("does NOT silence stderr when running tl check", function()
-      local name = util.write_tmp_file(finally, "add.tl", [[
+      local name = util.write_tmp_file(finally, [[
          local function add(a: number, b: number): number
             return a + b
          end
@@ -22,23 +22,23 @@ describe("-q --quiet flag", function()
          print(add("string", 20))
          print(add(10, true))
       ]])
-      local pd = io.popen("./tl -q check " .. name .. " 2>&1", "r")
+      local pd = io.popen(util.tl_cmd("check", "-q", name) .. "2>&1", "r")
       local output = pd:read("*a")
       util.assert_popen_close(nil, "exit", 1, pd:close())
       assert.match("2 errors:", output, 1, true)
    end)
    it("silences stdout when running tl gen", function()
-      local name = util.write_tmp_file(finally, "add.tl", [[
+      local name = util.write_tmp_file(finally, [[
          local function add(a: number, b: number): number
             return a + b
          end
 
          print(add(10, 20))
       ]])
-      local pd = io.popen("./tl --quiet gen " .. name, "r")
+      local pd = io.popen(util.tl_cmd("gen", "--quiet", name), "r")
       local output = pd:read("*a")
       util.assert_popen_close(true, "exit", 0, pd:close())
-      local lua_name = "add.lua"
+      local lua_name = name:gsub("tl$", "lua")
       assert.match("", output, 1, true)
       util.assert_line_by_line([[
          local function add(a, b)
@@ -49,10 +49,10 @@ describe("-q --quiet flag", function()
       ]], util.read_file(lua_name))
    end)
    it("does NOT silence stderr when running tl gen", function()
-      local name = util.write_tmp_file(finally, "add.tl", [[
+      local name = util.write_tmp_file(finally, [[
          print(add("string", 20))))))
       ]])
-      local pd = io.popen("./tl --quiet gen " .. name .. " 2>&1", "r")
+      local pd = io.popen(util.tl_cmd("gen", "--quiet", name) .. "2>&1", "r")
       local output = pd:read("*a")
       util.assert_popen_close(nil, "exit", 1, pd:close())
       assert.match("1 syntax error:", output, 1, true)

--- a/spec/error_reporting/module_error_spec.lua
+++ b/spec/error_reporting/module_error_spec.lua
@@ -19,7 +19,7 @@ describe("Uncaught compiler errors", function()
             ["my_script.tl"] = [[local mod = require("my_module"); mod.do_things()]],
          },
          cmd = "run",
-         args = "my_script.tl",
+         args = { "my_script.tl" },
          generated_files = {},
          popen = {
             status = nil,


### PR DESCRIPTION
 - This was the easy solution that worked at first when `tl build` was
   implemented, but making a bunch of random links can cause problems,
   so now we just run the `tl` command given its full path and tell
   busted to add the current dir to the lua path so `tl` can find
   `tl.lua`
 - write_tmp_file will now generate its own name and now
   accepts a parameter for the extension of the file it generates, i.e.
   previously: `write_tmp_file(finally, name, content)`
          now: `write_tmp_file(finally, content, extension)`
 - Add "tl", and ".busted" to .editorconfig