### PR TITLE
fix: adjust playground url

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -36,7 +36,7 @@ jobs:
       run: |
         yarn global add netlify-cli
         cd ${{ github.workspace }}/teal-playground
-        NETLIFY_URL=$(netlify deploy --dir=dist --alias=${{ github.event.pull_request.user.login }}-${{ github.event.pull_request.id }} | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
+        NETLIFY_URL=$(netlify deploy --dir=dist --alias=${{ github.event.pull_request.number }} | grep -Eo '(http|https)://[a-zA-Z0-9./?=_-]*(--)[a-zA-Z0-9./?=_-]*')
         echo "$NETLIFY_URL"
         echo "::set-output name=NETLIFY_URL::$NETLIFY_URL"
       env:


### PR DESCRIPTION
- remove username to avoid case sensitivity

@hishamhm I originally only used the username so that the [url looks good](https://github.com/teal-language/tl/blob/master/.github/workflows/playground.yml#L39) and and appending the PR `id` for uniqueness. They don't have any bearing on the tl [source links](https://github.com/teal-language/tl/blob/master/.github/workflows/playground.yml#L33). After looking at it, I think maybe we can just use the `pull_request.number` instead. So playground urls would change like so:

e.g. https://github.com/teal-language/tl/pull/315

```diff
-https://hishamhm-547967880--teal-playground.netlify.app
+https://315--teal-playground.netlify.app
```

Let me know if that works for you, unless having the username has benefits, then we can lower it in the script.