### PR TITLE
fix: do not leak type variables when defining functions 

### DIFF
--- a/spec/call/generic_function_spec.lua
+++ b/spec/call/generic_function_spec.lua
@@ -424,5 +424,11 @@ describe("generic function", function()
       end
    ]])
 
+   it("generic function definitions do not leak type variables (#322)", util.check [[
+      local function my_unpack<T>(_list: {T}, _x: number, _y: number): T...
+      end
+      local _tbl_unpack = my_unpack or table.unpack
+      local _map: {string:number} = setmetatable(assert({}), { __mode = "k" })
+   ]])
 end)
 

--- a/tl.lua
+++ b/tl.lua
@@ -6460,8 +6460,22 @@ show_type(var.t))
             node_error(node, "rawget expects two arguments")
          end
       elseif node.e1.tk == "print_type" then
-         print(show_type(b))
-         return b
+         if #b == 0 then
+
+            print("-----------------------------------------")
+            for i, s in ipairs(st) do
+               for s, v in pairs(s) do
+                  print(("%2d %-14s %-11s %s"):format(i, s, v.t.typename, show_type(v.t):sub(1, 50)))
+               end
+            end
+            print("-----------------------------------------")
+            return NONE
+         else
+            local t = show_type(b[1])
+            print(t)
+            node_warning(node.e2[1], "type is: %s", t)
+            return b
+         end
       elseif node.e1.tk == "require" then
          if #b == 1 then
             if node.e2[1].kind == "string" then

--- a/tl.lua
+++ b/tl.lua
@@ -3659,9 +3659,9 @@ local show_type
 local function show_type_base(t, seen)
 
    if seen[t] then
-      return "..."
+      return seen[t]
    end
-   seen[t] = true
+   seen[t] = "..."
 
    local function show(t)
       return show_type(t, seen)
@@ -3771,10 +3771,12 @@ local function show_type_base(t, seen)
 end
 
 show_type = function(t, seen)
-   local ret = show_type_base(t, seen or {})
+   seen = seen or {}
+   local ret = show_type_base(t, seen)
    if t.inferred_at then
       ret = ret .. " (inferred at " .. t.inferred_at_file .. ":" .. t.inferred_at.y .. ":" .. t.inferred_at.x .. ": )"
    end
+   seen[t] = ret
    return ret
 end
 

--- a/tl.lua
+++ b/tl.lua
@@ -3588,7 +3588,6 @@ local binop_types = {
          ["enum"] = STRING,
       },
       ["function"] = {
-         ["function"] = FUNCTION,
          ["boolean"] = BOOLEAN,
       },
       ["array"] = {
@@ -4888,7 +4887,10 @@ show_type(var.t))
          if find_var_type(k) then
             return comp(a, b)
          else
-            add_var(nil, k, resolve_typevars(v))
+            local resolved = resolve_typevars(v)
+            if resolved.typename ~= "unknown" then
+               add_var(nil, k, resolved)
+            end
             return true
          end
       end

--- a/tl.tl
+++ b/tl.tl
@@ -3654,14 +3654,14 @@ local function is_unknown(t: Type): boolean
        or t.typename == "unknown_emptytable_value"
 end
 
-local show_type: function(Type, {Type:boolean}): string
+local show_type: function(Type, {Type:string}): string
 
-local function show_type_base(t: Type, seen: {Type:boolean}): string
+local function show_type_base(t: Type, seen: {Type:string}): string
    -- FIXME this is a control for recursively built types, which should in principle not exist
    if seen[t] then
-      return "..."
+      return seen[t]
    end
-   seen[t] = true
+   seen[t] = "..."
 
    local function show(t: Type): string
       return show_type(t, seen)
@@ -3770,11 +3770,13 @@ local function show_type_base(t: Type, seen: {Type:boolean}): string
    end
 end
 
-show_type = function(t: Type, seen: {Type:boolean}): string
-   local ret = show_type_base(t, seen or {})
+show_type = function(t: Type, seen: {Type:string}): string
+   seen = seen or {}
+   local ret = show_type_base(t, seen)
    if t.inferred_at then
       ret = ret .. " (inferred at "..t.inferred_at_file..":"..t.inferred_at.y..":"..t.inferred_at.x..": )"
    end
+   seen[t] = ret
    return ret
 end
 

--- a/tl.tl
+++ b/tl.tl
@@ -6460,8 +6460,22 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             node_error(node, "rawget expects two arguments")
          end
       elseif node.e1.tk == "print_type" then
-         print(show_type(b))
-         return b
+         if #b == 0 then
+            -- when called with no arguments, print all variables currently in scope and their types.
+            print("-----------------------------------------")
+            for i, s in ipairs(st) do
+               for s, v in pairs(s) do
+                  print(("%2d %-14s %-11s %s"):format(i, s, v.t.typename, show_type(v.t):sub(1, 50)))
+               end
+            end
+            print("-----------------------------------------")
+            return NONE
+         else
+            local t = show_type(b[1])
+            print(t)
+            node_warning(node.e2[1], "type is: %s", t)
+            return b
+         end
       elseif node.e1.tk == "require" then
          if #b == 1 then
             if node.e2[1].kind == "string" then

--- a/tl.tl
+++ b/tl.tl
@@ -3588,7 +3588,6 @@ local binop_types: {string:{TypeName:{TypeName:Type}}} = {
          ["enum"] = STRING,
       },
       ["function"] = {
-         ["function"] = FUNCTION,
          ["boolean"] = BOOLEAN,
       },
       ["array"] = {
@@ -4888,7 +4887,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          if find_var_type(k) then
             return comp(a, b)
          else
-            add_var(nil, k, resolve_typevars(v))
+            local resolved = resolve_typevars(v)
+            if resolved.typename ~= "unknown" then
+               add_var(nil, k, resolved)
+            end
             return true
          end
       end


### PR DESCRIPTION
Fixes #322.

This is possibly not a perfect fix (it might still be tripping up when comparing generic functions with unresolved type arguments against each other, possibly defaulting to 'true' whenever two unresolved type variables are compared against each other -- is that correct?), but it makes the behavior way less wrong than before, fixing some freak errors described by @euclidianAce in #322.
