### PR TITLE
New and improved inference behavior for "is"

### DIFF
--- a/spec/assignment/to_array_spec.lua
+++ b/spec/assignment/to_array_spec.lua
@@ -41,8 +41,7 @@ describe("assignment to array", function()
          }
       }
    ]], {
+      { y = 6, x = 10, msg = "cannot index this expression" },
       { y = 6, msg = "syntax error" },
-      { y = 6, msg = "syntax error" },
-      { y = 8, msg = "syntax error" },
    }))
 end)

--- a/spec/call/record_method_spec.lua
+++ b/spec/call/record_method_spec.lua
@@ -28,7 +28,6 @@ describe("record method call", function()
       print(foo:bar)
    ]], {
       { y = 2, msg = "expected a function call" },
-      { y = 2, msg = "syntax error" },
    }))
 
    it("nested record method calls", util.check [[

--- a/spec/call/string_method_spec.lua
+++ b/spec/call/string_method_spec.lua
@@ -16,8 +16,7 @@ describe("string method call", function()
          print("  ":rep("foo"))
       ]], {
          { msg = "cannot call a method on this expression" },
-         { msg = "expected an expression" },
-         { msg = "syntax error" },
+         { msg = "syntax error, expected one of: ')', ','" },
       }))
    end)
    describe("with variable", function()

--- a/spec/call/syntax_errors_spec.lua
+++ b/spec/call/syntax_errors_spec.lua
@@ -5,13 +5,12 @@ describe("call", function()
       print("hello", "world",)
    ]], {
       { msg = "syntax error" },
-      { msg = "syntax error" },
+      { msg = "syntax error, expected ')'" },
    }))
 
    it("fails when lhs is not a prefixexp", util.check_syntax_error([[
       print(nil("hello"))
    ]], {
-      { x = 16, msg = "cannot call this expression" },
-      { msg = "syntax error" },
+      { y = 1, x = 16, msg = "cannot call this expression" },
    }))
 end)

--- a/spec/cli/run_spec.lua
+++ b/spec/cli/run_spec.lua
@@ -164,7 +164,7 @@ describe("tl run", function()
             -6 nil
             -5 nil
             -4 nil
-            -3 lua
+            -3 ]] .. util.lua_interpreter .. "\n" .. [[
             -2 ]] .. util.tl_executable .. "\n" .. [[
             -1 run
             0 ]] .. name .. "\n" .. [[
@@ -197,7 +197,7 @@ describe("tl run", function()
             -7 nil
             -6 nil
             -5 nil
-            -4 lua
+            -4 ]] .. util.lua_interpreter .. "\n" .. [[
             -3 ]] .. util.tl_executable .. "\n" .. [[
             -2 run
             -1 --
@@ -231,7 +231,7 @@ describe("tl run", function()
             -7 nil
             -6 nil
             -5 nil
-            -4 lua
+            -4 ]] .. util.lua_interpreter .. "\n" .. [[
             -3 ]] .. util.tl_executable .. "\n" .. [[
             -2 run
             -1 --
@@ -263,7 +263,7 @@ describe("tl run", function()
             -9 nil
             -8 nil
             -7 nil
-            -6 lua
+            -6 ]] .. util.lua_interpreter .. "\n" .. [[
             -5 ]] .. util.tl_executable .. "\n" .. [[
             -4 run
             -3 -I

--- a/spec/declaration/functiontype_spec.lua
+++ b/spec/declaration/functiontype_spec.lua
@@ -18,8 +18,6 @@ describe("functiontype declaration", function()
    ]], {
       { y = 1, msg = "syntax error: this syntax is no longer valid; use 'local type t = function('..." },
       { y = 3, msg = "expected a function call" },
-      { y = 3, msg = "expected an expression" },
-      { y = 3, msg = "syntax error" },
    }))
 
    it("functiontype can return a union including itself (#135)", util.check [[

--- a/spec/declaration/global_function_spec.lua
+++ b/spec/declaration/global_function_spec.lua
@@ -119,8 +119,6 @@ describe("global function", function()
                { y = 1 },
                { y = 1 },
                { y = 1 },
-               { y = 1 },
-               { y = 7 },
             }))
 
             it("has no ambiguity with parentheses in function type return", util.check([[

--- a/spec/declaration/local_function_spec.lua
+++ b/spec/declaration/local_function_spec.lua
@@ -140,8 +140,6 @@ describe("local function", function()
          { y = 1 },
          { y = 1 },
          { y = 1 },
-         { y = 1 },
-         { y = 7 },
       }))
 
       it("has no ambiguity with parentheses in function type return", util.check [[

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -34,7 +34,6 @@ describe("records", function()
       p.y = 12
    ]], {
       { y = 1, msg = "syntax error: this syntax is no longer valid; use 'local record Point'" },
-      { msg = "expected a function call" },
       { msg = "syntax error" },
    }))
 

--- a/spec/error_reporting/syntax_error_spec.lua
+++ b/spec/error_reporting/syntax_error_spec.lua
@@ -14,6 +14,15 @@ describe("syntax errors", function()
       { y = 1, msg = "expected an expression" },
    }))
 
+   it("unclosed list reports expected token", util.check_syntax_error([[
+      local t = {}
+      for k,v in pairs(t)
+         i = i + 1
+      end
+   ]], {
+      { y = 3, msg = "syntax error, expected one of: 'do'" },
+   }))
+
    it("in enum", util.check_syntax_error([[
       local type Direction = enum
          "north",

--- a/spec/operator/is_spec.lua
+++ b/spec/operator/is_spec.lua
@@ -159,7 +159,7 @@ describe("flow analysis with is", function()
             print(t)
          end
       ]], {
-         { y = 6, msg = 'branch is always false' },
+         { y = 6, msg = 'cannot resolve a type for t here' },
       }))
    end)
 
@@ -218,7 +218,20 @@ describe("flow analysis with is", function()
             print("hello")
          end
       ]], {
-         { msg = "unknown variable: x" },
+         { y = 2, x = 13, msg = "unknown variable: x" },
+         { y = 4, x = 10, msg = "cannot resolve a type for x here" },
+      }))
+
+      it("can resolve on else block even if it can't on if block (#210)", util.check_warnings([[
+         function foo(v: any)
+            if not v is string then
+               print("foo")
+            else
+               print(v:upper())
+            end
+         end
+      ]], {
+         { y = 2, x = 20, msg = "v: type cannot be narrowed in this branch" }
       }))
    end)
 

--- a/spec/operator/is_spec.lua
+++ b/spec/operator/is_spec.lua
@@ -233,6 +233,27 @@ describe("flow analysis with is", function()
       ]], {
          { y = 2, x = 20, msg = "v: type cannot be narrowed in this branch" }
       }))
