### PR TITLE
tl types: new CLI command (and tl API) for dumping type information

### DIFF
--- a/spec/call/syntax_errors_spec.lua
+++ b/spec/call/syntax_errors_spec.lua
@@ -5,7 +5,6 @@ describe("call", function()
       print("hello", "world",)
    ]], {
       { msg = "unexpected ')'" },
-      { msg = "syntax error, expected ')'" },
    }))
 
    it("cannot call a string", util.check_syntax_error([[

--- a/spec/cli/types_spec.lua
+++ b/spec/cli/types_spec.lua
@@ -1,0 +1,155 @@
+local assert = require("luassert")
+local util = require("spec.util")
+
+describe("tl types works like check", function()
+   describe("on .tl files", function()
+      it("works on empty files", function()
+         local name = util.write_tmp_file(finally, [[]])
+         local pd = io.popen(util.tl_cmd("types", name), "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(true, "exit", 0, pd:close())
+         -- TODO check json output
+      end)
+
+      it("reports 0 errors and code 0 on success", function()
+         local name = util.write_tmp_file(finally, [[
+            local function add(a: number, b: number): number
+               return a + b
+            end
+
+            print(add(10, 20))
+         ]])
+         local pd = io.popen(util.tl_cmd("types", name), "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(true, "exit", 0, pd:close())
+         -- TODO check json output
+      end)
+
+      it("reports number of errors in stderr and code 1 on type errors", function()
+         local name = util.write_tmp_file(finally, [[
+            local function add(a: number, b: number): number
+               return a + b
+            end
+
+            print(add("string", 20))
+            print(add(10, true))
+         ]])
+         local pd = io.popen(util.tl_cmd("types", name) .. "2>&1 1>/dev/null", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(nil, "exit", 1, pd:close())
+         assert.match("2 errors:", output, 1, true)
+         -- TODO check json output
+      end)
+
+      it("reports errors in multiple files", function()
+         local name1 = util.write_tmp_file(finally, [[
+            local function add(a: number, b: number): number
+               return a + b
+            end
+
+            print(add("string", 20))
+            print(add(10, true))
+         ]])
+         local name2 = util.write_tmp_file(finally, [[
+            local function add(a: number, b: number): number
+               return a + b
+            end
+
+            print(add("string", 20))
+            print(add(10, true))
+         ]])
+         local pd = io.popen(util.tl_cmd("types", name1, name2) .. " 2>&1 1>/dev/null", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(nil, "exit", 1, pd:close())
+         assert.match(name1 .. ":", output, 1, true)
+         assert.match(name2 .. ":", output, 1, true)
+         -- TODO check json output
+      end)
+
+      it("reports number of errors in stderr and code 1 on syntax errors", function()
+         local name = util.write_tmp_file(finally, [[
+            print(add("string", 20))))))
+         ]])
+         local pd = io.popen(util.tl_cmd("types", name) .. "2>&1 1>/dev/null", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(nil, "exit", 1, pd:close())
+         assert.match("1 syntax error:", output, 1, true)
+         -- TODO check json output
+      end)
+
+      it("reports use of unknowns as errors in stderr and returns code 1", function()
+         local name = util.write_tmp_file(finally, [[
+            local function unk(x, y): number, number
+               return a + b
+            end
+         ]])
+         local pd = io.popen(util.tl_cmd("types", name) .. "2>&1 1>/dev/null", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(nil, "exit", 1, pd:close())
+         assert.match("2 errors:", output, 1, true)
+         assert.match("unknown variable: a", output, 1, true)
+         assert.match("unknown variable: b", output, 1, true)
+         -- TODO check json output
+      end)
+   end)
+
+   describe("on .lua files", function()
+      it("reports 0 errors and code 0 on success", function()
+         local name = util.write_tmp_file(finally, [[
+            local function add(a: number, b: number): number
+               return a + b
+            end
+
+            print(add(10, 20))
+         ]], "lua")
+         local pd = io.popen(util.tl_cmd("types", name), "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(true, "exit", 0, pd:close())
+         -- TODO check json output
+      end)
+
+      it("reports number of errors in stderr and code 1 on type errors", function()
+         local name = util.write_tmp_file(finally, [[
+            local function add(a: number, b: number): number
+               return a + b
+            end
+
+            print(add("string", 20))
+            print(add(10, true))
+         ]], "lua")
+         local pd = io.popen(util.tl_cmd("types", name) .. " 2>&1 1>/dev/null", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(nil, "exit", 1, pd:close())
+         assert.match("2 errors:", output, 1, true)
+         -- TODO check json output
+      end)
+
+      it("reports number of errors in stderr and code 1 on syntax errors", function()
+         local name = util.write_tmp_file(finally, [[
+            print(add("string", 20))))))
+         ]], "lua")
+         local pd = io.popen(util.tl_cmd("types", name) .. "2>&1 1>/dev/null", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(nil, "exit", 1, pd:close())
+         assert.match("1 syntax error:", output, 1, true)
+         -- TODO check json output
+      end)
+
+      it("reports unknowns variables in stderr and code 0 if no errors", function()
+         local name = util.write_tmp_file(finally, [[
+            local function add(a: number, b: number): number
+               return a + b
+            end
+
+            local function sub(x, y): number
+               return x + y
+            end
+         ]], "lua")
+         local pd = io.popen(util.tl_cmd("types", name) .. " 2>&1 1>/dev/null", "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(true, "exit", 0, pd:close())
+         assert.match("2 unknown variables:", output, 1, true)
+         -- TODO check json output
+      end)
+   end)
+end)

--- a/spec/error_reporting/syntax_error_spec.lua
+++ b/spec/error_reporting/syntax_error_spec.lua
@@ -93,6 +93,7 @@ describe("syntax errors", function()
       print(4)
    ]], {
       { y = 1, msg = "syntax error" },
+      { y = 2, msg = "syntax error" },
    }))
 
    it("malformed string: non escapable character", util.check_syntax_error([[

--- a/spec/lexer/long_comment_spec.lua
+++ b/spec/lexer/long_comment_spec.lua
@@ -63,6 +63,7 @@ describe("long comment", function()
       ]=]
       local foo = 1
    ]], {
-      { msg = "syntax error" },
+      { y = 6, msg = "syntax error" },
+      { y = 7, msg = "syntax error" },
    }))
 end)

--- a/spec/lexer/long_string_spec.lua
+++ b/spec/lexer/long_string_spec.lua
@@ -69,6 +69,7 @@ describe("long string", function()
          ]=]
    ]], {
       { y = 6, x = 18, msg = "syntax error" },
+      { y = 7, x = 10, msg = "syntax error" },
    }))
 
    it("export Lua", function()

--- a/spec/operator/as_spec.lua
+++ b/spec/operator/as_spec.lua
@@ -61,6 +61,7 @@ describe("cast", function()
       local x = () as string
    ]], {
       { msg = "syntax error" },
-      { msg = "syntax error, expected ')'" }
+      { msg = "syntax error, expected ')'" },
+      { msg = "syntax error" },
    }))
 end)

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -451,10 +451,11 @@ function util.check_syntax_error(code, syntax_errors)
    return function()
       local tokens = tl.lex(code)
       local errors = {}
