### PR TITLE
Userdata records

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -105,7 +105,10 @@ precedence, see below.
 
 *  newtype ::= ‘record’ recordbody | ‘enum’ enumbody | type
 
-*  recordbody ::= [typeargs] [‘{’ type ‘}’] {Name ‘=’ newtype} {[‘metamethod’] recordkey ‘:’ type} ‘end’
+*  recordbody ::= [typeargs] {recordentry} ‘end’
+
+*  recordentry ::= ‘userdata’ | ‘{’ type ‘}’ |
+*      Name ‘=’ newtype | [‘metamethod’] recordkey ‘:’ type
 
 *  recordkey ::= Name | ‘[’ LiteralString ‘]’
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -129,22 +129,59 @@ we'll focus on the things that Teal adds to Lua, and those are primarily type
 declarations.
 
 Types in Teal are more specific than in Lua, because Lua tables are so general.
-These are the types in Teal:
+These are the basic types in Teal:
 
-* nil
-* boolean
-* number
-* string
-* thread
-* userdata
-* function
-* array
-* record
-* arrayrecord
-* tuple
-* map
+* `any`
+* `nil`
+* `boolean`
+* `number`
+* `string`
+* `thread` (coroutine)
+
+You can also declare more types using type constructors. This is the summary
+list with a few examples of each; we'll discuss them in more detail below:
+
+* arrays - `{number}`, `{{number}}`
+* tuples - `{number, number, string}`
+* maps - `{string:boolean}`
+* functions - `function(number, string): {number}, string`
+
+Finally, there are types that must be declared and referred to using names:
+
 * enum
-* any
+* record
+  * userdata
+  * arrayrecord
+
+Here is an example declaration of each. Again, we'll go into more detail below,
+but this should give you an overview:
+
+```
+-- an enum: a set of accepted strings
+local enum State
+   "open"
+   "closed"
+end
+
+-- a record: a table with a known set of fields
+local record Point
+   x: number
+   y: number
+end
+
+-- a userdata record: a record which is implemented as a userdata
+local record File
+   userdata
+   status: function(): State
+   close: function(File): boolean, string
+end
+
+-- an arrayrecord: a record which doubles as a record and an array
+local record TreeNode<T>
+   {TreeNode<T>}
+   item: T
+end
+```
 
 ## Local variables
 

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -452,4 +452,23 @@ describe("records", function()
          [ [[  "hi"  ]] ]: table
       end
    ]=])
+
+   it("can be declared as userdata", util.check [[
+      local type foo = record
+         userdata
+         x: number
+         y: number
+      end
+   ]])
+
+   it("cannot be declared as userdata twice", util.check_syntax_error([[
+      local type foo = record
+         userdata
+         userdata
+         x: number
+         y: number
+      end
+   ]], {
+      { msg = "duplicated 'userdata' declaration in record" },
+   }))
 end)

--- a/spec/declaration/union_spec.lua
+++ b/spec/declaration/union_spec.lua
@@ -43,6 +43,32 @@ describe("union declaration", function()
       { msg = "cannot discriminate a union between multiple table types" },
    }))
 
