### PR TITLE
Make it so function calls in expression lists get adjusted to 1 result

### DIFF
--- a/spec/inference/function_result_adjustment_spec.lua
+++ b/spec/inference/function_result_adjustment_spec.lua
@@ -1,0 +1,10 @@
+local util = require("spec.util")
+
+describe("function results", function()
+   it("should be adjusted down to 1 result in an expression list", util.check [[
+      local function f(): string, number
+      end
+      local a, b = f(), "hi"
+      a = "hey"
+   ]])
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -5963,7 +5963,13 @@ show_type(var.t))
 
       local is_va = vals.is_va
       for i = 1, #vals - 1 do
-         ret[i] = vals[i]
+         if vals[i].typename == "tuple" then
+
+
+            ret[i] = vals[i][1] or NIL
+         else
+            ret[i] = vals[i]
+         end
       end
 
       local last = vals[#vals]

--- a/tl.lua
+++ b/tl.lua
@@ -5963,13 +5963,7 @@ show_type(var.t))
 
       local is_va = vals.is_va
       for i = 1, #vals - 1 do
-         if vals[i].typename == "tuple" then
-
-
-            ret[i] = vals[i][1] or NIL
-         else
-            ret[i] = vals[i]
-         end
+         ret[i] = resolve_tuple(vals[i])
       end
 
       local last = vals[#vals]

--- a/tl.tl
+++ b/tl.tl
@@ -5963,13 +5963,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       -- get all arguments except the last...
       local is_va = vals.is_va
       for i = 1, #vals - 1 do
-         if vals[i].typename == "tuple" then
-            -- result of function call in explist
-            -- adjust to 1 result
-            ret[i] = vals[i][1] or NIL
-         else
-            ret[i] = vals[i]
-         end
+         ret[i] = resolve_tuple(vals[i])
       end
 
       local last = vals[#vals]

--- a/tl.tl
+++ b/tl.tl
@@ -5963,7 +5963,13 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       -- get all arguments except the last...
       local is_va = vals.is_va
       for i = 1, #vals - 1 do
-         ret[i] = vals[i]
+         if vals[i].typename == "tuple" then
+            -- result of function call in explist
+            -- adjust to 1 result
+            ret[i] = vals[i][1] or NIL
+         else
+            ret[i] = vals[i]
+         end
       end
 
       local last = vals[#vals]


### PR DESCRIPTION
No idea if this has caused any issues but I stumbled upon the following behavior:
```
local function f(): string, number
end

local a, b = f(), 1
print_type(a)
```
`a` is assigned the tuple `(string, number)`, and in the following case
```
local function f()
end
local a, b, c = 1, f(), 3
print_type(b)
```
`b` is an empty tuple `()`

Anyway, this fixes that and I'm not exactly sure how to write a test for this or even if it's needed