### PR TITLE
Fix casting empty expressions + never error with just "syntax error"

### DIFF
--- a/spec/assignment/to_array_spec.lua
+++ b/spec/assignment/to_array_spec.lua
@@ -42,6 +42,9 @@ describe("assignment to array", function()
       }
    ]], {
       { y = 6, x = 10, msg = "cannot index this expression" },
-      { y = 6, msg = "syntax error" },
+      { y = 6, msg = "expected a literal" },
+      { y = 6, msg = "expected an expression" },
+      { y = 7, msg = "syntax error, expected one of: '}', ','" },
+      { y = 10, msg = "expected one or more expressions" },
    }))
 end)

--- a/spec/call/syntax_errors_spec.lua
+++ b/spec/call/syntax_errors_spec.lua
@@ -4,7 +4,7 @@ describe("call", function()
    it("catches a syntax error", util.check_syntax_error([[
       print("hello", "world",)
    ]], {
-      { msg = "syntax error" },
+      { msg = "unexpected ')'" },
       { msg = "syntax error, expected ')'" },
    }))
 

--- a/spec/declaration/enum_spec.lua
+++ b/spec/declaration/enum_spec.lua
@@ -76,7 +76,7 @@ describe("enum declaration", function()
       end
    ]], {
       { y = 1, msg = "syntax error: this syntax is no longer valid; use 'local enum t'" },
-      { msg = "syntax error" },
+      { msg = "expected one or more expressions" },
    }))
 
    it("produces a nice error when global declared with the old syntax", util.check_syntax_error([[
@@ -94,7 +94,7 @@ describe("enum declaration", function()
       end
    ]], {
       { y = 1, msg = "syntax error: this syntax is no longer valid; use 'global enum t'" },
-      { msg = "syntax error" },
+      { msg = "expected one or more expressions" },
    }))
 
    it("produces a nice error when attempting to nest in a table", util.check_syntax_error([[

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -34,7 +34,7 @@ describe("records", function()
       p.y = 12
    ]], {
       { y = 1, msg = "syntax error: this syntax is no longer valid; use 'local record Point'" },
-      { msg = "syntax error" },
+      { msg = "expected one or more expressions" },
    }))
 
    it("produces a nice error when attempting to nest in a table", util.check_syntax_error([[

--- a/spec/error_reporting/syntax_error_spec.lua
+++ b/spec/error_reporting/syntax_error_spec.lua
@@ -42,31 +42,31 @@ describe("syntax errors", function()
       print(3)
       print(4)
    ]], {
-      { y = 1, msg = "syntax error" },
+      { y = 1, msg = "expected a single expression" },
    }))
 
    it("malformed string: non escapable character", util.check_syntax_error([[
       print("\s")
    ]], {
-      { y = 1, msg = "syntax error" },
+      { y = 1, msg = "expected a literal" }, -- TODO: this should actually say malformed string
    }))
 
    it("malformed string: bad hex character", util.check_syntax_error([[
       print("\xZZ")
    ]], {
-      { y = 1, msg = "syntax error" },
+      { y = 1, msg = "expected a literal" },
    }))
 
    it("malformed string: bad UTF-8 character", util.check_syntax_error([[
       print("\u{ZZ}")
    ]], {
-      { y = 1, msg = "syntax error" },
+      { y = 1, msg = "expected a literal" },
    }))
 
    it("malformed string: bad UTF-8 character", util.check_syntax_error([[
       print("\")
    ]], {
-      { y = 1, msg = "syntax error" },
+      { y = 1, msg = "syntax error, expected ')'" },
    }))
 
    it("valid strings: numbered escape", util.check [[
@@ -78,7 +78,7 @@ describe("syntax errors", function()
    it("malformed string: numbered escape", util.check_syntax_error([[
       print("hello\300hello")
    ]], {
-      { y = 1, msg = "syntax error" },
+      { y = 1, msg = "expected a literal" },
    }))
 
    it("reports on approximate source of missing 'end'", util.check_syntax_error([[

--- a/spec/lexer/long_comment_spec.lua
+++ b/spec/lexer/long_comment_spec.lua
@@ -63,7 +63,7 @@ describe("long comment", function()
       ]=]
       local foo = 1
    ]], {
-      { msg = "syntax error" }
+      { msg = "expected either an assignment or function call" }
    }))
 
    pending("export Lua", function()

--- a/spec/lexer/long_string_spec.lua
+++ b/spec/lexer/long_string_spec.lua
@@ -65,7 +65,7 @@ describe("long string", function()
             long string line 2
          ]=]
    ]], {
-      { y = 6, x = 18, msg = "syntax error" },
+      { y = 6, x = 18, msg = "expected either an assignment or function call" },
    }))
 
    it("export Lua", function()

--- a/spec/operator/as_spec.lua
+++ b/spec/operator/as_spec.lua
@@ -51,4 +51,17 @@ describe("cast", function()
       local z = 10
    ]])
 
+   it("should not crash on unexpected eof (#345)", util.check_syntax_error([[
+      local x = 1 as
+   ]], {
+      { msg = "expected a type" }
+   }))
+
+   it("should not crash when casting an empty expression (#345)", util.check_syntax_error([[
+      local x = () as string
+   ]], {
+      { msg = "expected a literal" },
+      { msg = "expected an expression" },
+      { msg = "syntax error, expected ')'" }
+   }))
 end)

--- a/spec/parser/syntax_errors_spec.lua
+++ b/spec/parser/syntax_errors_spec.lua
@@ -8,7 +8,7 @@ describe("syntax errors", function()
 
       print("what")
    ]], {
-      { y = 3, msg = "syntax error" },
+      { y = 3, msg = "expected one or more expressions" },
    }))
 
    it("in table declaration", util.check_syntax_error([[
@@ -19,7 +19,7 @@ describe("syntax errors", function()
       }
    ]], {
       { y = 3, x = 15, msg = "syntax error, expected one of: '}', ','" },
-      { y = 3, x = 17, msg = "syntax error" },
+      { y = 3, x = 17, msg = "expected an expression" },
    }))
 
    it("missing separators in table", util.check_syntax_error([[

--- a/tl.lua
+++ b/tl.lua
@@ -1105,7 +1105,7 @@ local function fail(ps, i, msg)
       table.insert(ps.errs, { y = eof.y, x = eof.x, msg = msg or "unexpected end of file" })
       return #ps.tokens
    end
-   table.insert(ps.errs, { y = ps.tokens[i].y, x = ps.tokens[i].x, msg = msg or "syntax error" })
+   table.insert(ps.errs, { y = ps.tokens[i].y, x = ps.tokens[i].x, msg = assert(msg, "syntax error, but no error message provided") })
    return math.min(#ps.tokens, i + 1)
 end
 
@@ -1186,7 +1186,7 @@ end
 local function parse_table_item(ps, i, n)
    local node = new_node(ps.tokens, i, "table_item")
    if ps.tokens[i].kind == "$EOF$" then
-      return fail(ps, i)
+      return fail(ps, i, "unexpected eof")
    end
 
    if ps.tokens[i].tk == "[" then
@@ -1239,7 +1239,7 @@ local function parse_table_item(ps, i, n)
    node.key.tk = tostring(n)
    i, node.value = parse_expression(ps, i)
    if not node.value then
-      return fail(ps, i)
+      return fail(ps, i, "expected an expression")
    end
    return i, node, n + 1
 end
@@ -1264,7 +1264,7 @@ local function parse_list(ps, i, list, close, sep, parse_item)
       if ps.tokens[i].tk == "," then
          i = i + 1
          if sep == "sep" and close[ps.tokens[i].tk] then
-            return fail(ps, i)
+            return fail(ps, i, "unexpected '" .. ps.tokens[i].tk .. "'")
          end
       elseif sep == "term" and ps.tokens[i].tk == ";" then
          i = i + 1
@@ -1455,7 +1455,7 @@ local function parse_base_type(ps, i)
       end
       return i, typ
    end
-   return fail(ps, i)
+   return fail(ps, i, "expected a type")
 end
 
 parse_type = function(ps, i)
@@ -1587,7 +1587,7 @@ local function parse_literal(ps, i)
    elseif ps.tokens[i].tk == "function" then
       return parse_function_value(ps, i)
    end
-   return fail(ps, i)
+   return fail(ps, i, "expected a literal")
 end
 
 local an_operator
@@ -1685,6 +1685,10 @@ do
          i, e1 = parse_literal(ps, i)
       end
 
+      if not e1 then
+         fail(ps, i, "expected an expression")
+         return i
+      end
       while true do
          if ps.tokens[i].kind == "string" or ps.tokens[i].kind == "{" then
             local op = new_operator(ps.tokens[i], 2, "@funcall")
@@ -1760,6 +1764,10 @@ do
                i, cast.casttype = parse_type_list(ps, i, "casttype")
             else
                i, cast.casttype = parse_type(ps, i)
+            end
+            if not cast.casttype then
+               fail(ps, i, "expected a type")
+               return i
             end
             e1 = { y = t1.y, x = t1.x, kind = "op", op = op, e1 = e1, e2 = cast, conststr = e1.conststr }
          else
@@ -2343,7 +2351,7 @@ parse_newtype = function(ps, i)
       i, node.newtype.def = parse_type(ps, i)
       return i, node
    end
-   return fail(ps, i)
+   return fail(ps, i, "expected a type")
 end
 
 local function parse_call_or_assignment(ps, i)
@@ -2353,7 +2361,7 @@ local function parse_call_or_assignment(ps, i)
    asgn.vars = new_node(ps.tokens, i, "variables")
    i = parse_trying_list(ps, i, asgn.vars, parse_expression)
    if #asgn.vars < 1 then
-      return fail(ps, i)
+      return fail(ps, i, "expected one or more expressions")
    end
    local lhs = asgn.vars[1]
 
@@ -2368,12 +2376,12 @@ local function parse_call_or_assignment(ps, i)
       return i, asgn
    end
    if #asgn.vars > 1 then
-      return failskip(ps, i, nil, parse_expression, tryi)
+      return failskip(ps, i, "expected a single expression", parse_expression, tryi)
    end
    if lhs.op and lhs.op.op == "@funcall" and #asgn.vars == 1 then
       return i, lhs
    end
-   return fail(ps, i)
+   return fail(ps, i, "expected either an assignment or function call")
 end
 
 local function parse_variable_declarations(ps, i, node_name)
@@ -4108,6 +4116,10 @@ local standard_library = {
    ["debug"] = a_type({
       typename = "record",
       fields = {
+         ["Info"] = a_type({
+            typename = "typetype",
+            def = DEBUG_GETINFO_TABLE,
+         }),
          ["Hook"] = a_type({
             typename = "typetype",
             def = DEBUG_HOOK_FUNCTION,

--- a/tl.tl
+++ b/tl.tl
@@ -1105,7 +1105,7 @@ local function fail(ps: ParseState, i: number, msg: string): number
       table.insert(ps.errs, { y = eof.y, x = eof.x, msg = msg or "unexpected end of file" })
       return #ps.tokens
    end
-   table.insert(ps.errs, { y = ps.tokens[i].y, x = ps.tokens[i].x, msg = msg or "syntax error" })
+   table.insert(ps.errs, { y = ps.tokens[i].y, x = ps.tokens[i].x, msg = assert(msg, "syntax error, but no error message provided") })
    return math.min(#ps.tokens, i + 1)
 end
 
@@ -1186,7 +1186,7 @@ end
 local function parse_table_item(ps: ParseState, i: number, n: number): number, Node, number
    local node = new_node(ps.tokens, i, "table_item")
    if ps.tokens[i].kind == "$EOF$" then
-      return fail(ps, i)
+      return fail(ps, i, "unexpected eof")
    end
 
    if ps.tokens[i].tk == "[" then
@@ -1239,7 +1239,7 @@ local function parse_table_item(ps: ParseState, i: number, n: number): number, N
    node.key.tk = tostring(n)
    i, node.value = parse_expression(ps, i)
    if not node.value then
-      return fail(ps, i)
+      return fail(ps, i, "expected an expression")
    end
    return i, node, n + 1
 end
@@ -1264,7 +1264,7 @@ local function parse_list<T>(ps: ParseState, i: number, list: {T}, close: {strin
       if ps.tokens[i].tk == "," then
          i = i + 1
          if sep == "sep" and close[ps.tokens[i].tk] then
-            return fail(ps, i)
+            return fail(ps, i, "unexpected '" .. ps.tokens[i].tk .. "'")
          end
       elseif sep == "term" and ps.tokens[i].tk == ";" then
          i = i + 1
@@ -1455,7 +1455,7 @@ local function parse_base_type(ps: ParseState, i: number): number, Type, number
       end
       return i, typ
    end
-   return fail(ps, i)
+   return fail(ps, i, "expected a type")
 end
 
 parse_type = function(ps: ParseState, i: number): number, Type, number
@@ -1587,7 +1587,7 @@ local function parse_literal(ps: ParseState, i: number): number, Node
    elseif ps.tokens[i].tk == "function" then
       return parse_function_value(ps, i)
    end
-   return fail(ps, i)
+   return fail(ps, i, "expected a literal")
 end
 
 local an_operator: function(Node, number, string): Operator
@@ -1685,6 +1685,10 @@ do
          i, e1 = parse_literal(ps, i)
       end
 
+      if not e1 then
+         fail(ps, i, "expected an expression")
+         return i
+      end
       while true do
          if ps.tokens[i].kind == "string" or ps.tokens[i].kind == "{" then
             local op: Operator = new_operator(ps.tokens[i], 2, "@funcall")
@@ -1760,6 +1764,10 @@ do
                i, cast.casttype = parse_type_list(ps, i, "casttype")
             else
                i, cast.casttype = parse_type(ps, i)
+            end
+            if not cast.casttype then
+               fail(ps, i, "expected a type")
+               return i
             end
             e1 = { y = t1.y, x = t1.x, kind = "op", op = op, e1 = e1, e2 = cast, conststr = e1.conststr }
          else
@@ -2343,7 +2351,7 @@ parse_newtype = function(ps: ParseState, i: number): number, Node
       i, node.newtype.def = parse_type(ps, i)
       return i, node
    end
-   return fail(ps, i)
+   return fail(ps, i, "expected a type")
 end
 
 local function parse_call_or_assignment(ps: ParseState, i: number): number, Node
@@ -2353,7 +2361,7 @@ local function parse_call_or_assignment(ps: ParseState, i: number): number, Node
    asgn.vars = new_node(ps.tokens, i, "variables")
    i = parse_trying_list(ps, i, asgn.vars, parse_expression)
    if #asgn.vars < 1 then
-      return fail(ps, i)
+      return fail(ps, i, "expected one or more expressions")
    end
    local lhs: Node = asgn.vars[1]
 
@@ -2368,12 +2376,12 @@ local function parse_call_or_assignment(ps: ParseState, i: number): number, Node
       return i, asgn
    end
    if #asgn.vars > 1 then
-      return failskip(ps, i, nil, parse_expression, tryi)
+      return failskip(ps, i, "expected a single expression", parse_expression, tryi)
    end
    if lhs.op and lhs.op.op == "@funcall" and #asgn.vars == 1 then
       return i, lhs
    end
-   return fail(ps, i)
+   return fail(ps, i, "expected either an assignment or function call")
 end
 
 local function parse_variable_declarations(ps: ParseState, i: number, node_name: NodeKind): number, Node


### PR DESCRIPTION
Previously expressions like `() as string` and `1 as` would crash the
compiler, these now produce syntax errors instead.

Additionally, any call to `fail` now must have an associated error
message

Fixes #345