### PR TITLE
perform flow inference based on ==

### DIFF
--- a/spec/operator/eq_spec.lua
+++ b/spec/operator/eq_spec.lua
@@ -79,6 +79,62 @@ describe("flow analysis with ==", function()
          { msg = "cannot index something that is not a record: number | string" }
       }))
 
+      it("propagates string constants for use as enums", util.check [[
+         local enum Direction
+            "north"
+            "south"
+            "east"
+            "west"
+         end
+
+         local function f(d: Direction)
+            print(d)
+         end
+
+         local s: string
+         if s == "north" then
+            f(s)
+         end
+      ]])
+
+      it("combines string constants for use as enums", util.check [[
+         local enum Direction
+            "north"
+            "south"
+            "east"
+            "west"
+         end
+
+         local function f(d: Direction)
+            print(d)
+         end
+
+         local s: string
+         if s == "north" or s == "south" then
+            f(s)
+         end
+      ]])
+
+      it("does not combine if not valid as enums", util.check_type_error([[
+         local enum Direction
+            "north"
+            "south"
+            "east"
+            "west"
+         end
+
+         local function f(d: Direction)
+            print(d)
+         end
+
+         local s: string
+         if s == "north" or s == "bad" then
+            f(s)
+         end
+      ]], {
+         { msg = [[argument 1: got string "north" | string "bad" (inferred at foo.tl:13:26), expected Direction]] }
+      }))
+
       it("works for type arguments", util.check [[
          local function test<T>(t: T)
             if t == 9 then

--- a/spec/operator/eq_spec.lua
+++ b/spec/operator/eq_spec.lua
@@ -30,3 +30,197 @@ describe("==", function()
       { msg = "not comparable for equality" }
    }))
 end)
