### PR TITLE
Close top level scope at the end of the file

### DIFF
--- a/spec/lexer/eof_spec.lua
+++ b/spec/lexer/eof_spec.lua
@@ -11,6 +11,6 @@ end
 describe("lexer", function()
    it("equals at the end of a line", function()
       local tokens = tl.lex("local type argh =")
-      assert.same({"local", "type", "argh", "="}, map(function(x) return x.tk end, tokens))
+      assert.same({"local", "type", "argh", "=", "$EOF$"}, map(function(x) return x.tk end, tokens))
    end)
 end)

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -101,6 +101,12 @@ local function indent(str)
    return (str:gsub("\n", "\n   "))
 end
 
+local function trim_end(str)
+   assert(type(str) == "string")
+
+   return str:match("(.-)%s*$")
+end
+
 local function batch_assertions(prefix)
    return {
       add = function(self, assert_func, ...)
@@ -223,6 +229,10 @@ function util.write_tmp_dir(finally, dir_structure)
             assert(lfs.mkdir(prefix .. name))
             traverse_dir(content, prefix .. name .. "/")
          else
+            if type(content) == "string" then
+               content = trim_end(content)
+            end
+
             local fd = io.open(prefix .. name, "w")
             fd:write(content)
             fd:close()
@@ -447,6 +457,8 @@ end
 function util.check_syntax_error(code, syntax_errors)
    assert(type(code) == "string")
    assert(type(syntax_errors) == "table")
+
+   code = trim_end(code)
 
    return function()
       local tokens = tl.lex(code)

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -51,6 +51,23 @@ function util.do_in(dir, func, ...)
    return t_unpack(res)
 end
 
+local function unindent(code)
+   assert(type(code) == "string")
+
+   return code:gsub("[ \t]+", " "):gsub("\n[ \t]+", "\n"):gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+local function indent(str)
+   assert(type(str) == "string")
+   return (str:gsub("\n", "\n   "))
+end
+
+local function trim_end(str)
+   assert(type(str) == "string")
+
+   return str:match("(.-)%s*$")
+end
+
 function util.mock_io(finally, filemap)
    assert(type(finally) == "function")
    assert(type(filemap) == "table")
@@ -77,9 +94,9 @@ function util.mock_io(finally, filemap)
          return {
             read = function (_, format)
                if format == "*a" then
-                  return filemap[basename]   -- Return fake file content
+                  return trim_end(filemap[basename]) -- Return fake file content
                else
-                  error("Not implemented!")  -- Implement other modes if needed
+                  error("Not implemented!") -- Implement other modes if needed
                end
             end,
             close = function () end,
@@ -88,23 +105,6 @@ function util.mock_io(finally, filemap)
          return io_open(filename, mode)
       end
    end
-end
-
-local function unindent(code)
-   assert(type(code) == "string")
-
-   return code:gsub("[ \t]+", " "):gsub("\n[ \t]+", "\n"):gsub("^%s+", ""):gsub("%s+$", "")
-end
-
-local function indent(str)
-   assert(type(str) == "string")
-   return (str:gsub("\n", "\n   "))
-end
-
-local function trim_end(str)
-   assert(type(str) == "string")
-
-   return str:match("(.-)%s*$")
 end
 
 local function batch_assertions(prefix)

--- a/tl.lua
+++ b/tl.lua
@@ -843,6 +843,8 @@ do
          end
       end
 
+      table.insert(tokens, { x = x + 1, y = y, i = i, tk = "$EOF$", kind = "$EOF$" })
+
       return tokens, (#errs > 0) and errs
    end
 end
@@ -3014,7 +3016,6 @@ function tl.parse_program(tokens, errs, filename)
       required_modules = {},
    }
    local last = ps.tokens[#ps.tokens] or { y = 1, x = 1, tk = "" }
-   table.insert(ps.tokens, { y = last.y, x = last.x + #last.tk, tk = "$EOF$", kind = "$EOF$" })
    local i, node = parse_statements(ps, 1, filename, true)
    clear_redundant_errors(errs)
    return i, node, ps.required_modules

--- a/tl.tl
+++ b/tl.tl
@@ -843,6 +843,8 @@ do
          end
       end
 
+      table.insert(tokens, { x = x + 1, y = y, i = i, tk = "$EOF$", kind = "$EOF$" })
+
       return tokens, (#errs > 0) and errs
    end
 end
@@ -3014,7 +3016,6 @@ function tl.parse_program(tokens: {Token}, errs: {Error}, filename: string): num
       required_modules = {},
    }
    local last = ps.tokens[#ps.tokens] or { y = 1, x = 1, tk = "" }
-   table.insert(ps.tokens, { y = last.y, x = last.x + #last.tk, tk = "$EOF$", kind = "$EOF$" })
    local i, node = parse_statements(ps, 1, filename, true)
    clear_redundant_errors(errs)
    return i, node, ps.required_modules


### PR DESCRIPTION
This fixes the output of `tl types -p y:x` when `y:x` is located after the last token in the file.

Some of the tests assumed that the errors would point to the last token in the file instead of the EOF, so I trimmed the trailing whitespace in a few places in `spec/util.lua`.

There are now 2 tests that fail because of the lack of trailing whitespace (these errors can be reproduced on master):

1) This line returns `variable 'x' has no type or initial value` instead of `expected an expression`

```lua
local x =
```

2) This line returns `syntax error, expected '='` instead of `expected a type`

```lua
local type argh =
```