+
+      it("attempting to use a type as a value produces sensible messages (#210)", util.check_type_error([[
+         local record MyRecord
+           my_record_field: number
+         end
+         local type a = string | number | MyRecord
+
+         if a is string then
+            print("Hello, " .. a)
+         elseif a is number then      --  8
+            print(a + 10)
+         else
+            print(a.my_record_field)  --  11
+         end
+      ]], {
+         { msg = "can only use 'is' on variables, not types" },
+         { msg = "cannot use operator '..'" },
+         { msg = "can only use 'is' on variables, not types" },
+         { msg = "cannot use operator '+'" },
+         { msg = "cannot index" },
+      }))
    end)
 
    describe("code gen", function()

--- a/spec/parser/syntax_errors_spec.lua
+++ b/spec/parser/syntax_errors_spec.lua
@@ -8,7 +8,7 @@ describe("syntax errors", function()
 
       print("what")
    ]], {
-      { y = 3, "syntax error" },
+      { y = 3, msg = "syntax error" },
    }))
 
    it("in table declaration", util.check_syntax_error([[
@@ -18,9 +18,8 @@ describe("syntax errors", function()
          foo = 9
       }
    ]], {
-      { y = 3, "syntax error" },
-      { y = 3, "syntax error" },
-      { y = 4, "expected an expression" },
+      { y = 3, x = 15, msg = "syntax error, expected one of: '}', ','" },
+      { y = 3, x = 17, msg = "syntax error" },
    }))
 
    it("missing separators in table", util.check_syntax_error([[
@@ -30,28 +29,28 @@ describe("syntax errors", function()
          brain = true
       }
    ]], {
-      { y = 3, "syntax error" },
-      { y = 3, "syntax error" },
-      { y = 4, "syntax error" },
+      { y = 3, msg = "syntax error, expected one of: '}', ','" },
+      { y = 4, msg = "syntax error, expected one of: '}', ','" },
    }))
 
    it("missing separators", util.check_syntax_error([[
       local function x(a b c)
 
       end
+   ]], {
+      { y = 1, x = 26, msg = "syntax error, expected one of: ')', ','" },
+      { y = 1, x = 28, msg = "syntax error, expected one of: ')', ','" },
+   }))
 
+   it("missing separators with types", util.check_syntax_error([[
       local function y(a: string b: string c: string)
          print(a b c)
       end
    ]], {
-      { y = 1, "syntax error" },
-      { y = 1, "expected an expression" },
-      { y = 1, "syntax error" },
-      { y = 5, "expected an expression" },
-      { y = 5, "syntax error" },
-      { y = 5, "expected an expression" },
-      { y = 5, "syntax error" },
-      { y = 5, "expected an expression" },
+      { y = 1, x = 34, msg = "syntax error, expected one of: ')', ','" },
+      { y = 1, x = 44, msg = "syntax error, expected one of: ')', ','" },
+      { y = 2, x = 18, msg = "syntax error, expected one of: ')', ','" },
+      { y = 2, x = 20, msg = "syntax error, expected one of: ')', ','" },
    }))
 
    it("in variadic return type", util.check_syntax_error([[
@@ -70,13 +69,13 @@ describe("syntax errors", function()
          end
       end
    ]], {
-      { y = 1, "expected a type list" },
+      { y = 1, msg = "expected a type list" },
    }))
 
    it("cannot use keyword as an identifier in an argument list", util.check_syntax_error([[
       local function foo(do: number | string) end
    ]], {
-      { y = 1, "syntax error, expected identifier" },
+      { y = 1, msg = "syntax error, expected identifier" },
    }))
 end)
 

--- a/spec/stdlib/rawget_spec.lua
+++ b/spec/stdlib/rawget_spec.lua
@@ -8,21 +8,4 @@ describe("rawget", function()
       local str = "hello"
       local a = {str:sub(2, 10)}
    ]])
-
-   it("catches a syntax error", util.check_syntax_error([[
-      local self = {
-         ["fmt"] = {
-            x = 123,
-            y = 234,
-         }
-         ["bla"] = {
-            z = 345,
-            w = 456,
-         }
-      }
-   ]], {
-      { msg = "syntax error" },
-      { msg = "syntax error" },
-      { msg = "syntax error" },
-   }))
 end)

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -110,6 +110,14 @@ local cmd_prefix = { string.format("LUA_PATH=%q", package.path) }
 for i = 1, 4 do
    table.insert(cmd_prefix, string.format("LUA_PATH_5_%d=%q", i, package.path))
 end
+
+local first_arg = 0
+while arg[first_arg - 1] do
+   first_arg = first_arg - 1
+end
+util.lua_interpreter = arg[first_arg]
+
+table.insert(cmd_prefix, util.lua_interpreter) -- Lua interpreter used by Busted
 table.insert(cmd_prefix, tl_executable)
 cmd_prefix = table.concat(cmd_prefix, " ")
 function util.tl_cmd(name, ...)

--- a/tl.lua
+++ b/tl.lua
@@ -5229,6 +5229,10 @@ show_type(var.t))
          return true
       end
 
+      if t1.typename == "bad_nominal" or t2.typename == "bad_nominal" then
+         return false
+      end
+
 
       if t1.typename == "nil" then
          return true
@@ -5296,7 +5300,17 @@ show_type(var.t))
          end
          return false, terr(t1, "cannot match against any alternatives of the polymorphic type")
       elseif t1.typename == "nominal" and t2.typename == "nominal" then
-         return are_same_nominals(t1, t2)
+         local same, err = are_same_nominals(t1, t2)
+         if same then
+            return true
+         end
+         local t1u = resolve_unary(t1)
+         local t2u = resolve_unary(t2)
+         if is_record_type(t1u) and is_record_type(t2u) then
+            return same, err
+         else
+            return is_a(t1u, t2u, for_equality)
+         end
       elseif t1.typename == "enum" and t2.typename == "string" then
          local ok
          if for_equality then

--- a/tl.lua
+++ b/tl.lua
@@ -1224,6 +1224,9 @@ local function parse_table_item(ps, i, n)
    node.key.constnum = n
    node.key.tk = tostring(n)
    i, node.value = parse_expression(ps, i)
+   if not node.value then
+      return fail(ps, i)
+   end
    return i, node, n + 1
 end
 
@@ -1252,7 +1255,23 @@ local function parse_list(ps, i, list, close, sep, parse_item)
       elseif sep == "term" and ps.tokens[i].tk == ";" then
          i = i + 1
       elseif not close[ps.tokens[i].tk] then
-         return fail(ps, i)
+         local options = {}
+         for k, _ in pairs(close) do
+            table.insert(options, "'" .. k .. "'")
+         end
+         table.sort(options)
+         table.insert(options, "','")
+         local expected = "syntax error, expected one of: " .. table.concat(options, ", ")
+         fail(ps, i, expected)
+         local first = options[1]:sub(2, -2)
+
+
+
+         if first ~= "}" and ps.tokens[i].y ~= ps.tokens[i - 1].y then
+
+            table.insert(ps.tokens, i, { tk = first, y = ps.tokens[i - 1].y, x = ps.tokens[i - 1].x + 1, kind = "keyword" })
+            return i, list
+         end
       end
    end
    return i, list
@@ -1676,17 +1695,24 @@ do
 
             if not after_valid_prefixexp(ps, e1, prev_i) then
                fail(ps, prev_i, "cannot call this expression")
-               return i + 1
+               return i
             end
 
             e1 = { y = t1.y, x = t1.x, kind = "op", op = op, e1 = e1, e2 = args }
          elseif ps.tokens[i].tk == "[" then
             local op = new_operator(ps.tokens[i], 2, "@index")
 
+            local prev_i = i
+
             local idx
             i = i + 1
             i, idx = parse_expression(ps, i)
             i = verify_tk(ps, i, "]")