+
+describe("flow analysis with ==", function()
+   describe("on expressions", function()
+      it("narrows type on expressions with and", util.check [[
+         local x: number | string
+         local y: string
+
+         local s = x == y and x:lower()
+      ]])
+
+      it("does not narrow type on expressions with or", util.check_type_error([[
+         local x: number | string
+         local n: number
+
+         local s = x == n and tostring(x + 1) or x:lower()
+      ]], {
+         { msg = "cannot index something that is not a record: number | string" }
+      }))
+
+      it("does not narrow type on expressions with not", util.check_type_error([[
+         local x: number | string
+         local y: string
+
+         local s = not (x == y) and tostring(x + 1)
+      ]], {
+         { msg = "cannot use operator '+' for types number | string and number" }
+      }))
+   end)
+
+   describe("on if", function()
+      it("resolves in both directions", util.check [[
+         local t: number | string
+         local n: number
+         if n == t then
+            print(t + 1)
+         end
+      ]])
+
+      it("resolves only on then branch", util.check_type_error([[
+         local t: number | string
+         if t == 9 then
+            print(t + 1)
+         else
+            print(t:upper())
+         end
+      ]], {
+         { msg = "cannot index something that is not a record: number | string" }
+      }))
+
+      it("works for type arguments", util.check [[
+         local function test<T>(t: T)
+            if t == 9 then
+               print(t + 1)
+            else
+               print(t)
+            end
+         end
+      ]])
+
+      it("works for not and type arguments", util.check [[
+         local function test<T>(t: T)
+            if not (t == 9) then
+               print(t)
+            else
+               print(t + 1)
+            end
+         end
+      ]])
+
+      it("does not narrow with not", util.check_type_error([[
+         local t: number | string
+         if not (t == 9) then
+            print(t:upper())
+         else
+            print(t + 1)
+         end
+      ]], {
+         { msg = "cannot index something that is not a record: number | string" }
+      }))
+
+      it("resolves with elseif", util.check [[
+         local v: number | string | {boolean}
+         if v == 9 then
+            v = v + 1
+         elseif v == "hello" then
+            print(v:upper())
+         end
+      ]])
+
+      it("resolves with a type definition", util.check [[
+         local type A = number
+         local type B = record
+           h: UnionAorB
+           t: UnionAorB
+         end
+         local type UnionAorB = A | B
+         local b: B = {}
+
+         function head(n: UnionAorB): UnionAorB
+           if n == b then
+             return n.h
+           end
+         end
+      ]])
+
+      it("does not resolve incrementally", util.check_type_error([[
+         local v: number | string | {boolean}
+         if v == 2 then
+            v = v + 1
+         elseif v == "hello" then
+            print(v:upper())
+         else
+            local b: {boolean} = v
+         end
+      ]], {
+         { msg = "in local declaration: b: got number | string | {boolean}, expected {boolean}" }
+      }))
+
+      it("can use inferred facts in elseif expression", util.check [[
+         local record Rec
+            op: string
+         end
+         local v: string | Rec
+         if v is string then
+            v = v:upper()
+         elseif v.op:match("something") then
+            print(v.op:upper())
+         end
+      ]])
+
+      it("does not resolve partially", util.check_type_error([[
+         local v: number | string | {boolean}
+         if v == 9 then
+            print(v + 1)
+         else
+            print(v:upper()) -- v is number | string | {boolean}
+         end
+      ]], {
+         { msg = "cannot index something that is not a record: number | string | {boolean}" }
+      }))
+
+      it("builds union types with == and or", util.check_type_error([[
+         local v: number | boolean | {string}
+         if (v == 9) or (v == true) then
+            print(v + 1) -- ERR
+         end
+      ]], {
+         { msg = "cannot use operator '+' for types number | boolean" },
+      }))
+
+      it("builds union types with == and or (parses priorities correctly)", util.check_type_error([[
+         local v: number | boolean | {string}
+         if v == 9 or v == true then
+            print(v + 1) -- ERR
+         end
+      ]], {
+         { msg = "cannot use operator '+' for types number | boolean" },
+      }))
+   end)
+
+   describe("on while", function()
+      it("widens unions on while to avoid errors", util.check_type_error([[
+         local t: number | string
+         t = 1
+         if t == 1 then
+            while t < 1000 do
+               if t is number then
+                  t = t + 1
+               end
+               if t == 10 then
+                  t = "hello"
+               end
+            end
+         end
+      ]], {
+         { y = 4, msg = [[cannot use operator '<' for types number | string and number]] },
+      }))
+
+      it("resolves == on the test", util.check [[
+         function process(ts: {number | string})
+            local t: number | string
+            t = ts[1]
+            local i = 1
+            local n: number = i
+            while t == n do
+               print(t + 1)
+               i = i + 1
+               t = ts[i]
+               n = i
+            end
+         end
+      ]])
+   end)
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -5292,7 +5292,7 @@ tl.type_check = function(ast, opts)
       return true
    end
 
-   local function unite(types)
+   local function unite(types, flatten_constants)
       if #types == 1 then
          return types[1]
       end
@@ -5321,7 +5321,7 @@ tl.type_check = function(ast, opts)
                table.insert(stack, s)
             end
          else
-            if primitive[t.typename] then
+            if primitive[t.typename] and (flatten_constants or not t.tk) then
                if not types_seen[t.typename] then
                   types_seen[t.typename] = true
                   table.insert(ts, t)
@@ -7591,6 +7591,10 @@ tl.type_check = function(ast, opts)
                end
             elseif node.op.arity == 1 and unop_types[node.op.op] then
                a = ua
+               if a.typename == "union" then
+                  a = unite(a.types, true)
+               end
+
                local types_op = unop_types[node.op.op]
                node.type = types_op[a.typename]
                local metamethod
@@ -7622,6 +7626,14 @@ tl.type_check = function(ast, opts)
 
                a = ua
                b = ub
+
+               if a.typename == "union" then
+                  a = unite(a.types, true)
+               end
+               if b.typename == "union" then
+                  b = unite(b.types, true)
+               end
+
                local types_op = binop_types[node.op.op]
                node.type = types_op[a.typename] and types_op[a.typename][b.typename]
                local metamethod

--- a/tl.tl
+++ b/tl.tl
@@ -5292,7 +5292,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       return true
    end
 
-   local function unite(types: {Type}): Type
+   local function unite(types: {Type}, flatten_constants: boolean): Type
       if #types == 1 then
          return types[1]
       end
@@ -5300,7 +5300,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       local ts: {Type} = {}
       local stack: {Type} = {}
 
-      -- Make things like string | string resolve to string
+      -- Make things like number | number resolve to number
       local types_seen: {(number|string):boolean} = {}
       -- but never add nil as a type in the union
       types_seen[NIL.typeid] = true
@@ -5321,7 +5321,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                table.insert(stack, s)
             end
          else
-            if primitive[t.typename] then
+            if primitive[t.typename] and (flatten_constants or not t.tk) then
                if not types_seen[t.typename] then
                   types_seen[t.typename] = true
                   table.insert(ts, t)
@@ -7591,6 +7591,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
             elseif node.op.arity == 1 and unop_types[node.op.op] then
                a = ua
+               if a.typename == "union" then
+                  a = unite(a.types, true) -- squash unions of string constants
+               end
+
                local types_op = unop_types[node.op.op]
                node.type = types_op[a.typename]
                local metamethod: Type
@@ -7622,6 +7626,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
                a = ua
                b = ub
+
+               if a.typename == "union" then
+                  a = unite(a.types, true) -- squash unions of string constants
+               end
+               if b.typename == "union" then
+                  b = unite(b.types, true) -- squash unions of string constants
+               end
+
                local types_op = binop_types[node.op.op]
                node.type = types_op[a.typename] and types_op[a.typename][b.typename]
                local metamethod: Type

--- a/tl.tl
+++ b/tl.tl
@@ -993,6 +993,7 @@ local enum FactType
    "and"
    "or"
    "not"
+   "=="
 end
 
 local record Fact
@@ -5011,7 +5012,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    end
 
    local function add_var(node: Node, var: string, valtype: Type, is_const: boolean, is_narrowing: boolean): Variable
-      if lax and node and is_unknown(valtype) and (var ~= "self" and var ~= "...") then
+      if lax and node and is_unknown(valtype) and (var ~= "self" and var ~= "...") and not is_narrowing then
          add_unknown(node, var)
       end
       local scope <const> = st[#st]
@@ -6563,6 +6564,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
                return { [f.var] = sub }
             end
+         elseif f.fact == "==" then
+            return {}
          elseif f.fact == "not" then
             return eval_fact(f.f1)
          elseif f.fact == "and" then
@@ -6636,6 +6639,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             else
                return { [f.var] = f.typ }
             end
+         elseif f.fact == "==" then
+            return { [f.var] = f.typ }
          elseif f.fact == "not" then
             return eval_not(f.f1)
          elseif f.fact == "and" then
@@ -7570,14 +7575,19 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                node.known = nil
                node.type = (ua.typename == "enum" and ua or ub)
             elseif node.op.op == "==" or node.op.op == "~=" then
-               if is_a(a, b, true) or is_a(b, a, true) then
-                  node.type = BOOLEAN
-               else
-                  if lax and (is_unknown(a) or is_unknown(b)) then
-                     node.type = UNKNOWN
-                  else
-                     node_error(node, "types are not comparable for equality: %s and %s", a, b)
+               node.type = BOOLEAN
+               if is_a(b, a, true) or a.typename == "typevar" then
+                  if node.op.op == "==" and node.e1.kind == "variable" then
+                     node.known = Fact { fact = "==", var = node.e1.tk, typ = b, where = node }
                   end
+               elseif is_a(a, b, true) or b.typename == "typevar" then
+                  if node.op.op == "==" and node.e2.kind == "variable" then
+                     node.known = Fact { fact = "==", var = node.e2.tk, typ = a, where = node }
+                  end
+               elseif lax and (is_unknown(a) or is_unknown(b)) then
+                  node.type = UNKNOWN
+               else
+                  node_error(node, "types are not comparable for equality: %s and %s", a, b)
                end
             elseif node.op.arity == 1 and unop_types[node.op.op] then
                a = ua


### PR DESCRIPTION
Makes code such as this valid:

```
local x: number | string

if x == 9 then
   print(x + 2)
end
```

A more interesting use is propagating string constants into enums:

```
local enum Direction
   "north"
   "south"
   "east"
   "west"
end

local function f(d: Direction)
   print(d)
end

local s: string
if s == "north" or s == "south" then
   f(s)
end
```

Note that _assignments_ do not (yet) propagate, since that would require a proper constant propagation algorithm. This is more of a clever hack reusing the conservative flow analysis I had implemented for `is`.