+   it("cannot declare a union between multiple userdata types", util.check_type_error([[
+      local record R1
+         userdata
+      end
+
+      local record R2
+         userdata
+      end
+
+      local t: R1 | R2
+   ]], {
+      { msg = "cannot discriminate a union between multiple userdata types" },
+   }))
+
+   it("can declare a union between one table and one userdata type", util.check [[
+      local record R1
+         userdata
+      end
+
+      local record R2
+         x: number
+      end
+
+      local t: R1 | R2 | number
+   ]])
+
    it("cannot declare a union between multiple records", util.check_type_error([[
       local type R1 = record
          f: string

--- a/spec/stdlib/io_spec.lua
+++ b/spec/stdlib/io_spec.lua
@@ -37,6 +37,14 @@ describe("io", function()
    end)
 
    describe("FILE", function()
+      it("is userdata", util.check [[
+         local record R
+            x: number
+         end
+         local fd = io.open("filename")
+         local u: R | FILE
+      ]])
+
       describe("lines", function()
          it("with no arguments", util.check [[
             for l in io.popen("ls"):lines() do

--- a/tl.lua
+++ b/tl.lua
@@ -898,6 +898,7 @@ local Type = {}
 
 
 
+
 local Operator = {}
 
 
@@ -2136,7 +2137,14 @@ parse_record_body = function(ps, i, def, node)
       i, def.typeargs = parse_typearg_list(ps, i)
    end
    while not ((not ps.tokens[i]) or ps.tokens[i].tk == "end") do
-      if ps.tokens[i].tk == "{" then
+      if ps.tokens[i].tk == "userdata" and ps.tokens[i + 1].tk ~= ":" then
+         if def.is_userdata then
+            fail(ps, i, "duplicated 'userdata' declaration in record")
+         else
+            def.is_userdata = true
+         end
+         i = i + 1
+      elseif ps.tokens[i].tk == "{" then
          if def.typename == "arrayrecord" then
             i = failskip(ps, i, "duplicated declaration of array element type in record", parse_type)
          else
@@ -3937,6 +3945,7 @@ local standard_library = {
       typename = "typetype",
       def = a_type({
          typename = "record",
+         is_userdata = true,
          fields = {
             ["close"] = a_type({ typename = "function", args = { NOMINAL_FILE }, rets = { BOOLEAN, STRING } }),
             ["flush"] = a_type({ typename = "function", args = { NOMINAL_FILE }, rets = {} }),
@@ -4541,11 +4550,17 @@ tl.type_check = function(ast, opts)
 
       local n_table_types = 0
       local n_function_types = 0
+      local n_userdata_types = 0
       local n_string_enum = 0
       local has_primitive_string_type = false
       for _, t in ipairs(typ.types) do
          t = resolve_unary(t)
-         if table_types[t.typename] then
+         if t.is_userdata then
+            n_userdata_types = n_userdata_types + 1
+            if n_userdata_types > 1 then
+               return false, "cannot discriminate a union between multiple userdata types: %s"
+            end
+         elseif table_types[t.typename] then
             n_table_types = n_table_types + 1
             if n_table_types > 1 then
                return false, "cannot discriminate a union between multiple table types: %s"

--- a/tl.tl
+++ b/tl.tl
@@ -851,6 +851,7 @@ local record Type
    field_order: {string}
    meta_fields: {string: Type}
    meta_field_order: {string}
+   is_userdata: boolean
 
    -- array
    elements: Type
@@ -2136,7 +2137,14 @@ parse_record_body = function(ps: ParseState, i: number, def: Type, node: Node): 
       i, def.typeargs = parse_typearg_list(ps, i)
    end
    while not ((not ps.tokens[i]) or ps.tokens[i].tk == "end") do
-      if ps.tokens[i].tk == "{" then
+      if ps.tokens[i].tk == "userdata" and ps.tokens[i+1].tk ~= ":" then
+         if def.is_userdata then
+            fail(ps, i, "duplicated 'userdata' declaration in record")
+         else
+            def.is_userdata = true
+         end
+         i = i + 1
+      elseif ps.tokens[i].tk == "{" then
          if def.typename == "arrayrecord" then
             i = failskip(ps, i, "duplicated declaration of array element type in record", parse_type)
          else
@@ -3937,6 +3945,7 @@ local standard_library: {string:Type} = {
       typename = "typetype",
       def = a_type {
          typename = "record",
+         is_userdata = true,
          fields = {
             ["close"] = a_type { typename = "function", args = { NOMINAL_FILE }, rets = { BOOLEAN, STRING} },
             ["flush"] = a_type { typename = "function", args = { NOMINAL_FILE }, rets = {} },
@@ -4541,11 +4550,17 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       -- due to codegen limitations (we only check with type() so far)
       local n_table_types = 0
       local n_function_types = 0
+      local n_userdata_types = 0
       local n_string_enum = 0
       local has_primitive_string_type = false
       for _, t in ipairs(typ.types) do
          t = resolve_unary(t)
-         if table_types[t.typename] then
+         if t.is_userdata then -- must be tested before table_types
+            n_userdata_types = n_userdata_types + 1
+            if n_userdata_types > 1 then
+               return false, "cannot discriminate a union between multiple userdata types: %s"
+            end
+         elseif table_types[t.typename] then
             n_table_types = n_table_types + 1
             if n_table_types > 1 then
                return false, "cannot discriminate a union between multiple table types: %s"


### PR DESCRIPTION
A record can now be declared as being a userdata, like this:

```lua
local record Thing
   userdata
   x: number
   y: number
end
```

The practical difference, as far as type checking goes, is that they no longer count as a "table" type in unions, so you can have a function like `function myfunc(a: Thing | {Thing})`.