-      tl.parse_program(tokens, errors)
+      local _, ast = tl.parse_program(tokens, errors)
       local batch = batch_assertions()
       batch_compare(batch, "syntax errors", syntax_errors, errors)
       batch:assert()
+      tl.type_check(ast, { filename = "foo.tl", lax = false })
    end
 end
 

--- a/tl
+++ b/tl
@@ -242,6 +242,9 @@ local function get_args_parser()
 
    parser:command("warnings", "List each kind of warning the compiler can produce.")
 
+   local types_command = parser:command("types", "Report all types found in one or more Teal files")
+   types_command:argument("file", "The Teal source file."):args("+")
+
    return parser
 end
 
@@ -842,6 +845,67 @@ if cmd == "check" then
       if i > 1 then
          collectgarbage()
       end
+   end
+   os.exit(exit)
+end
+
+
+--------------------------------------------------------------------
+--                           TYPES                                --
+--------------------------------------------------------------------
+
+local function json_out(fd, x)
+   local tx = type(x)
+   if tx == "number" or tx == "string" then
+      fd:write(string.format("%q", x))
+      return
+   end
+   assert(tx == "table")
+   if x[0] == false then -- special array marker for json dump
+      fd:write("[")
+      local l = #x
+      for i, v in ipairs(x) do
+         json_out(fd, v)
+         if i < l then
+            fd:write(",\n")
+         end
+      end
+      fd:write("]")
+   else
+      fd:write("{")
+      local c = ""
+      for k, v in pairs(x) do
+         fd:write(string.format("%s%q:", c, tostring(k)))
+         c = ",\n"
+         json_out(fd, v)
+      end
+      fd:write("}")
+   end
+end
+
+if cmd == "types" then
+   turbo(true)
+   tlconfig["quiet"] = true
+   tlconfig["gen_compat"] = "off"
+   local tr, trenv
+   local errs = false
+   for i, input_file in ipairs(args["file"]) do
+      local result = type_check_file(input_file)
+      if result and result.ast then
+         tr, trenv = tl.get_types(input_file, result.ast, trenv)
+      end
+      if #result.warnings > 0 or #result.syntax_errors > 0 or #result.type_errors > 0 then
+         errs = true
+      end
+      if i > 1 then
+         collectgarbage()
+      end
+   end
+   if tr then
+      if errs then
+         printerr("")
+      end
+      json_out(io.stdout, tr)
    end
    os.exit(exit)
 end

--- a/tl
+++ b/tl
@@ -244,6 +244,8 @@ local function get_args_parser()
 
    local types_command = parser:command("types", "Report all types found in one or more Teal files")
    types_command:argument("file", "The Teal source file."):args("+")
+   types_command:option("-p --position", "Report values in scope in position line[:column]")
+              :argname("<position>")
 
    return parser
 end
@@ -863,10 +865,11 @@ local function json_out(fd, x)
    if x[0] == false then -- special array marker for json dump
       fd:write("[")
       local l = #x
+      local colon = "," .. (#x < 10 and "" or "\n")
       for i, v in ipairs(x) do
          json_out(fd, v)
          if i < l then
-            fd:write(",\n")
+            fd:write(colon)
          end
       end
       fd:write("]")
@@ -895,7 +898,7 @@ if cmd == "types" then
    for i, input_file in ipairs(args["file"]) do
       local result = type_check_file(input_file)
       if result and result.ast then
-         tr, trenv = tl.get_types(input_file, result.ast, trenv)
+         tr, trenv = tl.get_types(result, trenv)
       end
       if #result.warnings > 0 or #result.syntax_errors > 0 or #result.type_errors > 0 then
          errs = true
@@ -908,7 +911,17 @@ if cmd == "types" then
       if errs then
          printerr("")
       end
-      json_out(io.stdout, tr)
+
+      local pos = args["position"]
+      if pos then
+         local y, x = pos:match("^(%d+):?(%d*)")
+         y = tonumber(y) or 1
+         x = tonumber(x) or 1
+         json_out(io.stdout, tl.symbols_in_scope(tr, y, x))
+      else
+         json_out(io.stdout, tr)
+      end
+
    end
    os.exit(exit)
 end

--- a/tl
+++ b/tl
@@ -667,7 +667,6 @@ local function type_check_file(file_name)
    local has_syntax_errors = report_errors("syntax error", result.syntax_errors)
    if has_syntax_errors then
       exit = 1
-      return
    end
 
    local ok = report_result(result)
@@ -887,6 +886,10 @@ if cmd == "types" then
    turbo(true)
    tlconfig["quiet"] = true
    tlconfig["gen_compat"] = "off"
+
+   setup_env(args["file"][1])
+   env.keep_going = true
+
    local tr, trenv
    local errs = false
    for i, input_file in ipairs(args["file"]) do

--- a/tl.lua
+++ b/tl.lua
@@ -7093,6 +7093,7 @@ tl.type_check = function(ast, opts)
 
                assert(var)
                add_var(var, var.tk, t, var.is_const)
+               var.type = t
 
                dismiss_unresolved(var.tk)
             end
@@ -7136,6 +7137,7 @@ tl.type_check = function(ast, opts)
                   end
                   t.inferred_len = nil
                   add_global(var, var.tk, t, var.is_const)
+                  var.type = t
 
                   dismiss_unresolved(var.tk)
                end

--- a/tl.lua
+++ b/tl.lua
@@ -8276,6 +8276,7 @@ function tl.get_types(result, trenv)
             by_pos = {},
             types = {},
             symbols = mark_array({}),
+            globals = {},
          },
       }
    end
@@ -8395,6 +8396,14 @@ function tl.get_types(result, trenv)
       assert(id)
       local sym = mark_array({ s.y, s.x, s.name, id })
       table.insert(tr.symbols, sym)
