### PR TITLE
Add fixed length array syntactic sugar for tuples

### DIFF
--- a/spec/declaration/tuple_spec.lua
+++ b/spec/declaration/tuple_spec.lua
@@ -48,4 +48,23 @@ describe("tuple declarations", function()
       local a: {number, string} = { [1] = 10, [2] = "hello" }
       local b: {number, string} = { [2] = "hello", [1] = 10 }
    ]])
+
+   describe("fixed length array syntactic sugar", function()
+      it("should not error", util.check [[
+         local _arr: { 3 of number }
+      ]])
+      it("should be compatible with regular tuples", util.check [[
+         local _a: { 3 of number } = {} as {number, number, number}
+      ]])
+      it("should be used when showing a unary tuple", util.check_warnings([[
+         local a: { 1 of number }
+      ]], {
+         { y = 1, msg = "unused variable a: {1 of number}"}
+      }))
+      it("should report an error when something other than a positive integer is used", util.check_syntax_error([[
+         local arr: {1.5 of number}
+      ]], {
+         { y = 1, msg = "expected a positive integer, got 1.5" }
+      }))
+   end)
 end)

--- a/tl.tl
+++ b/tl.tl
@@ -1353,6 +1353,10 @@ local function parse_function_type(ps: ParseState, i: number): number, Type
    return i, typ
 end
 
+local function is_positive_int(n: number): boolean
+   return n and n >= 1 and math.floor(n) == n
+end
+
 local function parse_base_type(ps: ParseState, i: number): number, Type, number
    if ps.tokens[i].tk == "string"
       or ps.tokens[i].tk == "boolean"
@@ -1374,6 +1378,21 @@ local function parse_base_type(ps: ParseState, i: number): number, Type, number
       i = i + 1
       local decl = new_type(ps, i, "array")
       local t: Type
+      if ps.tokens[i].kind == "number" then
+         local len <const> = tonumber(ps.tokens[i].tk)
+         if not is_positive_int(len) then
+            fail(ps, i, "expected a positive integer, got " .. ps.tokens[i].tk)
+         end
+         i = verify_tk(ps, i+1, "of")
+         i, t = parse_type(ps, i)
+         i = verify_tk(ps, i, "}")
+         decl.typename = "tupletable"
+         decl.types = {}
+         for _ = 1, len do
+            table.insert(decl.types, t)
+         end
+         return i, decl
+      end
       i, t = parse_type(ps, i)
       if ps.tokens[i].tk == "}" then
          decl.elements = t
@@ -3736,8 +3755,17 @@ local function show_type_base(t: Type, seen: {Type:string}): string
       return "(" .. table.concat(out, ", ") .. ")"
    elseif t.typename == "tupletable" then
       local out: {string} = {}
+      local all_same = true
+      local last_t: Type
       for _, v in ipairs(t.types) do
+         if last_t and v ~= last_t then
+            all_same = false
+         end
          table.insert(out, show(v))
+         last_t = v
+      end
+      if all_same then
+         return "{" .. tostring(#t.types) .. " of " .. show(t.types[1]) .. "}"
       end
       return "{" .. table.concat(out, ", ") .. "}"
    elseif t.typename == "poly" then
@@ -6899,10 +6927,6 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                x = node.x,
                typename = "emptytable",
             }
-
-            local function is_positive_int(n: number): boolean
-               return n and n >= 1 and math.floor(n) == n
-            end
 
             local is_record = false
             local is_array = false


### PR DESCRIPTION
Fixed length arrays are a good use case of tuples that should be
encouraged, so adding some sugar to do something like
`{4 of number}` rather than `{number,number,number,number}` makes them
easier to use.

Additionally, unary tuples can now be represented without resorting to
using a trailing `nil`

Closes #341
Still not 100% sold on the `of` syntax, but it's fitting enough and I can't think of anything better :P