+
+            if not after_valid_prefixexp(ps, e1, prev_i) then
+               fail(ps, prev_i, "cannot index this expression")
+               return i
+            end
 
             e1 = { y = t1.y, x = t1.x, kind = "op", op = op, e1 = e1, e2 = idx }
          elseif ps.tokens[i].tk == "." or ps.tokens[i].tk == ":" then
@@ -1700,12 +1726,13 @@ do
 
             if op.op == ":" then
                if not args_starters[ps.tokens[i].kind] then
-                  return fail(ps, i, "expected a function call for a method")
+                  fail(ps, i, "expected a function call for a method")
+                  return i
                end
 
                if not after_valid_prefixexp(ps, e1, prev_i) then
                   fail(ps, prev_i, "cannot call a method on this expression")
-                  return i + 1
+                  return i
                end
             end
 
@@ -1738,14 +1765,16 @@ do
          local rhs
          i, rhs = P(ps, i)
          if not rhs then
-            return fail(ps, i, "expected an expression")
+            fail(ps, i, "expected an expression")
+            return i
          end
          lookahead = ps.tokens[i].tk
          while precedences[2][lookahead] and ((precedences[2][lookahead] > (precedences[2][op.op])) or
             (is_right_assoc[lookahead] and (precedences[2][lookahead] == precedences[2][op.op]))) do
             i, rhs = E(ps, i, rhs, precedences[2][lookahead])
             if not rhs then
-               return fail(ps, i, "expected an expression")
+               fail(ps, i, "expected an expression")
+               return i
             end
             lookahead = ps.tokens[i].tk
          end
@@ -1756,12 +1785,17 @@ do
 
    parse_expression = function(ps, i)
       local lhs
+      local istart = i
       i, lhs = P(ps, i)
       i, lhs = E(ps, i, lhs, 0)
       if lhs then
          return i, lhs, 0
       else
-         return fail(ps, i, "expected an expression")
+         if i == istart then
+            return fail(ps, i, "expected an expression")
+         else
+            return i
+         end
       end
    end
 end
@@ -2211,7 +2245,7 @@ parse_record_body = function(ps, i, def, node)
          local v
          if ps.tokens[i].tk == "[" then
             i, v = parse_literal(ps, i + 1)
-            if not v.conststr then
+            if v and not v.conststr then
                return fail(ps, i, "expected a string literal")
             end
             i = verify_tk(ps, i, "]")

--- a/tl.lua
+++ b/tl.lua
@@ -57,9 +57,11 @@ local tl = {Env = {}, Result = {}, Error = {}, }
 
 
 
+
 tl.warning_kinds = {
    ["unused"] = true,
    ["redeclaration"] = true,
+   ["branch"] = true,
    ["debug"] = true,
 }
 
@@ -968,7 +970,19 @@ local FactType = {}
 
 
 
+
+
+
 local Fact = {}
+
+
+
+
+
+
+
+
+
 
 
 
@@ -6240,193 +6254,246 @@ show_type(var.t))
       end
    end
 
+
    local facts_and
    local facts_or
    local facts_not
+   local apply_facts
    do
-      local function join_facts(fss)
-         local vars = {}
+      setmetatable(Fact, {
+         __call = function(_, f)
+            return setmetatable(f, {
+               __tostring = function(f)
+                  if f.fact == "is" then
+                     return ("(%s is %s)"):format(f.var, show_type(f.typ))
+                  elseif f.fact == "not" then
+                     return ("(not %s)"):format(tostring(f.f1))
+                  elseif f.fact == "or" then
+                     return ("(%s or %s)"):format(tostring(f.f1), tostring(f.f2))
+                  elseif f.fact == "and" then
+                     return ("(%s and %s)"):format(tostring(f.f1), tostring(f.f2))
+                  end
+               end,
+            })
+         end,
+      })
 
-         for _, fs in ipairs(fss) do
-            for _, f in ipairs(fs) do
-               if not vars[f.var] then
-                  vars[f.var] = {}
-               end
-               table.insert(vars[f.var], f)
-            end
+      facts_and = function(f1, f2, where)
+         if f1 and f2 then
+            return Fact({ fact = "and", f1 = f1, f2 = f2, where = where })
+         elseif f1 then
+            return f1
+         elseif f2 then
+            return f2
          end
-         return vars
       end
 
-      local function intersect(xs, ys, same)
-         local rs = {}
-         for i = #xs, 1, -1 do
-            local x = xs[i]
-            for _, y in ipairs(ys) do
-               if same(x, y) then
-                  table.insert(rs, x)
-                  break
-               end
-            end
+      facts_or = function(f1, f2, where)
+         if f1 and f2 then
+            return Fact({ fact = "or", f1 = f1, f2 = f2, where = where })
+         else
+            return nil
          end
-         return rs
       end
 
-      local function same_type_for_intersect(t, u)
-         return (same_type(t, u))
+      facts_not = function(f1, where)
+         if f1 then
+            return Fact({ fact = "not", f1 = f1, where = where })
+         else
+            return nil
+         end
       end
 
-      local function intersect_facts(fs, errnode)
-         local all_is = true
-         local types = {}
-         for i, f in ipairs(fs) do
-            if f.fact ~= "is" then
-               all_is = false
-               break
-            end
-            if f.typ.typename == "union" then
-               if i == 1 then
-                  types = f.typ.types
-               else
-                  types = intersect(types, f.typ.types, same_type_for_intersect)
+
+      local function unite_types(t1, t2)
+         return unite({ t2, t1 })
+      end
+
+
+      local function intersect_types(t1, t2)
+         if t2.typename == "union" then
+            t1, t2 = t2, t1
+         end
+         if t1.typename == "union" then
+            local out = {}
+            for _, t in ipairs(t1.types) do
+               if is_a(t, t2) then
+                  table.insert(out, t)
                end
+            end
+            return unite(out)
+         else
+            if is_a(t1, t2) then
+               return t1
+            elseif is_a(t2, t1) then
+               return t2
             else
-               if i == 1 then
-                  types = { f.typ }
-               else
-                  types = intersect(types, { f.typ }, same_type_for_intersect)
-               end
+               return INVALID
             end
-         end
-
-         if #types == 0 then
-            node_error(errnode, "branch is always false")
-            return false
-         end
-
-         if all_is then
-            return true, unite(types)
-         else
-            return false
          end
       end
 
-      local function sum_facts(fs)
-         local all_is = true
-         local types = {}
-         for _, f in ipairs(fs) do
-            if f.fact ~= "is" then
-               all_is = false
-               break
-            end
-            table.insert(types, f.typ)
+      local function resolve_if_union(t)
+         local u = resolve_unary(t)
+         if u.typename == "union" then
+            return u
          end
-
-         if all_is then
-            return true, unite(types)
-         else
-            return false
-         end
+         return t
       end
 
-      local function subtract_types(u1, u2, errt)
+
+      local function subtract_types(t1, t2)
          local types = {}
-         for _, rt in ipairs(u1.types or { u1 }) do
+
+         t1 = resolve_if_union(t1)
+
+
+
+         if t1.typename ~= "union" then
+            return t1, "type cannot be narrowed in this branch"
+         end
+
+         t2 = resolve_if_union(t2)
+         local t2types = t2.types or { t2 }
+
+         for _, at in ipairs(t1.types) do
             local not_present = true
