### PR TITLE
Add --gen-compat and --gen-target

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ Teal
 
 This is the repository of **tl**, the compiler for Teal, a typed dialect of Lua.
 
+The core compiler has no dependencies and is implemented as a single `tl.lua`
+file which you can load into your projects. Running `tl.loader()` will add
+Teal support to your package loader, meaning that `require()` will be able to
+run `.tl` files.
+
 ## Introduction
 
 Here are videos of talks given at FOSDEM 2019 and 2020 which discuss the

--- a/spec/call/string_method_spec.lua
+++ b/spec/call/string_method_spec.lua
@@ -39,7 +39,7 @@ describe("string method call", function()
          print(("%s"):format"%s":format(2))
          print(("%s b"):format"a":upper())
       ]], [[
-         local _tl_compat53; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if m then _tl_compat53 = m end end; local string = _tl_compat53 and _tl_compat53.string or string
+         local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local string = _tl_compat and _tl_compat.string or string
          print(("xy"):rep(12):sub(1,3))
          print(("%s"):format("%s"):format(2))
          print(("%s b"):format("a"):upper())

--- a/spec/call/string_method_spec.lua
+++ b/spec/call/string_method_spec.lua
@@ -39,7 +39,7 @@ describe("string method call", function()
          print(("%s"):format"%s":format(2))
          print(("%s b"):format"a":upper())
       ]], [[
-         local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) and require('compat53.module'); local string = _tl_compat53 and _tl_compat53.string or string
+         local _tl_compat53; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if m then _tl_compat53 = m end end; local string = _tl_compat53 and _tl_compat53.string or string
          print(("xy"):rep(12):sub(1,3))
          print(("%s"):format("%s"):format(2))
          print(("%s b"):format("a"):upper())

--- a/spec/cli/gen_spec.lua
+++ b/spec/cli/gen_spec.lua
@@ -190,7 +190,7 @@ describe("tl gen", function()
          local lua_name = tl_to_lua(name)
          assert.match("Wrote: " .. lua_name, output, 1, true)
          util.assert_line_by_line([[
-            local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) and require('compat53.module'); local table = _tl_compat53 and _tl_compat53.table or table; local _tl_table_unpack = unpack or table.unpack; local t = { 1, 2, 3, 4 }
+            local _tl_compat53; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if m then _tl_compat53 = m end end; local table = _tl_compat53 and _tl_compat53.table or table; local _tl_table_unpack = unpack or table.unpack; local t = { 1, 2, 3, 4 }
             print(_tl_table_unpack(t))
          ]], util.read_file(lua_name))
       end)

--- a/spec/compat/lua_versions_spec.lua
+++ b/spec/compat/lua_versions_spec.lua
@@ -25,7 +25,7 @@ describe("Lua version compatibility", function()
          local c = 0xcafebabe
          local x = 2 & (c >> ~4 | 0xff)
       ]], [[
-         local bit32 = bit32 or require('bit32')
+         local bit32 = bit32; if not bit32 then local p, m = pcall(require, 'bit32'); if m then bit32 = m end end
 
          local c = 0xcafebabe
          local x = bit32.band(2, (bit32.bor(bit32.rshift(c, bit32.bnot(4)), 0xff)))

--- a/spec/compat/lua_versions_spec.lua
+++ b/spec/compat/lua_versions_spec.lua
@@ -25,7 +25,7 @@ describe("Lua version compatibility", function()
          local c = 0xcafebabe
          local x = 2 & (c >> ~4 | 0xff)
       ]], [[
-         local bit32 = bit32; if not bit32 then local p, m = pcall(require, 'bit32'); if m then bit32 = m end end
+         local bit32 = bit32; if not bit32 then local p, m = pcall(require, 'bit32'); if p then bit32 = m end end
 
          local c = 0xcafebabe
          local x = bit32.band(2, (bit32.bor(bit32.rshift(c, bit32.bnot(4)), 0xff)))

--- a/tl
+++ b/tl
@@ -43,6 +43,15 @@ local function find_in_sequence(seq, value)
    return false
 end
 
+local function keys(t)
+   local ks = {}
+   for k, _ in pairs(t) do
+      table.insert(ks, k)
+   end
+   table.sort(ks)
+   return ks
+end
+
 -- FIXME
 local function validate_config(config)
    local valid_keys = {
@@ -55,6 +64,8 @@ local function validate_config(config)
       quiet = "boolean",
       source_dir = "string",
       skip_compat53 = "boolean",
+      gen_compat = { ["off"] = true, ["optional"] = true, ["required"] = true },
+      gen_target = { ["5.1"] = true, ["5.3"] = true },
       disable_warnings = "{string}",
       warning_error = "{string}",
    }
@@ -62,6 +73,11 @@ local function validate_config(config)
    for k, v in pairs(config) do
       if not valid_keys[k] then
          print(string.format("Warning: unknown key '%s' in tlconfig.lua", k))
+      elseif type(valid_keys[k]) == "table" then
+         if not valid_keys[k][v] then
+            return "Invalid value for " .. k .. ", expected one of: " ..
+                   table.concat(keys(valid_keys[k][v]), ", ")
+         end
       else
          -- TODO: could we type-check the config file using tl?
          local arr_type = valid_keys[k]:match("{(.*)}")
@@ -80,6 +96,10 @@ local function validate_config(config)
             end
          end
       end
+   end
+
+   if config.skip_compat53 then
+      config.gen_compat = "off"
    end
 
    if config.disable_warnings then
@@ -173,7 +193,17 @@ local function get_args_parser()
 
    parser:option("--warning-error-all")
 
+   parser:option("--gen-compat", "Generate compatibility code for targeting different Lua VM versions.")
+         :choices({ "off", "optional", "required" })
+         :default("optional")
+         :defmode("a")
+
+   parser:option("--gen-target", "Minimum targeted Lua version for generated code.")
+         :choices({ "5.1", "5.3" })
+
    parser:flag("--skip-compat53", "Skip compat53 insertions.")
+         :hidden(true)
+         :action(function(args) args.gen_compat = "off" end)
 
    parser:flag("--version", "Print version and exit")
 
@@ -308,7 +338,9 @@ if cmd == "build" then
    tlconfig["source_dir"] = args["source_dir"] or tlconfig["source_dir"]
    tlconfig["build_dir"] = args["build_dir"] or tlconfig["build_dir"]
 end
-tlconfig["skip_compat53"] = args["skip_compat53"] or tlconfig["skip_compat53"]
+tlconfig["gen_target"] = args["gen_target"] or tlconfig["gen_target"]
+tlconfig["gen_compat"] = args["gen_compat"] or tlconfig["gen_compat"]
+                                            or (tlconfig["skip_compat53"] and "off")
 if cmd == "gen" and args["output"] and #args["file"] ~= 1 then
    print("Error: --output can only be used to map one input to one output")
    os.exit(1)
@@ -408,9 +440,10 @@ local function setup_env(filename)
          lax_mode = false
       end
 
-      local skip_compat53 = tlconfig["skip_compat53"]
+      local gen_compat = tlconfig["gen_compat"]
+      local gen_target = tlconfig["gen_target"]
 
-      env = tl.init_env(lax_mode, skip_compat53)
+      env = tl.init_env(lax_mode, gen_compat, gen_target)
    end
 end
 

--- a/tl.lua
+++ b/tl.lua
@@ -1,4 +1,4 @@
-local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) and require('compat53.module'); local assert = _tl_compat53 and _tl_compat53.assert or assert; local io = _tl_compat53 and _tl_compat53.io or io; local ipairs = _tl_compat53 and _tl_compat53.ipairs or ipairs; local load = _tl_compat53 and _tl_compat53.load or load; local math = _tl_compat53 and _tl_compat53.math or math; local os = _tl_compat53 and _tl_compat53.os or os; local package = _tl_compat53 and _tl_compat53.package or package; local pairs = _tl_compat53 and _tl_compat53.pairs or pairs; local string = _tl_compat53 and _tl_compat53.string or string; local table = _tl_compat53 and _tl_compat53.table or table; local _tl_table_unpack = unpack or table.unpack
+local _tl_compat53; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if m then _tl_compat53 = m end end; local assert = _tl_compat53 and _tl_compat53.assert or assert; local io = _tl_compat53 and _tl_compat53.io or io; local ipairs = _tl_compat53 and _tl_compat53.ipairs or ipairs; local load = _tl_compat53 and _tl_compat53.load or load; local math = _tl_compat53 and _tl_compat53.math or math; local os = _tl_compat53 and _tl_compat53.os or os; local package = _tl_compat53 and _tl_compat53.package or package; local pairs = _tl_compat53 and _tl_compat53.pairs or pairs; local string = _tl_compat53 and _tl_compat53.string or string; local table = _tl_compat53 and _tl_compat53.table or table; local _tl_table_unpack = unpack or table.unpack
 local TypeCheckOptions = {}
 
 
@@ -4426,23 +4426,25 @@ local function add_compat53_entries(program, used_set)
          local _
          _, code = tl.parse_program(tokens, {}, "@internal")
          tl.type_check(code, { lax = false, skip_compat53 = true })
-         code = code[1]
+         code = code
          compat53_code_cache[name] = code
       end
-      table.insert(program, n, code)
-      n = n + 1
+      for _, c in ipairs(code) do
+         table.insert(program, n, c)
+         n = n + 1
+      end
    end
 
    for _, name in ipairs(used_list) do
       if name == "table.unpack" then
          load_code(name, "local _tl_table_unpack = unpack or table.unpack")
       elseif name == "bit32" then
-         load_code(name, "local bit32 = bit32 or require('bit32')")
+         load_code(name, "local bit32 = bit32; if not bit32 then local p, m = pcall(require, 'bit32'); if m then bit32 = m; end")
       elseif name == "mt" then
          load_code(name, "local _tl_mt = function(m, s, a, b) return (getmetatable(s == 1 and a or b)[m](a, b) end")
       else
          if not compat53_loaded then
-            load_code("compat53", "local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) and require('compat53.module')")
+            load_code("compat53", "local _tl_compat53; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if m then _tl_compat53 = m; end")
             compat53_loaded = true
          end
          load_code(name, (("local $NAME = _tl_compat53 and _tl_compat53.$NAME or $NAME"):gsub("$NAME", name)))

--- a/tl.tl
+++ b/tl.tl
@@ -2942,12 +2942,36 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
       h: number
    end
 
-   local function increment_indent()
-      indent = indent + 1
+   local save_indent: {number} = {}
+
+   local function increment_indent(node: Node)
+      local child = node.body or node.thenpart or node[1]
+      if not child then
+         return
+      end
+      if child.y ~= node.y then
+         if indent == 0 and #save_indent > 0 then
+            indent = save_indent[#save_indent] + 1
+         else
+            indent = indent + 1
+         end
+      else
+         table.insert(save_indent, indent)
+         indent = 0
+      end
+   end
+
+   local function decrement_indent(node: Node, child: Node)
+      if child.y ~= node.y then
+         indent = indent - 1
+      else
+         indent = table.remove(save_indent)
+      end
    end
 
    if not opts.preserve_indent then
       increment_indent = nil
+      decrement_indent = function() end
    end
 
    local function add_string(out: Output, s: string)
@@ -3081,7 +3105,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             add_child(out, children[1], " ")
             table.insert(out, " then")
             add_child(out, children[2], " ")
-            indent = indent - 1
+            decrement_indent(node, node.thenpart)
             for i = 3, #children do
                add_child(out, children[i], " ", indent)
             end
@@ -3097,7 +3121,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             add_child(out, children[1], " ")
             table.insert(out, " do")
             add_child(out, children[2], " ")
-            indent = indent - 1
+            decrement_indent(node, node.body)
             add_child(out, { y = node.yend, h = 0, [1] = "end" }, " ", indent)
             return out
          end,
@@ -3108,9 +3132,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             local out: Output = { y = node.y, h = 0 }
             table.insert(out, "repeat")
             add_child(out, children[1], " ")
-            if opts.preserve_indent then
-               indent = indent - 1
-            end
+            decrement_indent(node, node.body)
             add_child(out, { y = node.yend, h = 0, [1] = "until " }, " ", indent)
             add_child(out, children[2])
             return out
@@ -3122,7 +3144,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             local out: Output = { y = node.y, h = 0 }
             table.insert(out, "do")
             add_child(out, children[1], " ")
-            indent = indent - 1
+            decrement_indent(node, node.body)
             add_child(out, { y = node.yend, h = 0, [1] = "end" }, " ", indent)
             return out
          end,
@@ -3137,7 +3159,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             add_child(out, children[2], " ")
             table.insert(out, " do")
             add_child(out, children[3], " ")
-            indent = indent - 1
+            decrement_indent(node, node.body)
             add_child(out, { y = node.yend, h = 0, [1] = "end" }, " ", indent)
             return out
          end,
@@ -3158,7 +3180,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             end
             table.insert(out, " do")
             add_child(out, children[5], " ")
-            indent = indent - 1
+            decrement_indent(node, node.body)
             add_child(out, { y = node.yend, h = 0, [1] = "end" }, " ", indent)
             return out
          end,
@@ -3207,7 +3229,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
                   table.insert(out, ",")
                   space = " "
                end
-               add_child(out, child, space)
+               add_child(out, child, space, child.y ~= node.y and indent)
             end
             return out
          end,
@@ -3217,7 +3239,6 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
          after = function(node: Node, children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
             if #children == 0 then
-               indent = indent - 1
                table.insert(out, "{}")
                return out
             end
@@ -3229,7 +3250,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
                   table.insert(out, ",")
                end
             end
-            indent = indent - 1
+            decrement_indent(node, node[1])
             add_child(out, { y = node.yend, h = 0, [1] = "}" }, " ", indent)
             return out
          end,
@@ -3262,7 +3283,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             add_child(out, children[2])
             table.insert(out, ")")
             add_child(out, children[4], " ")
-            indent = indent - 1
+            decrement_indent(node, node.body)
             add_child(out, { y = node.yend, h = 0, [1] = "end" }, " ", indent)
             return out
          end,
@@ -3277,7 +3298,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             add_child(out, children[2])
             table.insert(out, ")")
             add_child(out, children[4], " ")
-            indent = indent - 1
+            decrement_indent(node, node.body)
             add_child(out, { y = node.yend, h = 0, [1] = "end" }, " ", indent)
             return out
          end,
@@ -3302,7 +3323,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             add_child(out, children[3])
             table.insert(out, ")")
             add_child(out, children[5], " ")
-            indent = indent - 1
+            decrement_indent(node, node.body)
             add_child(out, { y = node.yend, h = 0, [1] = "end" }, " ", indent)
             return out
          end,
@@ -3315,7 +3336,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             add_child(out, children[1])
             table.insert(out, ")")
             add_child(out, children[3], " ")
-            indent = indent - 1
+            decrement_indent(node, node.body)
             add_child(out, { y = node.yend, h = 0, [1] = "end" }, " ", indent)
             return out
          end,

--- a/tl.tl
+++ b/tl.tl
@@ -92,39 +92,6 @@ local TargetMode = tl.TargetMode
 -- Lexer
 --------------------------------------------------------------------------------
 
---local inspect: function(any):string = require "inspect"
-
-local inspect = function(x: any):string
-   return tostring(x)
-end
-
-local keywords: {string:boolean} = {
-   ["and"] = true,
-   ["break"] = true,
-   ["do"] = true,
-   ["else"] = true,
-   ["elseif"] = true,
-   ["end"] = true,
-   ["false"] = true,
-   ["for"] = true,
-   ["function"] = true,
-   ["goto"] = true,
-   ["if"] = true,
-   ["in"] = true,
-   ["local"] = true,
-   ["nil"] = true,
-   ["not"] = true,
-   ["or"] = true,
-   ["repeat"] = true,
-   ["return"] = true,
-   ["then"] = true,
-   ["true"] = true,
-   ["until"] = true,
-   ["while"] = true,
-
---   ["global"] = true,
-}
-
 local enum TokenKind
    "keyword"
    "op"
@@ -148,659 +115,688 @@ local record Token
    kind: TokenKind
 end
 
-local lex_word_start: {string:boolean} = {}
-for c = string.byte("a"), string.byte("z") do
-   lex_word_start[string.char(c)] = true
-end
-for c = string.byte("A"), string.byte("Z") do
-   lex_word_start[string.char(c)] = true
-end
-lex_word_start["_"] = true
-
-local lex_word: {string:boolean} = {}
-for c = string.byte("a"), string.byte("z") do
-   lex_word[string.char(c)] = true
-end
-for c = string.byte("A"), string.byte("Z") do
-   lex_word[string.char(c)] = true
-end
-for c = string.byte("0"), string.byte("9") do
-   lex_word[string.char(c)] = true
-end
-lex_word["_"] = true
-
-local lex_decimal_start: {string:boolean} = {}
-for c = string.byte("1"), string.byte("9") do
-   lex_decimal_start[string.char(c)] = true
-end
-
-local lex_decimals: {string:boolean} = {}
-for c = string.byte("0"), string.byte("9") do
-   lex_decimals[string.char(c)] = true
-end
-
-local lex_hexadecimals: {string:boolean} = {}
-for c = string.byte("0"), string.byte("9") do
-   lex_hexadecimals[string.char(c)] = true
-end
-for c = string.byte("a"), string.byte("f") do
-   lex_hexadecimals[string.char(c)] = true
-end
-for c = string.byte("A"), string.byte("F") do
-   lex_hexadecimals[string.char(c)] = true
-end
-
-local lex_char_symbols: {string:boolean} = {}
-for _, c in ipairs({"[", "]", "(", ")", "{", "}", ",", "#", "`", ";"}) do
-   lex_char_symbols[c] = true
-end
-
-local lex_op_start: {string:boolean} = {}
-for _, c in ipairs({"+", "*", "|", "&", "%", "^"}) do
-   lex_op_start[c] = true
-end
-
-local lex_space: {string:boolean} = {}
-for _, c in ipairs({" ", "\t", "\v", "\n", "\r"}) do
-   lex_space[c] = true
-end
-
-local enum LexState
-   "start"
-   "any"
-   "identifier"
-   "maybecomment"
-   "maybecomment2"
-   "maybedotdot"
-   "maybedotdotdot"
-   "decimal_number"
-   "decimal_or_hex"
-   "decimal_float"
-   "power"
-   "power_sign"
-   "hex_number"
-   "hex_float"
-   "lt"
-   "gt"
-   "div"
-   "colon"
-   "maybeequals"
-   "maybelongstring"
-   "dblquote_string"
-   "singlequote_string"
-   "escape_dblquote_string"
-   "escape_singlequote_string"
-   "comment"
-   "longcomment"
-   "maybelongcomment"
-   "maybelongcommentend"
-   "longstring"
-   "maybelongstring"
-   "maybelongstringend"
-end
-
-local escapable_characters: {string:boolean} = {
-   a = true,
-   b = true,
-   f = true,
-   n = true,
-   r = true,
-   t = true,
-   v = true,
-   z = true,
-   ["\\"] = true,
-   ["\'"] = true,
-   ["\""] = true,
-   ["\r"] = true,
-   ["\n"] = true,
-}
-
-local function lex_string_escape(input: string, i: number, c: string): number, boolean
-   if escapable_characters[c] then
-      return 0, true
-   elseif c == "x" then
-      return 2, (
-         lex_hexadecimals[input:sub(i+1, i+1)] and
-         lex_hexadecimals[input:sub(i+2, i+2)]
-      )
-   elseif c == "u" then
-      if input:sub(i+1, i+1) == "{" then
-          local p = i + 2
-          if not lex_hexadecimals[input:sub(p, p)] then
-            return 2, false
-          end
-          while true do
-            p = p + 1
-            c = input:sub(p, p)
-            if not lex_hexadecimals[c] then
-               return p - i, c == "}"
-            end
-         end
-      end
-   elseif lex_decimals[c] then
-      local len = lex_decimals[input:sub(i+1, i+1)]
-                  and (lex_decimals[input:sub(i+2, i+2)] and 3 or 2)
-                  or  1
-      return len, tonumber(input:sub(i, i+len-1)) < 256
-   else
-      return 0, false
-   end
-end
-
-function tl.lex(input: string): {Token}, {Token}
-   local tokens: {Token} = {}
-
-   local state: LexState = "start"
-   local fwd = true
-   local y = 1
-   local x = 0
-   local i = 0
-   local lc_open_lvl = 0
-   local lc_close_lvl = 0
-   local ls_open_lvl = 0
-   local ls_close_lvl = 0
-   local errs: {Token} = {}
-
-   local tx: number
-   local ty: number
-   local ti: number
-   local in_token = false
-
-   local function begin_token()
-      tx = x
-      ty = y
-      ti = i
-      in_token = true
-   end
-
-   local function end_token(kind: TokenKind, last: number, t: string)
-      local tk = t or input:sub(ti, last or i) or ""
-      if keywords[tk] then
-         kind = "keyword"
-      end
-      table.insert(tokens, {
-         x = tx,
-         y = ty,
-         i = ti,
-         tk = tk,
-         kind = kind,
-      })
-      in_token = false
-   end
-
-   local function drop_token()
-      in_token = false
-   end
-
-   while i <= #input do
-      if fwd then
-         i = i + 1
-         if i > #input then
-            break
-         end
-      end
-
-      local c: string = input:sub(i, i)
-
-      if fwd then
-         if c == "\n" then
-            y = y + 1
-            x = 0
-         else
-            x = x + 1
-         end
-      else
-         fwd = true
-      end
-
-      if state == "start" then
-         if input:sub(1,2) == "#!" then
-            i = input:find("\n")
-            if not i then
-               break
-            end
-            c = "\n"
-            y = 2
-            x = 0
-         end
-         state = "any"
-      end
-
-      if state == "any" then
-         if c == "-" then
-            state = "maybecomment"
-            begin_token()
-         elseif c == "." then
-            state = "maybedotdot"
-            begin_token()
-         elseif c == "\"" then
-            state = "dblquote_string"
-            begin_token()
-         elseif c == "'" then
-            state = "singlequote_string"
-            begin_token()
-         elseif lex_word_start[c] then
-            state = "identifier"
-            begin_token()
-         elseif c == "0" then
-            state = "decimal_or_hex"
-            begin_token()
-         elseif lex_decimal_start[c] then
-            state = "decimal_number"
-            begin_token()
-         elseif c == "<" then
-            state = "lt"
-            begin_token()
-         elseif c == ":" then
-            state = "colon"
-            begin_token()
-         elseif c == ">" then
-            state = "gt"
-            begin_token()
-         elseif c == "/" then
-            state = "div"
-            begin_token()
-         elseif c == "=" or c == "~" then
-            state = "maybeequals"
-            begin_token()
-         elseif c == "[" then
-            state = "maybelongstring"
-            begin_token()
-         elseif lex_char_symbols[c] then
-            begin_token()
-            end_token(c as TokenKind)
-         elseif lex_op_start[c] then
-            begin_token()
-            end_token("op")
-         elseif lex_space[c] then
-            -- continue
-         else
-            begin_token()
-            end_token("$invalid$")
-            table.insert(errs, tokens[#tokens])
-         end
-      elseif state == "maybecomment" then
-         if c == "-" then
-            state = "maybecomment2"
-         else
-            end_token("op", nil, "-")
-            fwd = false
-            state = "any"
-         end
-      elseif state == "maybecomment2" then
-         if c == "[" then
-            state = "maybelongcomment"
-         else
-            fwd = false
-            state = "comment"
-            drop_token()
-         end
-      elseif state == "maybelongcomment" then
-         if c == "[" then
-            state = "longcomment"
-         elseif c == "=" then
-            lc_open_lvl = lc_open_lvl + 1
-         else
-            fwd = false
-            state = "comment"
-            drop_token()
-            lc_open_lvl = 0
-         end
-      elseif state == "longcomment" then
-         if c == "]" then
-            state = "maybelongcommentend"
-         end
-      elseif state == "maybelongcommentend" then
-         if c == "]" and lc_close_lvl == lc_open_lvl then
-            drop_token()
-            state = "any"
-            lc_open_lvl = 0
-            lc_close_lvl = 0
-         elseif c == "=" then
-            lc_close_lvl = lc_close_lvl + 1
-         else
-            state = "longcomment"
-            lc_close_lvl = 0
-         end
-      elseif state == "dblquote_string" then
-         if c == "\\" then
-            state = "escape_dblquote_string"
-         elseif c == "\"" then
-            end_token("string")
-            state = "any"
-         end
-      elseif state == "escape_dblquote_string" then
-         local skip, valid = lex_string_escape(input, i, c)
-         i = i + skip
-         if not valid then
-            end_token("$invalid_string$")
-            table.insert(errs, tokens[#tokens])
-         end
-         x = x + skip
-         state = "dblquote_string"
-      elseif state == "singlequote_string" then
-         if c == "\\" then
-            state = "escape_singlequote_string"
-         elseif c == "'" then
-            end_token("string")
-            state = "any"
-         end
-      elseif state == "escape_singlequote_string" then
-         local skip, valid = lex_string_escape(input, i, c)
-         i = i + skip
-         if not valid then
-            end_token("$invalid_string$")
-            table.insert(errs, tokens[#tokens])
-         end
-         x = x + skip
-         state = "singlequote_string"
-      elseif state == "maybeequals" then
-         if c == "=" then
-            end_token("op")
-            state = "any"
-         else
-            end_token("op", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "lt" then
-         if c == "=" or c == "<" then
-            end_token("op")
-            state = "any"
-         else
-            end_token("op", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "colon" then
-         if c == ":" then
-            end_token("::")
-            state = "any"
-         else
-            end_token(":", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "gt" then
-         if c == "=" or c == ">" then
-            end_token("op")
-            state = "any"
-         else
-            end_token("op", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "div" then
-         if c == "/" then
-            end_token("op")
-            state = "any"
-         else
-            end_token("op", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "maybelongstring" then
-         if c == "[" then
-            state = "longstring"
-         elseif c == "=" then
-            ls_open_lvl = ls_open_lvl + 1
-         else
-            end_token("[", i - 1)
-            fwd = false
-            state = "any"
-            ls_open_lvl = 0
-         end
-      elseif state == "longstring" then
-         if c == "]" then
-            state = "maybelongstringend"
-         end
-      elseif state == "maybelongstringend" then
-         if c == "]" then
-            if ls_close_lvl == ls_open_lvl then
-               end_token("string")
-               state = "any"
-               ls_open_lvl = 0
-               ls_close_lvl = 0
-            end
-         elseif c == "=" then
-            ls_close_lvl = ls_close_lvl + 1
-         else
-            state = "longstring"
-            ls_close_lvl = 0
-         end
-      elseif state == "maybedotdot" then
-         if c == "." then
-            state = "maybedotdotdot"
-         elseif lex_decimals[c] then
-            state = "decimal_float"
-         else
-            end_token(".", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "maybedotdotdot" then
-         if c == "." then
-            end_token("...")
-            state = "any"
-         else
-            end_token("op", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "comment" then
-         if c == "\n" then
-            state = "any"
-         end
-      elseif state == "identifier" then
-         if not lex_word[c] then
-            end_token("identifier", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "decimal_or_hex" then
-         if c == "x" or c == "X" then
-            state = "hex_number"
-         elseif c == "e" or c == "E" then
-            state = "power_sign"
-         elseif lex_decimals[c] then
-            state = "decimal_number"
-         elseif c == "." then
-            state = "decimal_float"
-         else
-            end_token("number", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "hex_number" then
-         if c == "." then
-            state = "hex_float"
-         elseif c == "p" or c == "P" then
-            state = "power_sign"
-         elseif not lex_hexadecimals[c] then
-            end_token("number", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "hex_float" then
-         if c == "p" or c == "P" then
-            state = "power_sign"
-         elseif not lex_hexadecimals[c] then
-            end_token("number", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "decimal_number" then
-         if c == "." then
-            state = "decimal_float"
-         elseif c == "e" or c == "E" then
-            state = "power_sign"
-         elseif not lex_decimals[c] then
-            end_token("number", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "decimal_float" then
-         if c == "e" or c == "E" then
-            state = "power_sign"
-         elseif not lex_decimals[c] then
-            end_token("number", i - 1)
-            fwd = false
-            state = "any"
-         end
-      elseif state == "power_sign" then
-         if c == "-" or c == "+" then
-            state = "power"
-         elseif lex_decimals[c] then
-            state = "power"
-         else
-            end_token("$invalid_number$")
-            table.insert(errs, tokens[#tokens])
-            state = "any"
-         end
-      elseif state == "power" then
-         if not lex_decimals[c] then
-            end_token("number", i - 1)
-            fwd = false
-            state = "any"
-         end
-      end
-   end
-
-   local terminals: {LexState:TokenKind} = {
-      ["identifier"] = "identifier",
-      ["decimal_or_hex"] = "number",
-      ["decimal_number"] = "number",
-      ["decimal_float"] = "number",
-      ["hex_number"] = "number",
-      ["hex_float"] = "number",
-      ["power"] = "number",
+do
+   local keywords: {string:boolean} = {
+      ["and"] = true,
+      ["break"] = true,
+      ["do"] = true,
+      ["else"] = true,
+      ["elseif"] = true,
+      ["end"] = true,
+      ["false"] = true,
+      ["for"] = true,
+      ["function"] = true,
+      ["goto"] = true,
+      ["if"] = true,
+      ["in"] = true,
+      ["local"] = true,
+      ["nil"] = true,
+      ["not"] = true,
+      ["or"] = true,
+      ["repeat"] = true,
+      ["return"] = true,
+      ["then"] = true,
+      ["true"] = true,
+      ["until"] = true,
+      ["while"] = true,
    }
 
-   if in_token then
-      if terminals[state] then
-         end_token(terminals[state], i - 1)
+   local lex_word_start: {string:boolean} = {}
+   for c = string.byte("a"), string.byte("z") do
+      lex_word_start[string.char(c)] = true
+   end
+   for c = string.byte("A"), string.byte("Z") do
+      lex_word_start[string.char(c)] = true
+   end
+   lex_word_start["_"] = true
+
+   local lex_word: {string:boolean} = {}
+   for c = string.byte("a"), string.byte("z") do
+      lex_word[string.char(c)] = true
+   end
+   for c = string.byte("A"), string.byte("Z") do
+      lex_word[string.char(c)] = true
+   end
+   for c = string.byte("0"), string.byte("9") do
+      lex_word[string.char(c)] = true
+   end
+   lex_word["_"] = true
+
+   local lex_decimal_start: {string:boolean} = {}
+   for c = string.byte("1"), string.byte("9") do
+      lex_decimal_start[string.char(c)] = true
+   end
+
+   local lex_decimals: {string:boolean} = {}
+   for c = string.byte("0"), string.byte("9") do
+      lex_decimals[string.char(c)] = true
+   end
+
+   local lex_hexadecimals: {string:boolean} = {}
+   for c = string.byte("0"), string.byte("9") do
+      lex_hexadecimals[string.char(c)] = true
+   end
+   for c = string.byte("a"), string.byte("f") do
+      lex_hexadecimals[string.char(c)] = true
+   end
+   for c = string.byte("A"), string.byte("F") do
+      lex_hexadecimals[string.char(c)] = true
+   end
+
+   local lex_char_symbols: {string:boolean} = {}
+   for _, c in ipairs({"[", "]", "(", ")", "{", "}", ",", "#", "`", ";"}) do
+      lex_char_symbols[c] = true
+   end
+
+   local lex_op_start: {string:boolean} = {}
+   for _, c in ipairs({"+", "*", "|", "&", "%", "^"}) do
+      lex_op_start[c] = true
+   end
+
+   local lex_space: {string:boolean} = {}
+   for _, c in ipairs({" ", "\t", "\v", "\n", "\r"}) do
+      lex_space[c] = true
+   end
+
+   local enum LexState
+      "start"
+      "any"
+      "identifier"
+      "maybecomment"
+      "maybecomment2"
+      "maybedotdot"
+      "maybedotdotdot"
+      "decimal_number"
+      "decimal_or_hex"
+      "decimal_float"
+      "power"
+      "power_sign"
+      "hex_number"
+      "hex_float"
+      "lt"
+      "gt"
+      "div"
+      "colon"
+      "maybeequals"
+      "maybelongstring"
+      "dblquote_string"
+      "singlequote_string"
+      "escape_dblquote_string"
+      "escape_singlequote_string"
+      "comment"
+      "longcomment"
+      "maybelongcomment"
+      "maybelongcommentend"
+      "longstring"
+      "maybelongstring"
+      "maybelongstringend"
+   end
+
+   local escapable_characters: {string:boolean} = {
+      a = true,
+      b = true,
+      f = true,
+      n = true,
+      r = true,
+      t = true,
+      v = true,
+      z = true,
+      ["\\"] = true,
+      ["\'"] = true,
+      ["\""] = true,
+      ["\r"] = true,
+      ["\n"] = true,
+   }
+
+   local function lex_string_escape(input: string, i: number, c: string): number, boolean
+      if escapable_characters[c] then
+         return 0, true
+      elseif c == "x" then
+         return 2, (
+            lex_hexadecimals[input:sub(i+1, i+1)] and
+            lex_hexadecimals[input:sub(i+2, i+2)]
+         )
+      elseif c == "u" then
+         if input:sub(i+1, i+1) == "{" then
+             local p = i + 2
+             if not lex_hexadecimals[input:sub(p, p)] then
+               return 2, false
+             end
+             while true do
+               p = p + 1
+               c = input:sub(p, p)
+               if not lex_hexadecimals[c] then
+                  return p - i, c == "}"
+               end
+            end
+         end
+      elseif lex_decimals[c] then
+         local len = lex_decimals[input:sub(i+1, i+1)]
+                     and (lex_decimals[input:sub(i+2, i+2)] and 3 or 2)
+                     or  1
+         return len, tonumber(input:sub(i, i+len-1)) < 256
       else
-         drop_token()
+         return 0, false
       end
    end
 
-   return tokens, (#errs > 0) and errs
+   function tl.lex(input: string): {Token}, {Token}
+      local tokens: {Token} = {}
+
+      local state: LexState = "start"
+      local fwd = true
+      local y = 1
+      local x = 0
+      local i = 0
+      local lc_open_lvl = 0
+      local lc_close_lvl = 0
+      local ls_open_lvl = 0
+      local ls_close_lvl = 0
+      local errs: {Token} = {}
+
+      local tx: number
+      local ty: number
+      local ti: number
+      local in_token = false
+
+      local function begin_token()
+         tx = x
+         ty = y
+         ti = i
+         in_token = true
+      end
+
+      local function end_token(kind: TokenKind, last: number, t: string)
+         local tk = t or input:sub(ti, last or i) or ""
+         if keywords[tk] then
+            kind = "keyword"
+         end
+         table.insert(tokens, {
+            x = tx,
+            y = ty,
+            i = ti,
+            tk = tk,
+            kind = kind,
+         })
+         in_token = false
+      end
+
+      local function drop_token()
+         in_token = false
+      end
+
+      while i <= #input do
+         if fwd then
+            i = i + 1
+            if i > #input then
+               break
+            end
+         end
+
+         local c: string = input:sub(i, i)
+
+         if fwd then
+            if c == "\n" then
+               y = y + 1
+               x = 0
+            else
+               x = x + 1
+            end
+         else
+            fwd = true
+         end
+
+         if state == "start" then
+            if input:sub(1,2) == "#!" then
+               i = input:find("\n")
+               if not i then
+                  break
+               end
+               c = "\n"
+               y = 2
+               x = 0
+            end
+            state = "any"
+         end
+
+         if state == "any" then
+            if c == "-" then
+               state = "maybecomment"
+               begin_token()
+            elseif c == "." then
+               state = "maybedotdot"
+               begin_token()
+            elseif c == "\"" then
+               state = "dblquote_string"
+               begin_token()
+            elseif c == "'" then
+               state = "singlequote_string"
+               begin_token()
+            elseif lex_word_start[c] then
+               state = "identifier"
+               begin_token()
+            elseif c == "0" then
+               state = "decimal_or_hex"
+               begin_token()
+            elseif lex_decimal_start[c] then
+               state = "decimal_number"
+               begin_token()
+            elseif c == "<" then
+               state = "lt"
+               begin_token()
+            elseif c == ":" then
+               state = "colon"
+               begin_token()
+            elseif c == ">" then
+               state = "gt"
+               begin_token()
+            elseif c == "/" then
+               state = "div"
+               begin_token()
+            elseif c == "=" or c == "~" then
+               state = "maybeequals"
+               begin_token()
+            elseif c == "[" then
+               state = "maybelongstring"
+               begin_token()
+            elseif lex_char_symbols[c] then
+               begin_token()
+               end_token(c as TokenKind)
+            elseif lex_op_start[c] then
+               begin_token()
+               end_token("op")
+            elseif lex_space[c] then
+               -- continue
+            else
+               begin_token()
+               end_token("$invalid$")
+               table.insert(errs, tokens[#tokens])
+            end
+         elseif state == "maybecomment" then
+            if c == "-" then
+               state = "maybecomment2"
+            else
+               end_token("op", nil, "-")
+               fwd = false
+               state = "any"
+            end
+         elseif state == "maybecomment2" then
+            if c == "[" then
+               state = "maybelongcomment"
+            else
+               fwd = false
+               state = "comment"
+               drop_token()
+            end
+         elseif state == "maybelongcomment" then
+            if c == "[" then
+               state = "longcomment"
+            elseif c == "=" then
+               lc_open_lvl = lc_open_lvl + 1
+            else
+               fwd = false
+               state = "comment"
+               drop_token()
+               lc_open_lvl = 0
+            end
+         elseif state == "longcomment" then
+            if c == "]" then
+               state = "maybelongcommentend"
+            end
+         elseif state == "maybelongcommentend" then
+            if c == "]" and lc_close_lvl == lc_open_lvl then
+               drop_token()
+               state = "any"
+               lc_open_lvl = 0
+               lc_close_lvl = 0
+            elseif c == "=" then
+               lc_close_lvl = lc_close_lvl + 1
+            else
+               state = "longcomment"
+               lc_close_lvl = 0
+            end
+         elseif state == "dblquote_string" then
+            if c == "\\" then
+               state = "escape_dblquote_string"
+            elseif c == "\"" then
+               end_token("string")
+               state = "any"
+            end
+         elseif state == "escape_dblquote_string" then
+            local skip, valid = lex_string_escape(input, i, c)
+            i = i + skip
+            if not valid then
+               end_token("$invalid_string$")
+               table.insert(errs, tokens[#tokens])
+            end
+            x = x + skip
+            state = "dblquote_string"
+         elseif state == "singlequote_string" then
+            if c == "\\" then
+               state = "escape_singlequote_string"
+            elseif c == "'" then
+               end_token("string")
+               state = "any"
+            end
+         elseif state == "escape_singlequote_string" then
+            local skip, valid = lex_string_escape(input, i, c)
+            i = i + skip
+            if not valid then
+               end_token("$invalid_string$")
+               table.insert(errs, tokens[#tokens])
+            end
+            x = x + skip
+            state = "singlequote_string"
+         elseif state == "maybeequals" then
+            if c == "=" then
+               end_token("op")
+               state = "any"
+            else
+               end_token("op", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "lt" then
+            if c == "=" or c == "<" then
+               end_token("op")
+               state = "any"
+            else
+               end_token("op", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "colon" then
+            if c == ":" then
+               end_token("::")
+               state = "any"
+            else
+               end_token(":", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "gt" then
+            if c == "=" or c == ">" then
+               end_token("op")
+               state = "any"
+            else
+               end_token("op", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "div" then
+            if c == "/" then
+               end_token("op")
+               state = "any"
+            else
+               end_token("op", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "maybelongstring" then
+            if c == "[" then
+               state = "longstring"
+            elseif c == "=" then
+               ls_open_lvl = ls_open_lvl + 1
+            else
+               end_token("[", i - 1)
+               fwd = false
+               state = "any"
+               ls_open_lvl = 0
+            end
+         elseif state == "longstring" then
+            if c == "]" then
+               state = "maybelongstringend"
+            end
+         elseif state == "maybelongstringend" then
+            if c == "]" then
+               if ls_close_lvl == ls_open_lvl then
+                  end_token("string")
+                  state = "any"
+                  ls_open_lvl = 0
+                  ls_close_lvl = 0
+               end
+            elseif c == "=" then
+               ls_close_lvl = ls_close_lvl + 1
+            else
+               state = "longstring"
+               ls_close_lvl = 0
+            end
+         elseif state == "maybedotdot" then
+            if c == "." then
+               state = "maybedotdotdot"
+            elseif lex_decimals[c] then
+               state = "decimal_float"
+            else
+               end_token(".", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "maybedotdotdot" then
+            if c == "." then
+               end_token("...")
+               state = "any"
+            else
+               end_token("op", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "comment" then
+            if c == "\n" then
+               state = "any"
+            end
+         elseif state == "identifier" then
+            if not lex_word[c] then
+               end_token("identifier", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "decimal_or_hex" then
+            if c == "x" or c == "X" then
+               state = "hex_number"
+            elseif c == "e" or c == "E" then
+               state = "power_sign"
+            elseif lex_decimals[c] then
+               state = "decimal_number"
+            elseif c == "." then
+               state = "decimal_float"
+            else
+               end_token("number", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "hex_number" then
+            if c == "." then
+               state = "hex_float"
+            elseif c == "p" or c == "P" then
+               state = "power_sign"
+            elseif not lex_hexadecimals[c] then
+               end_token("number", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "hex_float" then
+            if c == "p" or c == "P" then
+               state = "power_sign"
+            elseif not lex_hexadecimals[c] then
+               end_token("number", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "decimal_number" then
+            if c == "." then
+               state = "decimal_float"
+            elseif c == "e" or c == "E" then
+               state = "power_sign"
+            elseif not lex_decimals[c] then
+               end_token("number", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "decimal_float" then
+            if c == "e" or c == "E" then
+               state = "power_sign"
+            elseif not lex_decimals[c] then
+               end_token("number", i - 1)
+               fwd = false
+               state = "any"
+            end
+         elseif state == "power_sign" then
+            if c == "-" or c == "+" then
+               state = "power"
+            elseif lex_decimals[c] then
+               state = "power"
+            else
+               end_token("$invalid_number$")
+               table.insert(errs, tokens[#tokens])
+               state = "any" -- FIXME report malformed number
+            end
+         elseif state == "power" then
+            if not lex_decimals[c] then
+               end_token("number", i - 1)
+               fwd = false
+               state = "any"
+            end
+         end
+      end
+
+      local terminals: {LexState:TokenKind} = {
+         ["identifier"] = "identifier",
+         ["decimal_or_hex"] = "number",
+         ["decimal_number"] = "number",
+         ["decimal_float"] = "number",
+         ["hex_number"] = "number",
+         ["hex_float"] = "number",
+         ["power"] = "number",
+      }
+
+      if in_token then
+         if terminals[state] then
+            end_token(terminals[state], i - 1)
+         else
+            drop_token()
+         end
+      end
+
+      return tokens, (#errs > 0) and errs
+   end
 end
 
 --------------------------------------------------------------------------------
 -- Pretty-print tokens
 --------------------------------------------------------------------------------
 
-local add_space: {string:boolean} = {
-   ["identifier:identifier"] = true,
-   ["identifier:keyword"] = true,
-   ["identifier:word"] = true,
-   ["identifier:string"] = true,
-   ["identifier:="] = true,
-   ["identifier:op"] = true,
+do
+   local add_space: {string:boolean} = {
+      ["identifier:identifier"] = true,
+      ["identifier:keyword"] = true,
+      ["identifier:word"] = true,
+      ["identifier:string"] = true,
+      ["identifier:="] = true,
+      ["identifier:op"] = true,
 
-   ["keyword:identifier"] = true,
-   ["keyword:keyword"] = true,
-   ["keyword:string"] = true,
-   ["keyword:number"] = true,
-   ["keyword:="] = true,
-   ["keyword:op"] = true,
-   ["keyword:{"] = true,
-   ["keyword:("] = true,
-   ["keyword:#"] = true,
+      ["keyword:identifier"] = true,
+      ["keyword:keyword"] = true,
+      ["keyword:string"] = true,
+      ["keyword:number"] = true,
+      ["keyword:="] = true,
+      ["keyword:op"] = true,
+      ["keyword:{"] = true,
+      ["keyword:("] = true,
+      ["keyword:#"] = true,
 
-   ["=:identifier"] = true,
-   ["=:keyword"] = true,
-   ["=:string"] = true,
-   ["=:number"] = true,
-   ["=:{"] = true,
-   ["=:("] = true,
-   ["op:("] = true,
-   ["op:{"] = true,
-   ["op:#"] = true,
+      ["=:identifier"] = true,
+      ["=:keyword"] = true,
+      ["=:string"] = true,
+      ["=:number"] = true,
+      ["=:{"] = true,
+      ["=:("] = true,
+      ["op:("] = true,
+      ["op:{"] = true,
+      ["op:#"] = true,
 
-   ["::identifier"] = true,
+      ["::identifier"] = true,
 
-   [",:identifier"] = true,
-   [",:keyword"] = true,
-   [",:string"] = true,
-   [",:{"] = true,
+      [",:identifier"] = true,
+      [",:keyword"] = true,
+      [",:string"] = true,
+      [",:{"] = true,
 
-   ["):op"] = true,
-   ["):identifier"] = true,
-   ["):keyword"] = true,
+      ["):op"] = true,
+      ["):identifier"] = true,
+      ["):keyword"] = true,
 
-   ["op:string"] = true,
-   ["op:number"] = true,
-   ["op:identifier"] = true,
-   ["op:keyword"] = true,
+      ["op:string"] = true,
+      ["op:number"] = true,
+      ["op:identifier"] = true,
+      ["op:keyword"] = true,
 
-   ["]:identifier"] = true,
-   ["]:keyword"] = true,
-   ["]:="] = true,
-   ["]:op"] = true,
+      ["]:identifier"] = true,
+      ["]:keyword"] = true,
+      ["]:="] = true,
+      ["]:op"] = true,
 
-   ["string:op"] = true,
-   ["string:identifier"] = true,
-   ["string:keyword"] = true,
+      ["string:op"] = true,
+      ["string:identifier"] = true,
+      ["string:keyword"] = true,
 
-   ["number:identifier"] = true,
-   ["number:keyword"] = true,
-}
+      ["number:identifier"] = true,
+      ["number:keyword"] = true,
+   }
 
-local should_unindent: {string:boolean} = {
-   ["end"] = true,
-   ["elseif"] = true,
-   ["else"] = true,
-   ["}"] = true,
-}
+   local should_unindent: {string:boolean} = {
+      ["end"] = true,
+      ["elseif"] = true,
+      ["else"] = true,
+      ["}"] = true,
+   }
 
-local should_indent: {string:boolean} = {
-   ["{"] = true,
-   ["for"] = true,
-   ["if"] = true,
-   ["while"] = true,
-   ["elseif"] = true,
-   ["else"] = true,
-   ["function"] = true,
-   ["record"] = true,
-}
+   local should_indent: {string:boolean} = {
+      ["{"] = true,
+      ["for"] = true,
+      ["if"] = true,
+      ["while"] = true,
+      ["elseif"] = true,
+      ["else"] = true,
+      ["function"] = true,
+      ["record"] = true,
+   }
 
-function tl.pretty_print_tokens(tokens: {Token}): string
-   local y = 1
-   local out = {}
-   local indent = 0
-   local newline = false
-   local kind: string = ""
-   for _, t in ipairs(tokens) do
-      while t.y > y do
-         table.insert(out, "\n")
-         y = y + 1
-         newline = true
-         kind = ""
-      end
-      if should_unindent[t.tk] then
-         indent = indent - 1
-         if indent < 0 then
-            indent = 0
+   function tl.pretty_print_tokens(tokens: {Token}): string
+      local y = 1
+      local out = {}
+      local indent = 0
+      local newline = false
+      local kind: string = ""
+      for _, t in ipairs(tokens) do
+         while t.y > y do
+            table.insert(out, "\n")
+            y = y + 1
+            newline = true
+            kind = ""
          end
-      end
-      if newline then
-         for _ = 1, indent do
-            table.insert(out, "   ")
+         if should_unindent[t.tk] then
+            indent = indent - 1
+            if indent < 0 then
+               indent = 0
+            end
          end
-         newline = false
+         if newline then
+            for _ = 1, indent do
+               table.insert(out, "   ")
+            end
+            newline = false
+         end
+         if should_indent[t.tk] then
+            indent = indent + 1
+         end
+         if add_space[(kind or "") .. ":" .. t.kind] then
+            table.insert(out, " ")
+         end
+         table.insert(out, t.tk)
+         kind = t.kind or ""
       end
-      if should_indent[t.tk] then
-         indent = indent + 1
-      end
-      if add_space[(kind or "") .. ":" .. t.kind] then
-         table.insert(out, " ")
-      end
-      table.insert(out, t.tk)
-      kind = t.kind or ""
+      return table.concat(out)
    end
-   return table.concat(out)
 end
 
 --------------------------------------------------------------------------------
@@ -2866,7 +2862,7 @@ local function recurse_node<T>(ast: Node,
       end
    else
       if not ast.kind then
-         error("wat: " .. inspect(ast))
+         error("wat: " .. tostring(ast))
       end
       error("unknown node kind " .. ast.kind)
    end
@@ -3933,7 +3929,7 @@ local function show_type_base(t: Type, seen: {Type:string}): string
    elseif t.typename == "bad_nominal" then
       return table.concat(t.names, ".") .. " (an unknown type)"
    else
-      return inspect(t)
+      return tostring(t)
    end
 end
 

--- a/tl.tl
+++ b/tl.tl
@@ -4426,23 +4426,25 @@ local function add_compat53_entries(program: Node, used_set: {string: boolean})
          local _: number
          _, code = tl.parse_program(tokens, {}, "@internal")
          tl.type_check(code, { lax = false, skip_compat53 = true })
-         code = code[1]
+         code = code
          compat53_code_cache[name] = code
       end
-      table.insert(program, n, code)
-      n = n + 1
+      for _, c in ipairs(code) do
+         table.insert(program, n, c)
+         n = n + 1
+      end
    end
 
    for _, name in ipairs(used_list) do
       if name == "table.unpack" then
          load_code(name, "local _tl_table_unpack = unpack or table.unpack")
       elseif name == "bit32" then
-         load_code(name, "local bit32 = bit32 or require('bit32')")
+         load_code(name, "local bit32 = bit32; if not bit32 then local p, m = pcall(require, 'bit32'); if m then bit32 = m; end")
       elseif name == "mt" then
          load_code(name, "local _tl_mt = function(m, s, a, b) return (getmetatable(s == 1 and a or b)[m](a, b) end")
       else
          if not compat53_loaded then
-            load_code("compat53", "local _tl_compat53 = ((tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3) and require('compat53.module')")
+            load_code("compat53", "local _tl_compat53; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if m then _tl_compat53 = m; end")
             compat53_loaded = true
          end
          load_code(name, (("local $NAME = _tl_compat53 and _tl_compat53.$NAME or $NAME"):gsub("$NAME", name)))

--- a/tl.tl
+++ b/tl.tl
@@ -1,34 +1,40 @@
 
-local record TypeCheckOptions
-   lax: boolean
-   filename: string
-   skip_compat53: boolean
-   env: Env
-   result: Result
-end
-
 global _VERSION: string
 
-local enum LoadMode
-   "b"
-   "t"
-   "bt"
-end
-local type LoadFunction = function(...:any): any...
-
 local record tl
-   load: function(string, string, LoadMode, {any:any}): LoadFunction, string
-   process: function(string, Env, Result, {string}): (Result, string)
-   process_string: function(string, boolean, Env, Result, {string}, string): (Result, string)
-   gen: function(string, Env): string
-   type_check: function(Node, TypeCheckOptions): ({Error}, {Error}, Type)
-   init_env: function(boolean, boolean): Env
+   enum LoadMode
+      "b"
+      "t"
+      "bt"
+   end
+   type LoadFunction = function(...:any): any...
+
+   enum CompatMode
+      "off"
+      "optional"
+      "required"
+   end
+
+   enum TargetMode
+      "5.1"
+      "5.3"
+   end
+
+   record TypeCheckOptions
+      lax: boolean
+      filename: string
+      gen_compat: CompatMode
+      gen_target: TargetMode
+      env: Env
+      result: Result
+   end
 
    record Env
       globals: {string:Variable}
       modules: {string:Type}
       loaded: {string:Result}
-      skip_compat53: boolean
+      gen_compat: CompatMode
+      gen_target: TargetMode
    end
 
    record Result
@@ -48,6 +54,7 @@ local record tl
       "debug"
    end
    warning_kinds: {WarningKind:boolean}
+
    record Error
       y: number
       x: number
@@ -56,6 +63,13 @@ local record tl
 
       tag: WarningKind
    end
+
+   load: function(string, string, LoadMode, {any:any}): LoadFunction, string
+   process: function(string, Env, Result, {string}): (Result, string)
+   process_string: function(string, boolean, Env, Result, {string}, string): (Result, string)
+   gen: function(string, Env): string
+   type_check: function(Node, TypeCheckOptions): ({Error}, {Error}, Type)
+   init_env: function(boolean, boolean | CompatMode, TargetMode): Env
 end
 
 tl.warning_kinds = {
@@ -68,6 +82,11 @@ tl.warning_kinds = {
 local Result = tl.Result
 local Env = tl.Env
 local Error = tl.Error
+local CompatMode = tl.CompatMode
+local TypeCheckOptions = tl.TypeCheckOptions
+local LoadMode = tl.LoadMode
+local LoadFunction = tl.LoadFunction
+local TargetMode = tl.TargetMode
 
 --------------------------------------------------------------------------------
 -- Lexer
@@ -846,7 +865,7 @@ local record Type
    yend: number
 
    -- Lua compatibilty
-   needs_compat53: boolean
+   needs_compat: boolean
 
    -- tuple
    is_va: boolean
@@ -3971,7 +3990,7 @@ end
 local record Variable
    t: Type
    is_const: boolean
-   needs_compat53: boolean
+   needs_compat: boolean
    narrowed_from: Type
    is_narrowed: boolean
    declared_at: Node
@@ -4373,7 +4392,7 @@ local standard_library: {string:Type} = {
          ["pack"] = a_type { typename = "function", args = VARARG { ANY }, rets = { TABLE } },
          ["remove"] = a_type { typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA, OPT_NUMBER }, rets = { ALPHA } },
          ["sort"] = a_type { typename = "function", typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA, OPT_TABLE_SORT_FUNCTION }, rets = {} },
-         ["unpack"] = a_type { typename = "function", needs_compat53 = true, typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, NUMBER }, rets = VARARG { ALPHA } },
+         ["unpack"] = a_type { typename = "function", needs_compat = true, typeargs = { ARG_ALPHA }, args = { ARRAY_OF_ALPHA, NUMBER, NUMBER }, rets = VARARG { ALPHA } },
       },
    },
    ["utf8"] = a_type {
@@ -4403,10 +4422,10 @@ fill_field_order(DEBUG_GETINFO_TABLE)
 NOMINAL_FILE.found = standard_library["FILE"]
 NOMINAL_METATABLE_OF_ALPHA.found = standard_library["metatable"]
 
-local compat53_code_cache: {string:Node} = {}
+local compat_code_cache: {string:Node} = {}
 
-local function add_compat53_entries(program: Node, used_set: {string: boolean})
-   if not next(used_set) then
+local function add_compat_entries(program: Node, used_set: {string: boolean}, gen_compat: CompatMode)
+   if gen_compat == "off" or not next(used_set) then
       return
    end
 
@@ -4416,18 +4435,18 @@ local function add_compat53_entries(program: Node, used_set: {string: boolean})
    end
    table.sort(used_list)
 
-   local compat53_loaded = false
+   local compat_loaded = false
 
    local n = 1
    local function load_code(name: string, text: string)
-      local code: Node = compat53_code_cache[name]
+      local code: Node = compat_code_cache[name]
       if not code then
          local tokens = tl.lex(text)
          local _: number
          _, code = tl.parse_program(tokens, {}, "@internal")
-         tl.type_check(code, { lax = false, skip_compat53 = true })
+         tl.type_check(code, { lax = false, gen_compat = "off" })
          code = code
-         compat53_code_cache[name] = code
+         compat_code_cache[name] = code
       end
       for _, c in ipairs(code) do
          table.insert(program, n, c)
@@ -4435,25 +4454,31 @@ local function add_compat53_entries(program: Node, used_set: {string: boolean})
       end
    end
 
+   local function req(m: string): string
+      return (gen_compat == "optional")
+             and "pcall(require, '" .. m .. "')"
+             or  "true, require('" .. m .. "')"
+   end
+
    for _, name in ipairs(used_list) do
       if name == "table.unpack" then
          load_code(name, "local _tl_table_unpack = unpack or table.unpack")
       elseif name == "bit32" then
-         load_code(name, "local bit32 = bit32; if not bit32 then local p, m = pcall(require, 'bit32'); if m then bit32 = m; end")
+         load_code(name, "local bit32 = bit32; if not bit32 then local p, m = " .. req("bit32") .. "; if p then bit32 = m; end")
       elseif name == "mt" then
          load_code(name, "local _tl_mt = function(m, s, a, b) return (getmetatable(s == 1 and a or b)[m](a, b) end")
       else
-         if not compat53_loaded then
-            load_code("compat53", "local _tl_compat53; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if m then _tl_compat53 = m; end")
-            compat53_loaded = true
+         if not compat_loaded then
+            load_code("compat", "local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = " .. req("compat53.module") .. "; if p then _tl_compat = m; end")
+            compat_loaded = true
          end
-         load_code(name, (("local $NAME = _tl_compat53 and _tl_compat53.$NAME or $NAME"):gsub("$NAME", name)))
+         load_code(name, (("local $NAME = _tl_compat and _tl_compat.$NAME or $NAME"):gsub("$NAME", name)))
       end
    end
    program.y = 1
 end
 
-local function get_stdlib_compat53(lax: boolean): {string:boolean}
+local function get_stdlib_compat(lax: boolean): {string:boolean}
    if lax then
       return {
          ["utf8"] = true,
@@ -4515,10 +4540,10 @@ end
 
 local function init_globals(lax: boolean): {string:Variable}
    local globals: {string:Variable} = {}
-   local stdlib_compat53 = get_stdlib_compat53(lax)
+   local stdlib_compat = get_stdlib_compat(lax)
 
    for name, typ in pairs(standard_library) do
-      globals[name] = { t = typ, needs_compat53 = stdlib_compat53[name], is_const = true }
+      globals[name] = { t = typ, needs_compat = stdlib_compat[name], is_const = true }
    end
 
    -- only global scope and vararg functions accept `...`:
@@ -4529,12 +4554,28 @@ local function init_globals(lax: boolean): {string:Variable}
    return globals
 end
 
-tl.init_env = function(lax: boolean, skip_compat53: boolean): Env
+tl.init_env = function(lax: boolean, gen_compat: boolean | CompatMode, gen_target: TargetMode): Env
+   if gen_compat == true or gen_compat == nil then
+      gen_compat = "optional"
+   elseif gen_compat == false then
+      gen_compat = "off"
+   end
+   gen_compat = gen_compat as CompatMode
+
+   if not gen_target then
+      if _VERSION == "Lua 5.1" or _VERSION == "Lua 5.2" then
+         gen_target = "5.1"
+      else
+         gen_target = "5.3"
+      end
+   end
+
    local env = {
       modules = {},
       loaded = {},
       globals = init_globals(lax),
-      skip_compat53 = skip_compat53,
+      gen_compat = gen_compat,
+      gen_target = gen_target,
    }
 
    -- make standard library tables available as modules for require()
@@ -4549,7 +4590,7 @@ end
 
 tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Type
    opts = opts or {}
-   opts.env = opts.env or tl.init_env(opts.lax, opts.skip_compat53)
+   local env = opts.env or tl.init_env(opts.lax, opts.gen_compat, opts.gen_target)
    local lax = opts.lax
    local filename = opts.filename
    local result = opts.result or {
@@ -4559,9 +4600,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       warnings = {},
    }
 
-   local st: {{string:Variable}} = { opts.env.globals }
+   local st: {{string:Variable}} = { env.globals }
 
-   local all_needs_compat53 = {}
+   local all_needs_compat = {}
 
    local warnings: {Error} = result.warnings or {}
    local errors: {Error} = result.type_errors or {}
@@ -4572,8 +4613,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       for i = #st, 1, -1 do
          local scope = st[i]
          if scope[name] then
-            if i == 1 and scope[name].needs_compat53 then
-               all_needs_compat53[name] = true
+            if i == 1 and scope[name].needs_compat then
+               all_needs_compat[name] = true
             end
             if not raw then
                scope[name].used = true
@@ -6650,7 +6691,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          if #b == 1 then
             if node.e2[1].kind == "string" then
                local module_name = assert(node.e2[1].conststr)
-               local t, found = require_module(module_name, lax, opts.env, result)
+               local t, found = require_module(module_name, lax, env, result)
                if not found then
                   node_error(node, "module not found: '" .. module_name .. "'")
                elseif not lax and is_unknown(t) then
@@ -7439,11 +7480,11 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   end
                else
                   node.type = match_record_key(node, a, { y = node.e2.y, x = node.e2.x, kind = "string", tk = node.e2.tk }, orig_a)
-                  if node.type.needs_compat53 and not opts.skip_compat53 then
+                  if node.type.needs_compat and opts.gen_compat ~= "off" then
                      local key = node.e1.tk .. "." .. node.e2.tk
                      node.kind = "variable"
                      node.tk = "_tl_" .. node.e1.tk .. "_" .. node.e2.tk
-                     all_needs_compat53[key] = true
+                     all_needs_compat[key] = true
                   end
                end
             elseif node.op.op == ":" then
@@ -7494,12 +7535,12 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   end
                end
 
-               if node.op.op == "~" and (_VERSION == "Lua 5.1" or _VERSION == "Lua 5.2") then
+               if node.op.op == "~" and env.gen_target == "5.1" then
                   if metamethod then
-                     all_needs_compat53["mt"] = true
+                     all_needs_compat["mt"] = true
                      convert_node_to_compat_mt_call(node, unop_to_metamethod[node.op.op], 1, node.e1)
                   else
-                     all_needs_compat53["bit32"] = true
+                     all_needs_compat["bit32"] = true
                      convert_node_to_compat_call(node, "bit32", "bnot", node.e1)
                   end
                end
@@ -7530,20 +7571,20 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   end
                end
 
-               if node.op.op == "//" and (_VERSION == "Lua 5.1" or _VERSION == "Lua 5.2") then
+               if node.op.op == "//" and env.gen_target == "5.1" then
                   if metamethod then
-                     all_needs_compat53["mt"] = true
+                     all_needs_compat["mt"] = true
                      convert_node_to_compat_mt_call(node, "__idiv", meta_self, node.e1, node.e2)
                   else
                      local div: Node = { y = node.y, x = node.x, kind = "op", op = an_operator(node, 2, "/"), e1 = node.e1, e2 = node.e2 }
                      convert_node_to_compat_call(node, "math", "floor", div)
                   end
-               elseif bit_operators[node.op.op] and (_VERSION == "Lua 5.1" or _VERSION == "Lua 5.2") then
+               elseif bit_operators[node.op.op] and env.gen_target == "5.1" then
                   if metamethod then
-                     all_needs_compat53["mt"] = true
+                     all_needs_compat["mt"] = true
                      convert_node_to_compat_mt_call(node, binop_to_metamethod[node.op.op], meta_self, node.e1, node.e2)
                   else
-                     all_needs_compat53["bit32"] = true
+                     all_needs_compat["bit32"] = true
                      convert_node_to_compat_call(node, "bit32", bit_operators[node.op.op], node.e1, node.e2)
                   end
                end
@@ -7752,9 +7793,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    clear_redundant_errors(errors)
 
-   if not opts.skip_compat53 then
-      add_compat53_entries(ast, all_needs_compat53)
-   end
+   add_compat_entries(ast, all_needs_compat, env.gen_compat)
 
    return errors, unknowns, module_type
 end
@@ -7843,7 +7882,7 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
       filename = filename,
       env = env,
       result = result,
-      skip_compat53 = env.skip_compat53,
+      gen_compat = env.gen_compat,
    }
    err, unknown, result.type = tl.type_check(program, opts)
 


### PR DESCRIPTION
See documentation updates in this PR for details!

New flags: 

* --gen-target, accepts `5.1` or `5.3`
* --gen-compat, accepts `off`, `optional`, `required`

With this PR, we avoid _depending_ on auto-detection based on the Lua version running the compiler. This could cause problems, for example, if we ship a binary bundle built with Lua 5.4 and someone wants to build code to run with LuaJIT.

We still use version auto-detection as a fallback, which is useful for the case when the Teal compiler is used as a package loder (and therefore runs on the same VM where the Teal module being compiled will run).

We also deprecate --skip-compat53 (which is no longer advertised, but is still supported; --gen-compat=off is equivalent).