+   end
+
+   local gkeys = sorted_keys(result.env.globals)
+   for _, name in ipairs(gkeys) do
+      if name:sub(1, 1) ~= "@" then
+         local var = result.env.globals[name]
+         tr.globals[name] = get_typenum(var.t)
+      end
    end
 
    return tr, trenv

--- a/tl.lua
+++ b/tl.lua
@@ -100,7 +100,6 @@ local tl = {TypeCheckOptions = {}, Env = {}, Result = {}, Error = {}, TypeInfo =
 
 
 
-
 tl.warning_kinds = {
    ["unused"] = true,
    ["redeclaration"] = true,
@@ -8179,7 +8178,6 @@ function tl.get_types(filename, ast, trenv)
    if not trenv then
       trenv = {
          next_num = 1,
-
          typeid_to_num = {},
          tr = {
             by_pos = {},
@@ -8189,7 +8187,6 @@ function tl.get_types(filename, ast, trenv)
    end
 
    local tr = trenv.tr
-
    local typeid_to_num = trenv.typeid_to_num
 
    local function get_typenum(t)
@@ -8200,28 +8197,15 @@ function tl.get_types(filename, ast, trenv)
          return n
       end
 
-      local s
-      if t.typename == "string" then
-         s = "string"
-      else
-         s = show_type(t, true)
-      end
-
-
-
-
-
-
 
       n = trenv.next_num
       local ti = {
-         str = s,
+         str = show_type(t, true),
          file = t.filename,
          y = t.y,
          x = t.x,
       }
       tr.types[n] = ti
-
       typeid_to_num[t.typeid] = n
       trenv.next_num = trenv.next_num + 1
 

--- a/tl.tl
+++ b/tl.tl
@@ -39,13 +39,23 @@ local record tl
       keep_going: boolean
    end
 
+   record Symbol
+      x: number
+      y: number
+      name: string
+      typ: Type
+      other: number
+   end
+
    record Result
+      filename: string
       ast: Node
       type: Type
       syntax_errors: {Error}
       type_errors: {Error}
       unknowns: {Error}
       warnings: {Error}
+      symbol_list: {Symbol}
       env: Env
    end
 
@@ -83,6 +93,7 @@ local record tl
    record TypeReport
       by_pos: {string: {number: {number: number}}}
       types: {number: TypeInfo}
+      symbols: {{number, number, string, number}}
    end
 
    record TypeReportEnv
@@ -95,7 +106,7 @@ local record tl
    process: function(string, Env, Result, {string}): (Result, string)
    process_string: function(string, boolean, Env, Result, {string}, string): (Result, string)
    gen: function(string, Env): string
-   type_check: function(Node, TypeCheckOptions): ({Error}, {Error}, Type)
+   type_check: function(Node, TypeCheckOptions): ({Error}, {Error}, Type, {Symbol})
    init_env: function(boolean, boolean | CompatMode, TargetMode): Env
 
    package_loader_env: Env
@@ -120,6 +131,7 @@ local TargetMode = tl.TargetMode
 local TypeInfo = tl.TypeInfo
 local TypeReport = tl.TypeReport
 local TypeReportEnv = tl.TypeReportEnv
+local Symbol = tl.Symbol
 
 --------------------------------------------------------------------------------
 -- Lexer
@@ -4868,7 +4880,7 @@ tl.init_env = function(lax: boolean, gen_compat: boolean | CompatMode, gen_targe
    return env
 end
 
-tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Type
+tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, Type, {Symbol}
    opts = opts or {}
    local env = opts.env or tl.init_env(opts.lax, opts.gen_compat, opts.gen_target)
    local lax = opts.lax
@@ -4882,6 +4894,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    }
 
    local st: {{string:Variable}} = { env.globals }
+
+   local symbol_list: {Symbol} = {}
+   local symbol_list_n = 0
+   local symbol_list_scopes: {number} = {}
 
    local all_needs_compat = {}
 
@@ -5321,6 +5337,12 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
          end
       end
+
+      if node and valtype.typename ~= "unresolved" then
+         symbol_list_n = symbol_list_n + 1
+         symbol_list[symbol_list_n] = { y = node.y, x = node.x, name = var, typ = assert(scope[var].t) }
+      end
+
       return scope[var]
    end
 
@@ -5468,11 +5490,17 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
-   local function begin_scope()
+   local function begin_scope(node: Node)
       table.insert(st, {})
+
+      if node then
+         symbol_list_n = symbol_list_n + 1
+         symbol_list[symbol_list_n] = { y = node.y, x = node.x, name = "@{", other = -1 }
+         table.insert(symbol_list_scopes, symbol_list_n)
+      end
    end
 
-   local function end_scope()
+   local function end_scope(node: Node)
       local unresolved = st[#st]["@unresolved"]
       if unresolved then
          local upper = st[#st - 1]["@unresolved"]
@@ -5496,6 +5524,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       close_types(st[#st])
       check_for_unused_vars(st[#st])
       table.remove(st)
+
+      if node then
+         symbol_list_n = symbol_list_n + 1
+         local other = assert(table.remove(symbol_list_scopes))
+         assert(symbol_list[other].name == "@{")
+         symbol_list[symbol_list_n] = { y = node.yend or node.y, x = node.xend or node.x, name = "@}", other = other}
+         symbol_list[other].other = symbol_list_n
+      end
    end
 
    local function resolve_typevars_at(t: Type, where: Node): Type
@@ -6488,9 +6524,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
-   local function end_function_scope()
+   local function end_function_scope(node: Node)
       fail_unresolved()
-      end_scope()
+      end_scope(node)
    end
 
    resolve_unary = function(t: Type): Type
@@ -7075,8 +7111,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    visit_node.cbs = {
       ["statements"] = {
-         before = function()
-            begin_scope()
+         before = function(node: Node)
+            begin_scope(node)
          end,
          after = function(node: Node, _children: {Type}): Type
             -- if at the top level
@@ -7085,7 +7121,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
 
             if not node.is_repeat then
-               end_scope()
+               end_scope(node)
             end
             -- TODO extract node type from `return`
             node.type = NONE
@@ -7266,19 +7302,19 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       },
       ["if"] = {
          before_statements = function(node: Node)
-            begin_scope()
+            begin_scope(node)
             apply_facts(node.exp, node.exp.known)
          end,
          after = function(node: Node, _children: {Type}): Type
-            end_scope()
+            end_scope(node)
             node.type = NONE
             return node.type
          end,
       },
       ["elseif"] = {
          before = function(node: Node)
-            end_scope()
-            begin_scope()
+            end_scope(node)
+            begin_scope(node)
             local f = facts_not(node.parent_if.exp.known)
             for e = 1, node.elseif_n - 1 do
                f = facts_and(f, facts_not(node.parent_if.elseifs[e].exp.known), node)
@@ -7295,8 +7331,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       },
       ["else"] = {
          before = function(node: Node)
-            end_scope()
-            begin_scope()
+            end_scope(node)
+            begin_scope(node)
             local f = facts_not(node.parent_if.exp.known)
             for _, elseifnode in ipairs(node.parent_if.elseifs) do
                f = facts_and(f, facts_not(elseifnode.exp.known), node)
@@ -7314,11 +7350,11 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             widen_all_unions()
          end,
          before_statements = function(node: Node)
-            begin_scope()
+            begin_scope(node)
             apply_facts(node.exp, node.exp.known)
          end,
          after = function(node: Node, _children: {Type}): Type
-            end_scope()
+            end_scope(node)
             node.type = NONE
             return node.type
          end,
@@ -7363,15 +7399,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             widen_all_unions()
          end,
          after = function(node: Node, _children: {Type}): Type
-            -- only end scope after checking `until`, `statements` in repeat body has is_return == true
-            end_scope()
+            -- only end scope after checking `until`, `statements` in repeat body has is_repeat == true
+            end_scope(node)
             node.type = NONE
             return node.type
          end,
       },
       ["forin"] = {
-         before = function()
-            begin_scope()
+         before = function(node: Node)
+            begin_scope(node)
          end,
          before_statements = function(node: Node)
             local exp1 = node.exps[1]
@@ -7436,18 +7472,18 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
          end,
          after = function(node: Node, _children: {Type}): Type
-            end_scope()
+            end_scope(node)
             node.type = NONE
             return node.type
          end,
       },
       ["fornum"] = {
          before = function(node: Node)
-            begin_scope()
+            begin_scope(node)
             add_var(node.var, node.var.tk, NUMBER)
          end,
          after = function(node: Node, _children: {Type}): Type
-            end_scope()
+            end_scope(node)
             node.type = NONE
             return node.type
          end,
@@ -7671,15 +7707,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["local_function"] = {
-         before = function(_node: Node)
-            begin_scope()
+         before = function(node: Node)
+            begin_scope(node)
          end,
          before_statements = function(node: Node)
             add_internal_function_variables(node)
             add_function_definition_for_recursion(node)
          end,
          after = function(node: Node, children: {Type}): Type
-            end_function_scope()
+            end_function_scope(node)
             local rets = get_rets(children[3])
 
             add_var(node, node.name.tk, a_type {
@@ -7694,15 +7730,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["global_function"] = {
-         before = function(_node: Node)
-            begin_scope()
+         before = function(node: Node)
+            begin_scope(node)
          end,
          before_statements = function(node: Node)
             add_internal_function_variables(node)
             add_function_definition_for_recursion(node)
          end,
          after = function(node: Node, children: {Type}): Type
-            end_function_scope()
+            end_function_scope(node)
             add_global(nil, node.name.tk, a_type {
                y = node.y,
                x = node.x,
@@ -7715,8 +7751,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["record_function"] = {
-         before = function(_node: Node)
-            begin_scope()
+         before = function(node: Node)
+            begin_scope(node)
          end,
          before_statements = function(node: Node, children: {Type})
             add_internal_function_variables(node)
@@ -7765,21 +7801,21 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
          end,
          after = function(node: Node, _children: {Type}): Type
-            end_function_scope()
+            end_function_scope(node)
 
             node.type = NONE
             return node.type
          end,
       },
       ["function"] = {
-         before = function(_node: Node)
-            begin_scope()
+         before = function(node: Node)
+            begin_scope(node)
          end,
          before_statements = function(node: Node)
             add_internal_function_variables(node)
          end,
          after = function(node: Node, children: {Type}): Type
-            end_function_scope()
+            end_function_scope(node)
             -- children[1] args
             -- children[2] body
             node.type = a_type {
@@ -7806,7 +7842,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["op"] = {
-         before = function(_node: Node)
+         before = function()
             begin_scope()
          end,
          before_e2 = function(node: Node)
@@ -8216,15 +8252,21 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    add_compat_entries(ast, all_needs_compat, env.gen_compat)
 
-   return errors, unknowns, module_type
+   return errors, unknowns, module_type, symbol_list
 end
 
 --------------------------------------------------------------------------------
 -- Report types
 --------------------------------------------------------------------------------
 
-function tl.get_types(filename: string, ast: Node, trenv: TypeReportEnv): TypeReport, TypeReportEnv
-   assert(filename)
+function tl.get_types(result: Result, trenv: TypeReportEnv): TypeReport, TypeReportEnv
+   local filename = result.filename or "?"
+
+   local function mark_array<T>(x: T): T
+      local arr = x as {boolean}
+      arr[0] = false
+      return x
+   end
 
    if not trenv then
       trenv = {
@@ -8233,6 +8275,7 @@ function tl.get_types(filename: string, ast: Node, trenv: TypeReportEnv): TypeRe
          tr = {
             by_pos = {},
             types = {},
+            symbols = mark_array {},
          },
       }
    end
@@ -8275,7 +8318,8 @@ function tl.get_types(filename: string, ast: Node, trenv: TypeReportEnv): TypeRe
       -- store record field info
       if is_record_type(rt) then
          local r = {}
-         for k, v in pairs(rt.fields) do
+         for _, k in ipairs(rt.field_order) do
+            local v = rt.fields[k]
             r[k] = get_typenum(v)
          end
          ti.fields = r
@@ -8283,13 +8327,7 @@ function tl.get_types(filename: string, ast: Node, trenv: TypeReportEnv): TypeRe
 
       -- store enum info
       if rt.typename == "enum" then
-         local e = {}
-         for k, _ in pairs(rt.enumset) do
-            table.insert(e, k)
-         end
-         table.sort(e)
-         ti.enums = e
-         ti.enums[0] = false as string -- special array marker for json dump
+         ti.enums = mark_array(sorted_keys(rt.enumset))
       end
 
       return n
@@ -8319,9 +8357,9 @@ function tl.get_types(filename: string, ast: Node, trenv: TypeReportEnv): TypeRe
          ft[y] = yt
       end
 
-      if yt[x] then
-         return
-      end
+--      if yt[x] then
+--         return
+--      end
 
       yt[x] = get_typenum(typ)
    end
@@ -8338,11 +8376,76 @@ function tl.get_types(filename: string, ast: Node, trenv: TypeReportEnv): TypeRe
       end
    }
 
-   recurse_node(ast, visit_node, visit_type)
+   recurse_node(result.ast, visit_node, visit_type)
 
    tr.by_pos[filename][0] = nil
 
+   for _, s in ipairs(result.symbol_list) do
+      local id: number
+      if s.other then
+         if s.name == "@}" then
+            id = s.other - 1
+         else
+            id = s.other
+         end
+      else
+         assert(s.typ)
+         id = get_typenum(s.typ)
+      end
+      assert(id)
+      local sym = mark_array({s.y, s.x, s.name, id})
+      table.insert(tr.symbols, sym)
+   end
+
    return tr, trenv
+end
+
+function tl.symbols_in_scope(tr: TypeReport, y: number, x: number): {string:number}
+   local function le(vy: number, vx: number, y: number, x: number): boolean
+      return vy < y or (vy == y and vx <= x)
+   end
+
+   local function find(symbols: {{number, number, string, number}}, y: number, x: number): number
+      local len = #symbols
+      local s, mid, e = 1, 0, len
+      while s <= e do
+         mid = math.floor((s + e) / 2)
+         local v = symbols[mid]
+         if le(v[1], v[2], y, x) then
+            if mid == len then
+               return mid
+            else
+               local nv = symbols[mid + 1]
+               if not le(nv[1], nv[2], y, x) then
+                  return mid
+               end
+            end
+            s = mid + 1
+         else
+            e = mid - 1
+         end
+      end
+      return 0
+   end
+
+   local ret: {string:number} = {}
+
+   local n = find(tr.symbols, y, x)
+
+   local symbols = tr.symbols
+   while n >= 1 do
+      local s = symbols[n]
+      if s[3] == "@{" then
+         n = n - 1
+      elseif s[3] == "@}" then
+         n = s[4]
+      else
+         ret[s[3]] = s[4]
+         n = n - 1
+      end
+   end
+
+   return ret
 end
 
 --------------------------------------------------------------------------------
@@ -8435,8 +8538,9 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
       result = result,
       gen_compat = env.gen_compat,
    }
-   err, unknown, result.type = tl.type_check(program, opts)
+   err, unknown, result.type, result.symbol_list = tl.type_check(program, opts)
 
+   result.filename = filename
    result.ast = program
    result.env = env
 

--- a/tl.tl
+++ b/tl.tl
@@ -36,6 +36,7 @@ local record tl
       loaded: {string:Result}
       gen_compat: CompatMode
       gen_target: TargetMode
+      keep_going: boolean
    end
 
    record Result
@@ -1014,6 +1015,7 @@ local enum NodeKind
    "cast"
    "..."
    "paren"
+   "error_node"
 end
 
 local enum FactType
@@ -1237,12 +1239,18 @@ end
 
 local function parse_table_value(ps: ParseState, i: number): number, Node, number
    local next_word = ps.tokens[i].tk
+   local e: Node
    if next_word == "record" then
-      return failskip(ps, i, "syntax error: this syntax is no longer valid; declare nested record inside a record", skip_record)
+      i = failskip(ps, i, "syntax error: this syntax is no longer valid; declare nested record inside a record", skip_record)
    elseif next_word == "enum" then
-      return failskip(ps, i, "syntax error: this syntax is no longer valid; declare nested enum inside a record", skip_enum)
+      i = failskip(ps, i, "syntax error: this syntax is no longer valid; declare nested enum inside a record", skip_enum)
+   else
+      i, e = parse_expression(ps, i)
    end
-   return parse_expression(ps, i)
+   if not e then
+      e = new_node(ps.tokens, i - 1, "error_node")
+   end
+   return i, e
 end
 
 local function parse_table_item(ps: ParseState, i: number, n: number): number, Node, number
@@ -1327,7 +1335,8 @@ local function parse_list<T>(ps: ParseState, i: number, list: {T}, close: {strin
       if ps.tokens[i].tk == "," then
          i = i + 1
          if sep == "sep" and close[ps.tokens[i].tk] then
-            return fail(ps, i, "unexpected '" .. ps.tokens[i].tk .. "'")
+            fail(ps, i, "unexpected '" .. ps.tokens[i].tk .. "'")
+            return i, list
          end
       elseif sep == "term" and ps.tokens[i].tk == ";" then
          i = i + 1
@@ -1509,6 +1518,9 @@ local function parse_base_type(ps: ParseState, i: number): number, Type, number
          i = i + 1
          decl.keys = t
          i, decl.values = parse_type(ps, i)
+         if not decl.values then
+            return i
+         end
          end_at(decl as Node, ps.tokens[i])
          i = verify_tk(ps, i, "}")
       else
@@ -1600,7 +1612,7 @@ parse_type_list = function(ps: ParseState, i: number, mode: ParseTypeListMode): 
       if nrets > 0 then
          list.is_va = true
       else
-         return fail(ps, i, "unexpected '...'")
+         fail(ps, i, "unexpected '...'")
       end
    end
 
@@ -1917,22 +1929,26 @@ do
       local lhs: Node
       local istart = i
       i, lhs = P(ps, i)
-      i, lhs = E(ps, i, lhs, 0)
+      if lhs then
+         i, lhs = E(ps, i, lhs, 0)
+      end
       if lhs then
          return i, lhs, 0
-      else
-         if i == istart then
-            return fail(ps, i, "expected an expression")
-         else
-            return i -- a more specific error was already thrown
-         end
       end
+      -- if cursor moved, a more specific error was already thrown
+      if i == istart then
+         i = fail(ps, i, "expected an expression")
+      end
+      return i
    end
 end
 
 parse_expression_and_tk = function(ps: ParseState, i: number, tk: string): number, Node
    local e: Node
    i, e = parse_expression(ps, i)
+   if not e then
+      e = new_node(ps.tokens, i - 1, "error_node")
+   end
    if ps.tokens[i].tk == tk then
       i = i + 1
    else
@@ -2003,7 +2019,7 @@ parse_argument_list = function(ps: ParseState, i: number): number, Node
    i, node = parse_bracket_list(ps, i, node, "(", ")", "sep", parse_argument)
    for a, arg in ipairs(node) do
       if arg.tk == "..." and a ~= #node then
-         return fail(ps, i, "'...' can only be last argument")
+         fail(ps, i, "'...' can only be last argument")
       end
    end
    return i, node
@@ -2042,11 +2058,19 @@ parse_argument_type_list = function(ps: ParseState, i: number): number, Type
    return i, list
 end
 
+local function parse_identifier(ps: ParseState, i: number): number, Node
+   if ps.tokens[i].kind == "identifier" then
+      return i + 1, new_node(ps.tokens, i, "identifier")
+   end
+   i = fail(ps, i, "syntax error, expected identifier")
+   return i, new_node(ps.tokens, i, "error_node")
+end
+
 local function parse_local_function(ps: ParseState, i: number): number, Node
    i = verify_tk(ps, i, "local")
    i = verify_tk(ps, i, "function")
    local node = new_node(ps.tokens, i, "local_function")
-   i, node.name = verify_kind(ps, i, "identifier")
+   i, node.name = parse_identifier(ps, i)
    return parse_function_args_rets_body(ps, i, node)
 end
 
@@ -2056,14 +2080,14 @@ local function parse_global_function(ps: ParseState, i: number): number, Node
    local fn = new_node(ps.tokens, i, "global_function")
    local node = fn
    local names: {Node} = {}
-   i, names[1] = verify_kind(ps, i, "identifier")
+   i, names[1] = parse_identifier(ps, i)
    while ps.tokens[i].tk == "." do
       i = i + 1
-      i, names[#names + 1] = verify_kind(ps, i, "identifier")
+      i, names[#names + 1] = parse_identifier(ps, i)
    end
    if ps.tokens[i].tk == ":" then
       i = i + 1
-      i, names[#names + 1] = verify_kind(ps, i, "identifier")
+      i, names[#names + 1] = parse_identifier(ps, i)
       fn.is_method = true
    end
 
@@ -2136,7 +2160,7 @@ local function parse_fornum(ps: ParseState, i: number): number, Node
    local istart = i
    local node = new_node(ps.tokens, i, "fornum")
    i = i + 1
-   i, node.var = verify_kind(ps, i, "identifier")
+   i, node.var = parse_identifier(ps, i)
    i = verify_tk(ps, i, "=")
    i, node.from = parse_expression_and_tk(ps, i, ",")
    i, node.to = parse_expression(ps, i)
@@ -2533,6 +2557,12 @@ do
          i = i + 1
          local val: Node
          i, val = parse_expression(ps, i)
+         if not val then
+            if #asgn.exps == 0 then
+               asgn.exps = nil
+            end
+            return i
+         end
          table.insert(asgn.exps, val)
       until ps.tokens[i].tk ~= ","
       return i, asgn
@@ -2555,6 +2585,7 @@ local function parse_variable_declarations(ps: ParseState, i: number, node_name:
       local next_word = ps.tokens[i + 1].tk
       if next_word == "record" then
          local scope = node_name == "local_declaration" and "local" or "global"
+
          return failskip(ps, i + 1, "syntax error: this syntax is no longer valid; use '" .. scope .. " record " .. asgn.vars[1].tk .. "'", skip_record)
       elseif next_word == "enum" then
          local scope = node_name == "local_declaration" and "local" or "global"
@@ -2570,6 +2601,12 @@ local function parse_variable_declarations(ps: ParseState, i: number, node_name:
          i = i + 1
          local val: Node
          i, val = parse_expression(ps, i)
+         if not val then
+            if #asgn.exps == 0 then
+               asgn.exps = nil
+            end
+            return i
+         end
          table.insert(asgn.exps, val)
          v = v + 1
       until ps.tokens[i].tk ~= ","
@@ -2618,7 +2655,7 @@ local function parse_type_constructor(ps: ParseState, i: number, node_name: Node
 end
 
 local function skip_type_declaration(ps: ParseState, i: number): number
-   return (parse_type_declaration(ps, i, "local_type"))
+   return (parse_type_declaration(ps, i - 1, "local_type"))
 end
 
 local function parse_statement(ps: ParseState, i: number): number, Node
@@ -2694,7 +2731,9 @@ parse_statements = function(ps: ParseState, i: number, filename: string, topleve
       if (not toplevel) and stop_statement_list[ps.tokens[i].tk] then
          break
       end
+      local prev_i = i
       i, item = parse_statement(ps, i)
+      assert(i > prev_i)
       if filename then
          for j = 1, #ps.errs do
             if not ps.errs[j].filename then
@@ -2702,10 +2741,15 @@ parse_statements = function(ps: ParseState, i: number, filename: string, topleve
             end
          end
       end
-      if not item then
-         break
+      if item then
+         table.insert(node, item)
+      elseif i > 1 then
+         -- heuristic to resync at the next line after an invalid statement
+         local lasty = ps.tokens[i - 1].y
+         while ps.tokens[i].kind ~= "$EOF$" and ps.tokens[i].y == lasty do
+            i = i + 1
+         end
       end
-      table.insert(node, item)
    end
    end_at(node, ps.tokens[i])
    return i, node
@@ -3035,6 +3079,7 @@ local function recurse_node<T>(ast: Node,
           or ast.kind == "label"
           or ast.kind == "nil"
           or ast.kind == "..."
+          or ast.kind == "error_node"
           or ast.kind == "boolean" then
       if ast.decltype then
          xs[1] = recurse_type(ast.decltype, visit_type)
@@ -7994,6 +8039,12 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             node.type = node.newtype
             return node.type
          end,
+      },
+      ["error_node"] = {
+         after = function(node: Node, _children: {Type}): Type
+            node.type = INVALID
+            return node.type
+         end,
       }
    }
 
@@ -8363,7 +8414,7 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
    end
 
    local _, program = tl.parse_program(tokens, result.syntax_errors, filename)
-   if #result.syntax_errors > 0 then
+   if (not env.keep_going) and #result.syntax_errors > 0 then
       return result
    end
 
@@ -8396,12 +8447,11 @@ end
 tl.gen = function(input: string, env: Env): string, Result
    env = env or tl.init_env()
    local result, err = tl.process_string(input, false, env)
-
    if err then
       return nil, nil
    end
 
-   if not result.ast then
+   if (not result.ast) or #result.syntax_errors > 0 then
       return nil, result
    end
 

--- a/tl.tl
+++ b/tl.tl
@@ -69,6 +69,28 @@ local record tl
       i: number
    end
 
+   record TypeInfo
+      str: string
+      file: string
+      x: number
+      y: number
+      ref: number
+      fields: {string: number}
+      enums: {string}
+   end
+
+   record TypeReport
+      by_pos: {string: {number: {number: number}}}
+      types: {number: TypeInfo}
+   end
+
+   record TypeReportEnv
+      str_to_num: {string: number}
+      typeid_to_num: {number: number}
+      next_num: number
+      tr: TypeReport
+   end
+
    load: function(string, string, LoadMode, {any:any}): LoadFunction, string
    process: function(string, Env, Result, {string}): (Result, string)
    process_string: function(string, boolean, Env, Result, {string}, string): (Result, string)
@@ -95,6 +117,9 @@ local TypeCheckOptions = tl.TypeCheckOptions
 local LoadMode = tl.LoadMode
 local LoadFunction = tl.LoadFunction
 local TargetMode = tl.TargetMode
+local TypeInfo = tl.TypeInfo
+local TypeReport = tl.TypeReport
+local TypeReportEnv = tl.TypeReportEnv
 
 --------------------------------------------------------------------------------
 -- Lexer
@@ -8143,6 +8168,151 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    return errors, unknowns, module_type
 end
+
+--------------------------------------------------------------------------------
+-- Report types
+--------------------------------------------------------------------------------
+
+function tl.get_types(filename: string, ast: Node, trenv: TypeReportEnv): TypeReport, TypeReportEnv
+   assert(filename)
+
+   if not trenv then
+      trenv = {
+         next_num = 1,
+--         str_to_num = {},
+         typeid_to_num = {},
+         tr = {
+            by_pos = {},
+            types = {},
+         },
+      }
+   end
+
+   local tr = trenv.tr
+--   local str_to_num = trenv.str_to_num
+   local typeid_to_num = trenv.typeid_to_num
+
+   local function get_typenum(t: Type): number
+      assert(t.typeid)
+      -- try by typeid
+      local n = typeid_to_num[t.typeid]
+      if n then
+         return n
+      end
+--      -- try by string representation
+      local s: string
+      if t.typename == "string" then
+         s = "string"
+      else
+         s = show_type(t, true)
+      end
+--      n = str_to_num[s]
+--      if n then
+--         typeid_to_num[t.typeid] = n
+--         return n
+--      end
+
+      -- it's a new entry: store and increment
+      n = trenv.next_num
+      local ti: TypeInfo = {
+         str = s,
+         file = t.filename,
+         y = t.y,
+         x = t.x,
+      }
+      tr.types[n] = ti
+--      str_to_num[s] = n
+      typeid_to_num[t.typeid] = n
+      trenv.next_num = trenv.next_num + 1
+
+      local rt = t
+      if rt.typename == "typetype" then
+         rt = rt.def
+      end
+      if t.found then
+         ti.ref = get_typenum(t.found)
+      end
+      if t.resolved then
+         rt = t
+      end
+      assert(rt.typename ~= "typetype")
+
+      -- store record field info
+      if is_record_type(rt) then
+         local r = {}
+         for k, v in pairs(rt.fields) do
+            r[k] = get_typenum(v)
+         end
+         ti.fields = r
+      end
+
+      -- store enum info
+      if rt.typename == "enum" then
+         local e = {}
+         for k, _ in pairs(rt.enumset) do
+            table.insert(e, k)
+         end
+         table.sort(e)
+         ti.enums = e
+         ti.enums[0] = false as string -- special array marker for json dump
+      end
+
+      return n
+   end
+
+   local visit_node: Visitor<NodeKind, Node, nil> = { allow_missing_cbs = true }
+   local visit_type: Visitor<TypeName, Type, nil> = { allow_missing_cbs = true }
+
+   local skip: {TypeName: boolean} = {
+      ["none"] = true,
+      ["tuple"] = true,
+      ["table_item"] = true,
+      ["enum_item"] = true,
+   }
+
+   local ft: {number:{number:number}} = {}
+   tr.by_pos[filename] = ft
+
+   local function store(y: number, x: number, typ: Type)
+      if skip[typ.typename] then
+         return
+      end
+
+      local yt = ft[y]
+      if not yt then
+         yt = {}
+         ft[y] = yt
+      end
+
+      if yt[x] then
+         return
+      end
+
+      yt[x] = get_typenum(typ)
+   end
+
+   visit_node.after = {
+      ["after"] = function(node: Node): nil
+         store(node.y, node.x, node.type)
+      end
+   }
+
+   visit_type.after = {
+      ["after"] = function(typ: Type): nil
+         store(typ.y or 0, typ.x or 0, typ)
+      end
+   }
+
+   recurse_node(ast, visit_node, visit_type)
+
+   tr.by_pos[filename][0] = nil
+
+   return tr, trenv
+end
+
+--------------------------------------------------------------------------------
+-- High-level API
+--------------------------------------------------------------------------------
 
 tl.process = function(filename: string, env: Env, result: Result, preload_modules: {string}): Result, string
    if env and env.loaded and env.loaded[filename] then

--- a/tl.tl
+++ b/tl.tl
@@ -94,6 +94,7 @@ local record tl
       by_pos: {string: {number: {number: number}}}
       types: {number: TypeInfo}
       symbols: {{number, number, string, number}}
+      globals: {string: number}
    end
 
    record TypeReportEnv
@@ -8276,6 +8277,7 @@ function tl.get_types(result: Result, trenv: TypeReportEnv): TypeReport, TypeRep
             by_pos = {},
             types = {},
             symbols = mark_array {},
+            globals = {},
          },
       }
    end
@@ -8395,6 +8397,14 @@ function tl.get_types(result: Result, trenv: TypeReportEnv): TypeReport, TypeRep
       assert(id)
       local sym = mark_array({s.y, s.x, s.name, id})
       table.insert(tr.symbols, sym)
+   end
+
+   local gkeys = sorted_keys(result.env.globals)
+   for _, name in ipairs(gkeys) do
+      if name:sub(1, 1) ~= "@" then
+         local var = result.env.globals[name]
+         tr.globals[name] = get_typenum(var.t)
+      end
    end
 
    return tr, trenv

--- a/tl.tl
+++ b/tl.tl
@@ -7093,6 +7093,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
                assert(var)
                add_var(var, var.tk, t, var.is_const)
+               var.type = t
 
                dismiss_unresolved(var.tk)
             end
@@ -7136,6 +7137,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   end
                   t.inferred_len = nil
                   add_global(var, var.tk, t, var.is_const)
+                  var.type = t
 
                   dismiss_unresolved(var.tk)
                end

--- a/tl.tl
+++ b/tl.tl
@@ -85,7 +85,6 @@ local record tl
    end
 
    record TypeReportEnv
-      str_to_num: {string: number}
       typeid_to_num: {number: number}
       next_num: number
       tr: TypeReport
@@ -8179,7 +8178,6 @@ function tl.get_types(filename: string, ast: Node, trenv: TypeReportEnv): TypeRe
    if not trenv then
       trenv = {
          next_num = 1,
---         str_to_num = {},
          typeid_to_num = {},
          tr = {
             by_pos = {},
@@ -8189,7 +8187,6 @@ function tl.get_types(filename: string, ast: Node, trenv: TypeReportEnv): TypeRe
    end
 
    local tr = trenv.tr
---   local str_to_num = trenv.str_to_num
    local typeid_to_num = trenv.typeid_to_num
 
    local function get_typenum(t: Type): number
@@ -8199,29 +8196,16 @@ function tl.get_types(filename: string, ast: Node, trenv: TypeReportEnv): TypeRe
       if n then
          return n
       end
---      -- try by string representation
-      local s: string
-      if t.typename == "string" then
-         s = "string"
-      else
-         s = show_type(t, true)
-      end
---      n = str_to_num[s]
---      if n then
---         typeid_to_num[t.typeid] = n
---         return n
---      end
 
       -- it's a new entry: store and increment
       n = trenv.next_num
       local ti: TypeInfo = {
-         str = s,
+         str = show_type(t, true),
          file = t.filename,
          y = t.y,
          x = t.x,
       }
       tr.types[n] = ti
---      str_to_num[s] = n
       typeid_to_num[t.typeid] = n
       trenv.next_num = trenv.next_num + 1
 

--- a/tl.tl
+++ b/tl.tl
@@ -81,13 +81,24 @@ local record tl
    end
 
    record TypeInfo
+      t: number
+
       str: string
       file: string
       x: number
       y: number
+      -- nominals
       ref: number
+      -- records
       fields: {string: number}
+      -- enums
       enums: {string}
+      -- functions
+      args: {{number, string}}
+      rets: {{number, string}}
+      vararg: boolean
+      -- poly
+      types: {TypeInfo}
    end
 
    record TypeReport
@@ -8285,7 +8296,23 @@ function tl.get_types(result: Result, trenv: TypeReportEnv): TypeReport, TypeRep
    local tr = trenv.tr
    local typeid_to_num = trenv.typeid_to_num
 
-   local function get_typenum(t: Type): number
+   local get_typenum: function(t: Type): number
+
+   local function store_function(ti: TypeInfo, rt: Type)
+      local args: {{number, string}} = {}
+      for _, arg in ipairs(rt.args) do
+         table.insert(args, mark_array { get_typenum(arg), nil })
+      end
+      ti.args = mark_array(args)
+      local rets: {{number, string}} = {}
+      for _, arg in ipairs(rt.rets) do
+         table.insert(rets, mark_array { get_typenum(arg), nil })
+      end
+      ti.rets = mark_array(rets)
+      ti.vararg = rt.is_va
+   end
+
+   get_typenum = function(t: Type): number
       assert(t.typeid)
       -- try by typeid
       local n = typeid_to_num[t.typeid]
@@ -8317,19 +8344,29 @@ function tl.get_types(result: Result, trenv: TypeReportEnv): TypeReport, TypeRep
       end
       assert(rt.typename ~= "typetype")
 
-      -- store record field info
       if is_record_type(rt) then
+         -- store record field info
          local r = {}
          for _, k in ipairs(rt.field_order) do
             local v = rt.fields[k]
             r[k] = get_typenum(v)
          end
          ti.fields = r
-      end
-
-      -- store enum info
-      if rt.typename == "enum" then
+      elseif rt.typename == "enum" then
+         -- store enum info
          ti.enums = mark_array(sorted_keys(rt.enumset))
+      elseif rt.typename == "function" then
+         -- store function info
+         store_function(ti, rt)
+      elseif rt.typename == "poly" then
+         -- store poly info
+         local tis = {}
+         for _, pt in ipairs(rt.types) do
+            local pti = {}
+            store_function(pti, pt)
+            table.insert(tis, pti)
+         end
+         ti.types = mark_array(tis)
       end
 
       return n

--- a/tl.tl
+++ b/tl.tl
@@ -1429,16 +1429,24 @@ local function parse_function_type(ps: ParseState, i: number): number, Type
    return i, typ
 end
 
+local simple_type_names: {TypeName} = {
+   "string",
+   "boolean",
+   "nil",
+   "number",
+   "any",
+   "thread"
+}
+
+local simple_types: {string:Type} = {}
+for _, name in ipairs(simple_type_names) do
+   simple_types[name] = a_type { typename = name }
+end
+
 local function parse_base_type(ps: ParseState, i: number): number, Type, number
-   if ps.tokens[i].tk == "string"
-      or ps.tokens[i].tk == "boolean"
-      or ps.tokens[i].tk == "nil"
-      or ps.tokens[i].tk == "number"
-      or ps.tokens[i].tk == "any"
-      or ps.tokens[i].tk == "thread" then
-      local typ = new_type(ps, i, ps.tokens[i].tk as TypeName)
-      typ.tk = nil
-      return i + 1, typ
+   local st = simple_types[ps.tokens[i].tk]
+   if st then
+      return i + 1, st
    elseif ps.tokens[i].tk == "table" then
       local typ = new_type(ps, i, "map")
       typ.keys = a_type { typename = "any" }
@@ -3150,7 +3158,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
          return
       end
 
-      if child.y < out.y then
+      if child.y ~= -1 and child.y < out.y then
          out.y = child.y
       end
 
@@ -3616,7 +3624,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
    visit_type.cbs = {
       ["string"] = {
          after = function(typ: Type, _children: {Output}): Output
-            local out: Output = { y = typ.y, h = 0 }
+            local out: Output = { y = typ.y or -1, h = 0 }
             local r = typ.resolved or typ
             local lua_type = primitive[r.typename]
                              or (r.is_userdata and "userdata")


### PR DESCRIPTION
This is an MVP for dumping type information for consumption by third-party tools.

These were my high-level goals:

* minimal tl API
* not exposing the raw AST
* simple output, designed for quick lookup
* JSON output in the CLI

Right now the main thing is a map mapping filename:y:x positions to types.

One next improvement to add would be mapping variables to their definition locations (right now they map to their types only).

By visual inspection alone, I have already noticed that some of the information returned is a bit wonky and can be improved (some nested AST nodes report the same x, y positions and I just picked the first one; so we probably should tweak the AST a bit to ensure the most relevant information is returned). But I think this is a good start, and should be a good kickstart for getting feedback on what data is missing and what can work better!

(Visualizing the raw data this way has already prompted some other improvements in the compiler, even, see the other commits in this PR!)