-            for _, ft in ipairs(u2.types or { u2 }) do
-               if same_type(rt, ft) then
+            for _, bt in ipairs(t2types) do
+               if same_type(at, bt) then
                   not_present = false
                   break
                end
             end
             if not_present then
-               table.insert(types, rt)
+               table.insert(types, at)
             end
          end
 
          if #types == 0 then
-            type_error(errt, "branch is always false")
-            return INVALID
+            return INVALID, "no valid types match in this branch"
          end
 
          return unite(types)
       end
 
-      facts_and = function(f1, f2, errnode)
-         if not f1 then
-            return f2
-         end
-         if not f2 then
-            return f1
-         end
+      local eval_not
+      local or_types
+      local and_types
+      local eval_fact
 
-         local out = {}
-         for v, fs in pairs(join_facts({ f1, f2 })) do
-            local ok, u = intersect_facts(fs, errnode)
-
-            if ok then
-               table.insert(out, { fact = "is", var = v, typ = u })
-            else
-
-               for _, f in ipairs(fs) do
-                  table.insert(out, f)
-               end
-            end
-         end
-         return out
-      end
-
-      facts_or = function(f1, f2)
-         if not f1 or not f2 then
-            return nil
-         end
-
-         local out = {}
-         for v, fs in pairs(join_facts({ f1, f2 })) do
-            local ok, u = sum_facts(fs)
-            if ok then
-               table.insert(out, { fact = "is", var = v, typ = u })
-            else
-
-               for _, f in ipairs(fs) do
-                  table.insert(out, f)
-               end
-            end
-         end
-         return out
-      end
-
-      facts_not = function(f1)
-         if not f1 then
-            return nil
-         end
-
-         local out = {}
-         for v, fs in pairs(join_facts({ f1 })) do
-            local realtype = find_var_type(v)
-            if realtype then
-               realtype = resolve_unary(realtype)
-               local ok, u = sum_facts(fs)
-               if ok then
-                  local not_typ = subtract_types(realtype, u, fs[1].typ)
-                  table.insert(out, { fact = "is", var = v, typ = not_typ })
-               end
-            end
-         end
-         return out
-      end
-   end
-
-   local function apply_facts(where, facts)
-      if not facts then
-         return
-      end
-      for _, f in ipairs(facts) do
+      eval_not = function(f)
          if f.fact == "is" then
-            local t = shallow_copy(f.typ)
+            local typ = find_var_type(f.var, true)
+            if not typ then
+               return { [f.var] = INVALID }
+            end
+            if not is_a(f.typ, typ) then
+               node_warning("branch", f.where, f.var .. " (of type %s) can never be a %s", show_type(typ), show_type(f.typ))
+               return { [f.var] = INVALID }
+            else
+               local sub, warn = subtract_types(typ, f.typ)
+               if warn then
+                  node_warning("branch", f.where, f.var .. ": " .. warn)
+               end
+               return { [f.var] = sub }
+            end
+         elseif f.fact == "not" then
+            return eval_fact(f.f1)
+         elseif f.fact == "and" then
+            return or_types(eval_not(f.f1), eval_not(f.f2))
+         elseif f.fact == "or" then
+            return and_types(eval_not(f.f1), eval_not(f.f2))
+         end
+      end
+
+      or_types = function(vs1, vs2)
+         local realtypes = {}
+
+         local ret = {}
+
+         for var, typ in pairs(vs1) do
+            local vt = find_var_type(var, true) or INVALID
+            realtypes[var] = vt
+            if not is_a(typ, vt) then
+               return vs2
+            end
+            ret[var] = typ
+         end
+
+         for var, typ in pairs(vs2) do
+            local vt = realtypes[var] or find_var_type(var, true) or INVALID
+            realtypes[var] = vt
+            if not is_a(typ, vt) then
+               return vs1
+            end
+            ret[var] = unite_types(typ, ret[var])
+         end
+
+         return ret
+      end
+
+      and_types = function(vs1, vs2)
+         local realtypes = {}
+
+         local ret = {}
+
+         for var, typ in pairs(vs1) do
+            local vt = find_var_type(var, true) or INVALID
+            realtypes[var] = vt
+            if not is_a(typ, vt) then
+               return {}
+            end
+            ret[var] = typ
+         end
+
+         for var, typ in pairs(vs2) do
+            local vt = realtypes[var] or find_var_type(var, true) or INVALID
+            realtypes[var] = vt
+            if not is_a(typ, vt) then
+               return {}
+            end
+            ret[var] = ret[var] and intersect_types(typ, ret[var]) or typ
+         end
+
+         return ret
+      end
+
+      eval_fact = function(f)
+         if f.fact == "is" then
+            local typ = find_var_type(f.var, true)
+            if not typ then
+               return { [f.var] = INVALID }
+            end
+            if not is_a(f.typ, typ) then
+               node_error(f.where, f.var .. " (of type %s) can never be a %s", typ, f.typ)
+               return { [f.var] = INVALID }
+            else
+               return { [f.var] = f.typ }
+            end
+         elseif f.fact == "not" then
+            return eval_not(f.f1)
+         elseif f.fact == "and" then
+            return and_types(eval_fact(f.f1), eval_fact(f.f2))
+         elseif f.fact == "or" then
+            return or_types(eval_fact(f.f1), eval_fact(f.f2))
+         end
+      end
+
+      apply_facts = function(where, known)
+         if not known then
+            return
+         end
+
+         local vars = eval_fact(known)
+
+         for v, t in pairs(vars) do
+            if t.typename == "invalid" then
+               node_error(where, "cannot resolve a type for " .. v .. " here")
+            end
+            t = shallow_copy(t)
             t.inferred_at = where
             t.inferred_at_file = filename
-            add_var(nil, f.var, t, nil, true)
+            add_var(nil, v, t, nil, true)
          end
       end
    end
@@ -6708,7 +6775,7 @@ show_type(var.t))
       ["if"] = {
          before_statements = function(node)
             begin_scope()
-            apply_facts(node.exp, node.exp.facts)
+            apply_facts(node.exp, node.exp.known)
          end,
          after = function(node, _children)
             end_scope()
@@ -6719,14 +6786,14 @@ show_type(var.t))
          before = function(node)
             end_scope()
             begin_scope()
-            local f = facts_not(node.parent_if.exp.facts)
+            local f = facts_not(node.parent_if.exp.known)
             for e = 1, node.elseif_n - 1 do
-               f = facts_and(f, facts_not(node.parent_if.elseifs[e].exp.facts), node)
+               f = facts_and(f, facts_not(node.parent_if.elseifs[e].exp.known), node)
             end
             apply_facts(node.exp, f)
          end,
          before_statements = function(node)
-            apply_facts(node.exp, node.exp.facts)
+            apply_facts(node.exp, node.exp.known)
          end,
          after = function(node, _children)
             node.type = NONE
@@ -6736,9 +6803,9 @@ show_type(var.t))
          before = function(node)
             end_scope()
             begin_scope()
-            local f = facts_not(node.parent_if.exp.facts)
+            local f = facts_not(node.parent_if.exp.known)
             for _, elseifnode in ipairs(node.parent_if.elseifs) do
