### PR TITLE
fix type comparison of tuple elements

### DIFF
--- a/spec/statement/forin_spec.lua
+++ b/spec/statement/forin_spec.lua
@@ -81,6 +81,20 @@ describe("forin", function()
       { x = 14, y = 5, msg = "too many variables for this iterator; it produces 1 value" }
    }))
 
+   it("catches when too many values are passed, smart behavior about tuples", util.check_type_error([[
+      local record R
+         fields: function({number, nil}, string): (function(): string)
+         fields: function({number, number}, string): (function(): string, string)
+         fields: function({number} | number, string): (function(): string...)
+      end
+
+      for a, b in R.fields({1}, "hello") do
+         -- if you try to put "for a, b" here you get an error
+      end
+   ]], {
+      { y = 7, "too many variables for this iterator; it produces 1 value" }
+   }))
+
    describe("regression tests", function()
       it("with an iterator declared as a nominal (#183)", util.check [[
          local type Iterator = function(): string

--- a/tl.lua
+++ b/tl.lua
@@ -5411,7 +5411,7 @@ show_type(var.t))
             #t2.types
 
             for i = 1, len do
-               if not is_a(t2.types[i], t1.elements, for_equality) then
+               if not is_a(t1.elements, t2.types[i], for_equality) then
                   return false, terr(t1, "tuple entry " .. tostring(i) .. " of type %s does not match type of array elements, which is %s", t2.types[i], t1.elements)
                end
             end

--- a/tl.tl
+++ b/tl.tl
@@ -5411,7 +5411,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                         or  #t2.types
 
             for i = 1, len do
-               if not is_a(t2.types[i], t1.elements, for_equality) then
+               if not is_a(t1.elements, t2.types[i], for_equality) then
                   return false, terr(t1, "tuple entry " .. tostring(i) .. " of type %s does not match type of array elements, which is %s", t2.types[i], t1.elements)
                end
             end


### PR DESCRIPTION
As a side effect, allows `{T, nil}` to be used as an idiom for an
effectively unary tuple (since `{T}` means array of T).