### PR TITLE
fixed math.randomseed() types; both input and returned

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -4691,7 +4691,7 @@ local function init_globals(lax)
             ["pow"] = a_type({ typename = "function", args = TUPLE({ NUMBER, NUMBER }), rets = TUPLE({ NUMBER }) }),
             ["rad"] = a_type({ typename = "function", args = TUPLE({ NUMBER }), rets = TUPLE({ NUMBER }) }),
             ["random"] = a_type({ typename = "function", args = TUPLE({ NUMBER, NUMBER }), rets = TUPLE({ NUMBER }) }),
-            ["randomseed"] = a_type({ typename = "function", args = TUPLE({ NUMBER }), rets = TUPLE({}) }),
+            ["randomseed"] = a_type({ typename = "function", args = TUPLE({ NUMBER, NUMBER }), rets = TUPLE({ NUMBER, NUMBER }) }),
             ["sin"] = a_type({ typename = "function", args = TUPLE({ NUMBER }), rets = TUPLE({ NUMBER }) }),
             ["sinh"] = a_type({ typename = "function", args = TUPLE({ NUMBER }), rets = TUPLE({ NUMBER }) }),
             ["sqrt"] = a_type({ typename = "function", args = TUPLE({ NUMBER }), rets = TUPLE({ NUMBER }) }),

--- a/tl.tl
+++ b/tl.tl
@@ -4691,7 +4691,7 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
             ["pow"] = a_type { typename = "function", args = TUPLE { NUMBER, NUMBER }, rets = TUPLE { NUMBER } },
             ["rad"] = a_type { typename = "function", args = TUPLE { NUMBER }, rets = TUPLE { NUMBER } },
             ["random"] = a_type { typename = "function", args = TUPLE { NUMBER, NUMBER }, rets = TUPLE { NUMBER } },
-            ["randomseed"] = a_type { typename = "function", args = TUPLE { NUMBER }, rets = TUPLE {} },
+            ["randomseed"] = a_type { typename = "function", args = TUPLE { NUMBER, NUMBER }, rets = TUPLE {NUMBER, NUMBER} },
             ["sin"] = a_type { typename = "function", args = TUPLE { NUMBER }, rets = TUPLE { NUMBER } },
             ["sinh"] = a_type { typename = "function", args = TUPLE { NUMBER }, rets = TUPLE { NUMBER } },
             ["sqrt"] = a_type { typename = "function", args = TUPLE { NUMBER }, rets = TUPLE { NUMBER } },


### PR DESCRIPTION
math.randomseed accepts two values and returns two values. 
tl.tl was updated to reflect this. (the original version only had 1 input and 0 return values)