-               f = facts_and(f, facts_not(elseifnode.exp.facts), node)
+               f = facts_and(f, facts_not(elseifnode.exp.known), node)
             end
             apply_facts(node, f)
          end,
@@ -6753,7 +6820,7 @@ show_type(var.t))
          end,
          before_statements = function(node)
             begin_scope()
-            apply_facts(node.exp, node.exp.facts)
+            apply_facts(node.exp, node.exp.known)
          end,
          after = function(node, _children)
             end_scope()
@@ -7202,7 +7269,7 @@ show_type(var.t))
       },
       ["paren"] = {
          after = function(node, children)
-            node.facts = node.e1 and node.e1.facts
+            node.known = node.e1 and node.e1.known
             node.type = resolve_unary(children[1])
          end,
       },
@@ -7212,9 +7279,9 @@ show_type(var.t))
          end,
          before_e2 = function(node)
             if node.op.op == "and" then
-               apply_facts(node, node.e1.facts)
+               apply_facts(node, node.e1.known)
             elseif node.op.op == "or" then
-               apply_facts(node, facts_not(node.e1.facts))
+               apply_facts(node, facts_not(node.e1.known))
             end
          end,
          after = function(node, children)
@@ -7241,7 +7308,7 @@ show_type(var.t))
                node.type = b
             elseif node.op.op == "is" then
                if node.e1.kind == "variable" then
-                  node.facts = { { fact = "is", var = node.e1.tk, typ = b } }
+                  node.known = Fact({ fact = "is", var = node.e1.tk, typ = b, where = node })
                else
                   node_error(node, "can only use 'is' on variables")
                end
@@ -7266,24 +7333,24 @@ show_type(var.t))
             elseif node.op.op == ":" then
                node.type = match_record_key(node, node.e1.type, node.e2, orig_a)
             elseif node.op.op == "not" then
-               node.facts = facts_not(node.e1.facts)
+               node.known = facts_not(node.e1.known)
                node.type = BOOLEAN
             elseif node.op.op == "and" then
-               node.facts = facts_and(node.e1.facts, node.e2.facts, node)
+               node.known = facts_and(node.e1.known, node.e2.known, node)
                node.type = resolve_tuple(b)
             elseif node.op.op == "or" and b.typename == "emptytable" then
-               node.facts = nil
+               node.known = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "or" and is_a(ub, ua) then
-               node.facts = facts_or(node.e1.facts, node.e2.facts)
+               node.known = facts_or(node.e1.known, node.e2.known)
                node.type = resolve_tuple(a)
             elseif node.op.op == "or" and b.typename == "nil" then
-               node.facts = nil
+               node.known = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "or" and
                ((ua.typename == "enum" and ub.typename == "string" and is_a(ub, ua)) or
                (ua.typename == "string" and ub.typename == "enum" and is_a(ua, ub))) then
-               node.facts = nil
+               node.known = nil
                node.type = (ua.typename == "enum" and ua or ub)
             elseif node.op.op == "==" or node.op.op == "~=" then
                if is_a(a, b, true) or is_a(b, a, true) then
@@ -7323,7 +7390,7 @@ show_type(var.t))
 
             elseif node.op.arity == 2 and binop_types[node.op.op] then
                if node.op.op == "or" then
-                  node.facts = facts_or(node.e1.facts, node.e2.facts)
+                  node.known = facts_or(node.e1.known, node.e2.known)
                end
 
                a = ua

--- a/tl.lua
+++ b/tl.lua
@@ -7307,7 +7307,9 @@ show_type(var.t))
             elseif node.op.op == "as" then
                node.type = b
             elseif node.op.op == "is" then
-               if node.e1.kind == "variable" then
+               if ua.typename == "typetype" then
+                  node_error(node, "can only use 'is' on variables, not types")
+               elseif node.e1.kind == "variable" then
                   node.known = Fact({ fact = "is", var = node.e1.tk, typ = b, where = node })
                else
                   node_error(node, "can only use 'is' on variables")

--- a/tl.tl
+++ b/tl.tl
@@ -1224,6 +1224,9 @@ local function parse_table_item(ps: ParseState, i: number, n: number): number, N
    node.key.constnum = n
    node.key.tk = tostring(n)
    i, node.value = parse_expression(ps, i)
+   if not node.value then
+      return fail(ps, i)
+   end
    return i, node, n + 1
 end
 
@@ -1252,7 +1255,23 @@ local function parse_list<T>(ps: ParseState, i: number, list: {T}, close: {strin
       elseif sep == "term" and ps.tokens[i].tk == ";" then
          i = i + 1
       elseif not close[ps.tokens[i].tk] then
-         return fail(ps, i)
+         local options = {}
+         for k, _ in pairs(close) do
+            table.insert(options, "'" .. k .. "'")
+         end
+         table.sort(options)
+         table.insert(options, "','")
+         local expected = "syntax error, expected one of: " .. table.concat(options, ", ")
+         fail(ps, i, expected)
+         local first = options[1]:sub(2, -2)
+         -- heuristic for error recovery to avoid a cascade of errors:
+         -- * if we're parsing a bracketed list, assume the missing token is a separator;
+         -- * otherwise, if we have a line break, insert expected terminator token.
+         if first ~= "}" and ps.tokens[i].y ~= ps.tokens[i-1].y then
+            -- FIXME closing token may not be a keyword (but non-keywords are checked with verify_tk, so it should work)
+            table.insert(ps.tokens, i, { tk = first, y = ps.tokens[i-1].y, x = ps.tokens[i-1].x + 1, kind = "keyword" })
+            return i, list
+         end
       end
    end
    return i, list
@@ -1676,17 +1695,24 @@ do
 
             if not after_valid_prefixexp(ps, e1, prev_i) then
                fail(ps, prev_i, "cannot call this expression")
-               return i + 1
+               return i
             end
 
             e1 = { y = t1.y, x = t1.x, kind = "op", op = op, e1 = e1, e2 = args }
          elseif ps.tokens[i].tk == "[" then
             local op: Operator = new_operator(ps.tokens[i], 2, "@index")
 
+            local prev_i = i
+
             local idx: Node
             i = i + 1
             i, idx = parse_expression(ps, i)
             i = verify_tk(ps, i, "]")
+
+            if not after_valid_prefixexp(ps, e1, prev_i) then
+               fail(ps, prev_i, "cannot index this expression")
+               return i
+            end
 
             e1 = { y = t1.y, x = t1.x, kind = "op", op = op, e1 = e1, e2 = idx }
          elseif ps.tokens[i].tk == "." or ps.tokens[i].tk == ":" then
@@ -1700,12 +1726,13 @@ do
 
             if op.op == ":" then
                if not args_starters[ps.tokens[i].kind] then
-                  return fail(ps, i, "expected a function call for a method")
+                  fail(ps, i, "expected a function call for a method")
+                  return i
                end
 
                if not after_valid_prefixexp(ps, e1, prev_i) then
                   fail(ps, prev_i, "cannot call a method on this expression")
-                  return i + 1
+                  return i
                end
             end
 
@@ -1738,14 +1765,16 @@ do
          local rhs: Node
          i, rhs = P(ps, i)
          if not rhs then
-            return fail(ps, i, "expected an expression")
+            fail(ps, i, "expected an expression")
+            return i
          end
          lookahead = ps.tokens[i].tk
          while precedences[2][lookahead] and ((precedences[2][lookahead] > (precedences[2][op.op]))
             or (is_right_assoc[lookahead] and (precedences[2][lookahead] == precedences[2][op.op]))) do
             i, rhs = E(ps, i, rhs, precedences[2][lookahead])
             if not rhs then
-               return fail(ps, i, "expected an expression")
+               fail(ps, i, "expected an expression")
+               return i
             end
             lookahead = ps.tokens[i].tk
          end
@@ -1756,12 +1785,17 @@ do
 
    parse_expression = function(ps: ParseState, i: number): number, Node, number
       local lhs: Node
+      local istart = i
       i, lhs = P(ps, i)
       i, lhs = E(ps, i, lhs, 0)
       if lhs then
          return i, lhs, 0
       else
-         return fail(ps, i, "expected an expression")
+         if i == istart then
+            return fail(ps, i, "expected an expression")
+         else
+            return i -- a more specific error was already thrown
+         end
       end
    end
 end
@@ -2211,7 +2245,7 @@ parse_record_body = function(ps: ParseState, i: number, def: Type, node: Node): 
          local v: Node
          if ps.tokens[i].tk == "[" then
             i, v = parse_literal(ps, i+1)
-            if not v.conststr then
+            if v and not v.conststr then
                return fail(ps, i, "expected a string literal")
             end
             i = verify_tk(ps, i, "]")

--- a/tl.tl
+++ b/tl.tl
@@ -5229,6 +5229,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          return true
       end
 
+      if t1.typename == "bad_nominal" or t2.typename == "bad_nominal" then
+         return false -- an error has been generated elsewhere
+      end
+
       -- ∀ t, nil <: t
       if t1.typename == "nil" then -- TODO nilable
          return true
@@ -5296,7 +5300,17 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end
          return false, terr(t1, "cannot match against any alternatives of the polymorphic type")
       elseif t1.typename == "nominal" and t2.typename == "nominal" then
-         return are_same_nominals(t1, t2)
+         local same, err = are_same_nominals(t1, t2)
+         if same then
+            return true
+         end
+         local t1u = resolve_unary(t1)
+         local t2u = resolve_unary(t2)
+         if is_record_type(t1u) and is_record_type(t2u) then
+            return same, err
+         else
+            return is_a(t1u, t2u, for_equality)
+         end
       elseif t1.typename == "enum" and t2.typename == "string" then
          local ok: boolean
          if for_equality then

--- a/tl.tl
+++ b/tl.tl
@@ -7307,7 +7307,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             elseif node.op.op == "as" then
                node.type = b
             elseif node.op.op == "is" then
-               if node.e1.kind == "variable" then
+               if ua.typename == "typetype" then
+                  node_error(node, "can only use 'is' on variables, not types")
+               elseif node.e1.kind == "variable" then
                   node.known = Fact { fact = "is", var = node.e1.tk, typ = b, where = node }
                else
                   node_error(node, "can only use 'is' on variables")

--- a/tl.tl
+++ b/tl.tl
@@ -44,6 +44,7 @@ local record tl
    enum WarningKind
       "unused"
       "redeclaration"
+      "branch"
       "debug"
    end
    warning_kinds: {WarningKind:boolean}
@@ -60,6 +61,7 @@ end
 tl.warning_kinds = {
    ["unused"] = true,
    ["redeclaration"] = true,
+   ["branch"] = true,
    ["debug"] = true,
 }
 
@@ -966,12 +968,24 @@ end
 
 local enum FactType
    "is"
+   "and"
+   "or"
+   "not"
 end
 
 local record Fact
    fact: FactType
+   where: Node
+
+   -- is
    var: string
    typ: Type
+
+   -- not, and, or
+   f1: Fact
+   f2: Fact
+
+   metamethod __call: function(Fact, Fact): Fact
 end
 
 local enum KeyParsed
@@ -989,7 +1003,7 @@ local record Node
 
    yend: number
 
-   facts: {Fact}
+   known: Fact
 
    key: Node
    value: Node
@@ -6240,193 +6254,246 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
-   local facts_and: function(f1: {Fact}, f2: {Fact}, errnode: Node): {Fact}
-   local facts_or:  function(f1: {Fact}, f2: {Fact}): {Fact}
-   local facts_not: function(f1: {Fact}): {Fact}
+   -- Inference engine for 'is' operator
+   local facts_and: function(f1: Fact, f2: Fact, where: Node): Fact
+   local facts_or: function(f1: Fact, f2: Fact, where: Node): Fact
+   local facts_not: function(f1: Fact, where: Node): Fact
+   local apply_facts: function(where: Node, known: Fact)
    do
-      local function join_facts(fss: {{Fact}}): {string:{Fact}}
-         local vars: {string:{Fact}} = {}
-
-         for _, fs in ipairs(fss) do
-            for _, f in ipairs(fs) do
-               if not vars[f.var] then
-                  vars[f.var] = {}
+      setmetatable(Fact, {
+         __call = function(_: Fact, f: Fact): Fact
+            return setmetatable(f, {
+               __tostring = function(f: Fact): string
+                  if f.fact == "is" then
+                     return ("(%s is %s)"):format(f.var, show_type(f.typ))
+                  elseif f.fact == "not" then
+                     return ("(not %s)"):format(tostring(f.f1))
+                  elseif f.fact == "or" then
+                     return ("(%s or %s)"):format(tostring(f.f1), tostring(f.f2))
+                  elseif f.fact == "and" then
+                     return ("(%s and %s)"):format(tostring(f.f1), tostring(f.f2))
+                  end
                end
-               table.insert(vars[f.var], f)
-            end
+            })
+         end,
+      })
+
+      facts_and = function(f1: Fact, f2: Fact, where: Node): Fact
+         if f1 and f2 then
+            return Fact { fact = "and", f1 = f1, f2 = f2, where = where }
+         elseif f1 then
+            return f1
+         elseif f2 then
+            return f2
          end
-         return vars
       end
 
-      local function intersect<T>(xs: {T}, ys: {T}, same: function(T, T): boolean): {T}
-         local rs = {}
-         for i = #xs, 1, -1 do
-            local x = xs[i]
-            for _, y in ipairs(ys) do
-               if same(x, y) then
-                  table.insert(rs, x)
-                  break
-               end
-            end
+      facts_or = function(f1: Fact, f2: Fact, where: Node): Fact
+         if f1 and f2 then
+            return Fact { fact = "or", f1 = f1, f2 = f2, where = where }
+         else
+            return nil
          end
-         return rs
       end
 
-      local function same_type_for_intersect(t: Type, u: Type): boolean
-         return (same_type(t, u))
+      facts_not = function(f1: Fact, where: Node): Fact
+         if f1 then
+            return Fact { fact = "not", f1 = f1, where = where }
+         else
+            return nil
+         end
       end
 
-      local function intersect_facts(fs: {Fact}, errnode: Node): boolean, Type
-         local all_is = true
-         local types = {}
-         for i, f in ipairs(fs) do
-            if f.fact ~= "is" then
-               all_is = false
-               break
-            end
-            if f.typ.typename == "union" then
-               if i == 1 then
-                  types = f.typ.types
-               else
-                  types = intersect(types, f.typ.types, same_type_for_intersect)
+      -- t1 ∪ t2
+      local function unite_types(t1: Type, t2: Type): Type, string
+         return unite({t2, t1})
+      end
+
+      -- t1 ∩ t2
+      local function intersect_types(t1: Type, t2: Type): Type, string
+         if t2.typename == "union" then
+            t1, t2 = t2, t1
+         end
+         if t1.typename == "union" then
+            local out = {}
+            for _, t in ipairs(t1.types) do
+               if is_a(t, t2) then
+                  table.insert(out, t)
                end
+            end
+            return unite(out)
+         else
+            if is_a(t1, t2) then
+               return t1
+            elseif is_a(t2, t1) then
+               return t2
             else
-               if i == 1 then
-                  types = { f.typ }
-               else
-                  types = intersect(types, { f.typ }, same_type_for_intersect)
-               end
+               return INVALID
             end
-         end
-
-         if #types == 0 then
-            node_error(errnode, "branch is always false")
-            return false
-         end
-
-         if all_is then
-            return true, unite(types)
-         else
-            return false
          end
       end
 
-      local function sum_facts(fs: {Fact}): boolean, Type
-         local all_is = true
-         local types: {Type} = {}
-         for _, f in ipairs(fs) do
-            if f.fact ~= "is" then
-               all_is = false
-               break
-            end
-            table.insert(types, f.typ)
+      local function resolve_if_union(t: Type): Type
+         local u = resolve_unary(t)
+         if u.typename == "union" then
+            return u
          end
-
-         if all_is then
-            return true, unite(types)
-         else
-            return false
-         end
+         return t
       end
 
-      local function subtract_types(u1: Type, u2: Type, errt: Type): Type
+      -- t1 - t2
+      local function subtract_types(t1: Type, t2: Type): Type, string
          local types: {Type} = {}
-         for _, rt in ipairs(u1.types or { u1 }) do
+
+         t1 = resolve_if_union(t1)
+
+         -- things like "not x is string" given "x: any" can't be narrowed.
+         -- also, poly are not first-class, so we don't handle them here
+         if t1.typename ~= "union" then
+            return t1, "type cannot be narrowed in this branch"
+         end
+
+         t2 = resolve_if_union(t2)
+         local t2types = t2.types or { t2 }
+
+         for _, at in ipairs(t1.types) do
             local not_present = true
-            for _, ft in ipairs(u2.types or { u2 }) do
-               if same_type(rt, ft) then
+            for _, bt in ipairs(t2types) do
+               if same_type(at, bt) then
                   not_present = false
                   break
                end
             end
             if not_present then
-               table.insert(types, rt)
+               table.insert(types, at)
             end
          end
 
          if #types == 0 then
-            type_error(errt, "branch is always false")
-            return INVALID
+            return INVALID, "no valid types match in this branch"
          end
 
          return unite(types)
       end
 
-      facts_and = function(f1: {Fact}, f2: {Fact}, errnode: Node): {Fact}
-         if not f1 then
-            return f2
-         end
-         if not f2 then
-            return f1
-         end
+      local eval_not: function(f: Fact): {string:Type}
+      local or_types: function(vs1: {string:Type}, vs2: {string:Type}): {string:Type}
+      local and_types: function(vs1: {string:Type}, vs2: {string:Type}): {string:Type}
+      local eval_fact: function(f: Fact): {string:Type}
 
-         local out: {Fact} = {}
-         for v, fs in pairs(join_facts({f1, f2})) do
-            local ok, u = intersect_facts(fs, errnode)
-
-            if ok then
-               table.insert(out, { fact = "is", var = v, typ = u })
-            else
-               -- FIXME handle non-"is" facts... when we have them
-               for _, f in ipairs(fs) do
-                  table.insert(out, f)
-               end
-            end
-         end
-         return out
-      end
-
-      facts_or = function(f1: {Fact}, f2: {Fact}): {Fact}
-         if not f1 or not f2 then
-            return nil
-         end
-
-         local out: {Fact} = {}
-         for v, fs in pairs(join_facts({f1, f2})) do
-            local ok, u = sum_facts(fs)
-            if ok then
-               table.insert(out, { fact = "is", var = v, typ = u })
-            else
-               -- FIXME handle non-"is" facts... when we have them
-               for _, f in ipairs(fs) do
-                  table.insert(out, f)
-               end
-            end
-         end
-         return out
-      end
-
-      facts_not = function(f1: {Fact}): {Fact}
-         if not f1 then
-            return nil
-         end
-
-         local out: {Fact} = {}
-         for v, fs in pairs(join_facts({f1})) do
-            local realtype = find_var_type(v)
-            if realtype then
-               realtype = resolve_unary(realtype)
-               local ok, u = sum_facts(fs) -- is this correct?
-               if ok then
-                  local not_typ = subtract_types(realtype, u, fs[1].typ)
-                  table.insert(out, { fact = "is", var = v, typ = not_typ })
-               end
-            end
-         end
-         return out
-      end
-   end
-
-   local function apply_facts(where: Node, facts: {Fact})
-      if not facts then
-         return
-      end
-      for _, f in ipairs(facts) do
+      eval_not = function(f: Fact): {string:Type}
          if f.fact == "is" then
-            local t = shallow_copy(f.typ) -- new type object
+            local typ = find_var_type(f.var, true)
+            if not typ then
+               return { [f.var] = INVALID }
+            end
+            if not is_a(f.typ, typ) then
+               node_warning("branch", f.where, f.var .. " (of type %s) can never be a %s", show_type(typ), show_type(f.typ))
+               return { [f.var] = INVALID }
+            else
+               local sub, warn = subtract_types(typ, f.typ)
+               if warn then
+                  node_warning("branch", f.where, f.var .. ": " .. warn)
+               end
+               return { [f.var] = sub }
+            end
+         elseif f.fact == "not" then
+            return eval_fact(f.f1)
+         elseif f.fact == "and" then
+            return or_types(eval_not(f.f1), eval_not(f.f2))
+         elseif f.fact == "or" then
+            return and_types(eval_not(f.f1), eval_not(f.f2))
+         end
+      end
+
+      or_types = function(vs1: {string:Type}, vs2: {string:Type}): {string:Type}
+         local realtypes: {string:Type} = {}
+
+         local ret: {string:Type} = {}
+
+         for var, typ in pairs(vs1) do
+            local vt = find_var_type(var, true) or INVALID
+            realtypes[var] = vt
+            if not is_a(typ, vt) then
+               return vs2
+            end
+            ret[var] = typ
+         end
+
+         for var, typ in pairs(vs2) do
+            local vt = realtypes[var] or find_var_type(var, true) or INVALID
+            realtypes[var] = vt
+            if not is_a(typ, vt) then
+               return vs1
+            end
+            ret[var] = unite_types(typ, ret[var])
+         end
+
+         return ret
+      end
+
+      and_types = function(vs1: {string:Type}, vs2: {string:Type}): {string:Type}
+         local realtypes: {string:Type} = {}
+
+         local ret: {string:Type} = {}
+
+         for var, typ in pairs(vs1) do
+            local vt = find_var_type(var, true) or INVALID
+            realtypes[var] = vt
+            if not is_a(typ, vt) then
+               return {}
+            end
+            ret[var] = typ
+         end
+
+         for var, typ in pairs(vs2) do
+            local vt = realtypes[var] or find_var_type(var, true) or INVALID
+            realtypes[var] = vt
+            if not is_a(typ, vt) then
+               return {}
+            end
+            ret[var] = ret[var] and intersect_types(typ, ret[var]) or typ
+         end
+
+         return ret
+      end
+
+      eval_fact = function(f: Fact): {string:Type}
+         if f.fact == "is" then
+            local typ = find_var_type(f.var, true)
+            if not typ then
+               return { [f.var] = INVALID }
+            end
+            if not is_a(f.typ, typ) then
+               node_error(f.where, f.var .. " (of type %s) can never be a %s", typ, f.typ)
+               return { [f.var] = INVALID }
+            else
+               return { [f.var] = f.typ }
+            end
+         elseif f.fact == "not" then
+            return eval_not(f.f1)
+         elseif f.fact == "and" then
+            return and_types(eval_fact(f.f1), eval_fact(f.f2))
+         elseif f.fact == "or" then
+            return or_types(eval_fact(f.f1), eval_fact(f.f2))
+         end
+      end
+
+      apply_facts = function(where: Node, known: Fact)
+         if not known then
+            return
+         end
+
+         local vars = eval_fact(known)
+
+         for v, t in pairs(vars) do
+            if t.typename == "invalid" then
+               node_error(where, "cannot resolve a type for " .. v .. " here")
+            end
+            t = shallow_copy(t) -- new type object
             t.inferred_at = where
             t.inferred_at_file = filename
-            add_var(nil, f.var, t, nil, true)
+            add_var(nil, v, t, nil, true)
          end
       end
    end
@@ -6708,7 +6775,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       ["if"] = {
          before_statements = function(node: Node)
             begin_scope()
-            apply_facts(node.exp, node.exp.facts)
+            apply_facts(node.exp, node.exp.known)
          end,
          after = function(node: Node, _children: {Type}): Type
             end_scope()
@@ -6719,14 +6786,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          before = function(node: Node)
             end_scope()
             begin_scope()
-            local f = facts_not(node.parent_if.exp.facts)
+            local f = facts_not(node.parent_if.exp.known)
             for e = 1, node.elseif_n - 1 do
-               f = facts_and(f, facts_not(node.parent_if.elseifs[e].exp.facts), node)
+               f = facts_and(f, facts_not(node.parent_if.elseifs[e].exp.known), node)
             end
             apply_facts(node.exp, f)
          end,
          before_statements = function(node: Node)
-            apply_facts(node.exp, node.exp.facts)
+            apply_facts(node.exp, node.exp.known)
          end,
          after = function(node: Node, _children: {Type}): Type
             node.type = NONE
@@ -6736,9 +6803,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          before = function(node: Node)
             end_scope()
             begin_scope()
-            local f = facts_not(node.parent_if.exp.facts)
+            local f = facts_not(node.parent_if.exp.known)
             for _, elseifnode in ipairs(node.parent_if.elseifs) do
-               f = facts_and(f, facts_not(elseifnode.exp.facts), node)
+               f = facts_and(f, facts_not(elseifnode.exp.known), node)
             end
             apply_facts(node, f)
          end,
@@ -6753,7 +6820,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
          before_statements = function(node: Node)
             begin_scope()
-            apply_facts(node.exp, node.exp.facts)
+            apply_facts(node.exp, node.exp.known)
          end,
          after = function(node: Node, _children: {Type}): Type
             end_scope()
@@ -7202,7 +7269,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       },
       ["paren"] = {
          after = function(node: Node, children: {Type}): Type
-            node.facts = node.e1 and node.e1.facts
+            node.known = node.e1 and node.e1.known
             node.type = resolve_unary(children[1])
          end,
       },
@@ -7212,9 +7279,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
          before_e2 = function(node: Node)
             if node.op.op == "and" then
-               apply_facts(node, node.e1.facts)
+               apply_facts(node, node.e1.known)
             elseif node.op.op == "or" then
-               apply_facts(node, facts_not(node.e1.facts))
+               apply_facts(node, facts_not(node.e1.known))
             end
          end,
          after = function(node: Node, children: {Type}): Type
@@ -7241,7 +7308,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                node.type = b
             elseif node.op.op == "is" then
                if node.e1.kind == "variable" then
-                  node.facts = { { fact = "is", var = node.e1.tk, typ = b } }
+                  node.known = Fact { fact = "is", var = node.e1.tk, typ = b, where = node }
                else
                   node_error(node, "can only use 'is' on variables")
                end
@@ -7266,24 +7333,24 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             elseif node.op.op == ":" then
                node.type = match_record_key(node, node.e1.type, node.e2, orig_a)
             elseif node.op.op == "not" then
-               node.facts = facts_not(node.e1.facts)
+               node.known = facts_not(node.e1.known)
                node.type = BOOLEAN
             elseif node.op.op == "and" then
-               node.facts = facts_and(node.e1.facts, node.e2.facts, node)
+               node.known = facts_and(node.e1.known, node.e2.known, node)
                node.type = resolve_tuple(b)
             elseif node.op.op == "or" and b.typename == "emptytable" then
-               node.facts = nil
+               node.known = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "or" and is_a(ub, ua) then
-               node.facts = facts_or(node.e1.facts, node.e2.facts)
+               node.known = facts_or(node.e1.known, node.e2.known)
                node.type = resolve_tuple(a)
             elseif node.op.op == "or" and b.typename == "nil" then
-               node.facts = nil
+               node.known = nil
                node.type = resolve_tuple(a)
             elseif node.op.op == "or"
                    and ((ua.typename == "enum" and ub.typename == "string" and is_a(ub, ua))
                     or  (ua.typename == "string" and ub.typename == "enum" and is_a(ua, ub))) then
-               node.facts = nil
+               node.known = nil
                node.type = (ua.typename == "enum" and ua or ub)
             elseif node.op.op == "==" or node.op.op == "~=" then
                if is_a(a, b, true) or is_a(b, a, true) then
@@ -7323,7 +7390,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
             elseif node.op.arity == 2 and binop_types[node.op.op] then
                if node.op.op == "or" then
-                  node.facts = facts_or(node.e1.facts, node.e2.facts)
+                  node.known = facts_or(node.e1.known, node.e2.known)
                end
 
                a = ua


### PR DESCRIPTION
Two main changes in this PR:

* Establishes that nominal checking applies only to records, not other types. This makes the type system structural for all other types (functions, unions, etc.), which avoids surprises when behavior would change when a long type such as a union was abbreviated via a `local type`. This causes the original example in #269 to typecheck correctly because that example uses a number, but that issue as a whole is still not resolved, but I have some more thoughts on that matter that I'm yet to implement.

* New inference engine for the `is` operator. This is more of a bugfix than a feature, because it now "behaves more like what you expect", by implementing negation correctly, applying DeMorgan's Laws. It fixes the testcase by @Zash in #201, and is probably a lot more robust for complex expressions. It also addresses the test case attempted by @Fang- [here](https://github.com/teal-language/tl/issues/210#issuecomment-716061485), providing a better error message. It still does not calculate fixpoints and does not propagate known facts across statements (it only computes facts within a single expression), so there's still room for improvement, but it's a step forward.

Fixes #210.