### PR TITLE
Track require dependencies in parser (Cherry picks from #362)

### DIFF
--- a/spec/api/parse_program_spec.lua
+++ b/spec/api/parse_program_spec.lua
@@ -1,0 +1,17 @@
+local tl = require("tl")
+
+describe("tl.parse_program", function()
+   it("returns a list of all require arguments", function()
+      local tl_code = [[
+         require("foo")
+         require("foo.bar")
+         local var = "hi"
+         require(var)
+         pcall(require, "baz")
+      ]]
+
+      local tks = assert(tl.lex(tl_code))
+      local _, _, reqs = tl.parse_program(tks)
+      assert.are.same({ "foo", "foo.bar", "baz" }, reqs)
+   end)
+end)

--- a/spec/config/type_check_spec.lua
+++ b/spec/config/type_check_spec.lua
@@ -14,7 +14,7 @@ describe("config type checking", function()
             exit = "exit",
             code = 1,
          },
-         cmd_output = "Error loading config: Expected include to be a {string}\n",
+         cmd_output = "Error loading config: Expected include to be a {string}, got string\n",
       })
    end)
    it("should error out when config.source_dir is not a string", function()
@@ -30,7 +30,7 @@ describe("config type checking", function()
             exit = "exit",
             code = 1,
          },
-         cmd_output = "Error loading config: Expected source_dir to be a string\n",
+         cmd_output = "Error loading config: Expected source_dir to be a string, got boolean\n",
       })
    end)
 end)

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -42,9 +42,9 @@ end
 
 function util.do_in(dir, func, ...)
    local cdir = assert(lfs.currentdir())
-   assert(lfs.chdir(dir))
+   assert(lfs.chdir(dir), "unable to chdir into " .. dir)
    local res = {pcall(func, ...)}
-   assert(lfs.chdir(cdir))
+   assert(lfs.chdir(cdir), "unable to chdir into " .. cdir)
    if not table.remove(res, 1) then
       error(res[1], 2)
    end

--- a/tl
+++ b/tl
@@ -141,16 +141,16 @@ local function validate_config(config)
          local arr_type = valid_keys[k]:match("{(.*)}")
          if arr_type then
             if type(v) ~= "table" then
-               return "Expected " .. k .. " to be a " .. valid_keys[k]
+               return "Expected " .. k .. " to be a " .. valid_keys[k] .. ", got " .. type(v)
             end
             for i, val in ipairs(v) do
                if type(val) ~= arr_type then
-                  return "Expected " .. k .. "[" .. i .. "] to be a " .. valid_keys[k]
+                  return "Expected " .. k .. "[" .. i .. "] to be a " .. valid_keys[k] .. ", got " .. type(val)
                end
             end
          else
             if type(v) ~= valid_keys[k] then
-               return "Expected " .. k .. " to be a " .. valid_keys[k]
+               return "Expected " .. k .. " to be a " .. valid_keys[k] .. ", got " .. type(v)
             end
          end
       end

--- a/tl.lua
+++ b/tl.lua
@@ -125,6 +125,8 @@ local tl = {TypeCheckOptions = {}, Env = {}, Symbol = {}, Result = {}, Error = {
 
 
 
+
+
 tl.warning_kinds = {
    ["unused"] = true,
    ["redeclaration"] = true,
@@ -5011,12 +5013,12 @@ tl.type_check = function(ast, opts)
    local lax = opts.lax
    local filename = opts.filename
 
-   local result = opts.result or {
-      syntax_errors = {},
-      type_errors = {},
-      unknowns = {},
-      warnings = {},
-      dependencies = {},
+   local result = {
+      syntax_errors = opts.result and opts.result.syntax_errors or {},
+      type_errors = opts.result and opts.result.type_errors or {},
+      unknowns = opts.result and opts.result.unknowns or {},
+      warnings = opts.result and opts.result.warnings or {},
+      dependencies = opts.result and opts.result.dependencies or {},
    }
 
    local st = { env.globals }

--- a/tl.lua
+++ b/tl.lua
@@ -124,6 +124,7 @@ local tl = {TypeCheckOptions = {}, Env = {}, Symbol = {}, Result = {}, Error = {
 
 
 
+
 tl.warning_kinds = {
    ["unused"] = true,
    ["redeclaration"] = true,
@@ -1242,6 +1243,8 @@ local ParseState = {}
 
 
 
+
+
 local ParseTypeListMode = {}
 
 
@@ -1385,6 +1388,7 @@ local function parse_table_item(ps, i, n)
          filename = ps.filename,
          tokens = ps.tokens,
          errs = {},
+         require_calls = ps.require_calls,
       }
       i, node.key = verify_kind(try_ps, i, "identifier", "string")
       node.key.conststr = node.key.tk
@@ -2182,7 +2186,6 @@ local function parse_global_function(ps, i)
    local orig_i = i
    i = verify_tk(ps, i, "function")
    local fn = new_node(ps.tokens, i, "global_function")
-   local node = fn
    local names = {}
    i, names[1] = parse_identifier(ps, i)
    while ps.tokens[i].tk == "." do
@@ -2218,7 +2221,7 @@ local function parse_global_function(ps, i)
       return orig_i + 1
    end
 
-   return i, node
+   return i, fn
 end
 
 local function parse_if(ps, i)
@@ -2889,12 +2892,13 @@ function tl.parse_program(tokens, errs, filename)
       tokens = tokens,
       errs = errs,
       filename = filename,
+      require_calls = {},
    }
    local last = ps.tokens[#ps.tokens] or { y = 1, x = 1, tk = "" }
    table.insert(ps.tokens, { y = last.y, x = last.x + #last.tk, tk = "$EOF$", kind = "$EOF$" })
    local i, node = parse_statements(ps, 1, filename, true)
    clear_redundant_errors(errs)
-   return i, node
+   return i, node, ps.require_calls
 end
 
 
@@ -4314,6 +4318,14 @@ local function require_module(module_name, lax, env, result)
    local loaded = env.loaded
 
    if modules[module_name] then
+      if not result.dependencies[module_name] then
+
+         local found, fd = tl.search_module(module_name, true)
+         if found then
+            fd:close()
+         end
+         result.dependencies[module_name] = found
+      end
       return modules[module_name], true
    end
    modules[module_name] = UNKNOWN
@@ -4330,6 +4342,7 @@ local function require_module(module_name, lax, env, result)
 
       loaded[found] = found_result
       modules[module_name] = found_result.type
+      result.dependencies[module_name] = found
 
       return found_result.type, true
    end
@@ -4983,6 +4996,7 @@ tl.type_check = function(ast, opts)
       type_errors = {},
       unknowns = {},
       warnings = {},
+      dependencies = {},
    }
 
    local st = { env.globals }
@@ -4996,6 +5010,7 @@ tl.type_check = function(ast, opts)
    local warnings = result.warnings or {}
    local errors = result.type_errors or {}
    local unknowns = result.unknowns or {}
+
    local module_type
 
    local function find_var(name, raw)
@@ -8740,6 +8755,7 @@ function tl.process_string(input, is_lua, env, result, preload_modules,
       syntax_errors = result and result.syntax_errors or {},
       type_errors = result and result.type_errors or {},
       unknowns = result and result.unknowns or {},
+      dependencies = result and result.dependencies or {},
    }
    preload_modules = preload_modules or {}
    filename = filename or ""

--- a/tl.lua
+++ b/tl.lua
@@ -1800,13 +1800,18 @@ end
 
 local function node_is_require_call(n)
    if n.e1 and n.e2 and
-      n.e1.kind == "variable" and
-      n.e1.tk == "require" and
-      n.e2.kind == "expression_list" and
-      #n.e2 == 1 and
+      n.e1.kind == "variable" and n.e1.tk == "require" and
+      n.e2.kind == "expression_list" and #n.e2 == 1 and
       n.e2[1].kind == "string" then
 
       return n.e2[1].conststr
+   elseif n.op and n.op.op == "@funcall" and
+      n.e1 and n.e1.tk == "pcall" and
+      n.e2 and #n.e2 == 2 and
+      n.e2[1].kind == "variable" and n.e2[1].tk == "require" and
+      n.e2[2].kind == "string" and n.e2[2].conststr then
+
+      return n.e2[2].conststr
    else
       return nil
    end

--- a/tl.tl
+++ b/tl.tl
@@ -57,6 +57,7 @@ local record tl
       warnings: {Error}
       symbol_list: {Symbol}
       env: Env
+      dependencies: {string:string} -- module name, file found
    end
 
    enum WarningKind
@@ -1240,6 +1241,8 @@ local record ParseState
    tokens: {Token}
    errs: {Error}
    filename: string
+
+   require_calls: {Node}
 end
 
 local enum ParseTypeListMode
@@ -1385,6 +1388,7 @@ local function parse_table_item(ps: ParseState, i: number, n: number): number, N
          filename = ps.filename,
          tokens = ps.tokens,
          errs = {},
+         require_calls = ps.require_calls,
       }
       i, node.key = verify_kind(try_ps, i, "identifier", "string")
       node.key.conststr = node.key.tk
@@ -2182,7 +2186,6 @@ local function parse_global_function(ps: ParseState, i: number): number, Node
    local orig_i = i
    i = verify_tk(ps, i, "function")
    local fn = new_node(ps.tokens, i, "global_function")
-   local node = fn
    local names: {Node} = {}
    i, names[1] = parse_identifier(ps, i)
    while ps.tokens[i].tk == "." do
@@ -2218,7 +2221,7 @@ local function parse_global_function(ps: ParseState, i: number): number, Node
       return orig_i + 1
    end
 
-   return i, node
+   return i, fn
 end
 
 local function parse_if(ps: ParseState, i: number): number, Node
@@ -2883,18 +2886,19 @@ local function clear_redundant_errors(errors: {Error})
    end
 end
 
-function tl.parse_program(tokens: {Token}, errs: {Error}, filename: string): number, Node
+function tl.parse_program(tokens: {Token}, errs: {Error}, filename: string): number, Node, {Node}
    errs = errs or {}
    local ps: ParseState = {
       tokens = tokens,
       errs = errs,
       filename = filename,
+      require_calls = {},
    }
    local last = ps.tokens[#ps.tokens] or { y = 1, x = 1, tk = "" }
    table.insert(ps.tokens, { y = last.y, x = last.x + #last.tk, tk = "$EOF$", kind = "$EOF$" })
    local i, node = parse_statements(ps, 1, filename, true)
    clear_redundant_errors(errs)
-   return i, node
+   return i, node, ps.require_calls
 end
 
 --------------------------------------------------------------------------------
@@ -4314,6 +4318,14 @@ local function require_module(module_name: string, lax: boolean, env: Env, resul
    local loaded = env.loaded
 
    if modules[module_name] then
+      if not result.dependencies[module_name] then
+         -- TODO: should we store a map of module names to file names in Env to get rid of this redundant search?
+         local found, fd = tl.search_module(module_name, true)
+         if found then
+            fd:close()
+         end
+         result.dependencies[module_name] = found
+      end
       return modules[module_name], true
    end
    modules[module_name] = UNKNOWN
@@ -4330,6 +4342,7 @@ local function require_module(module_name: string, lax: boolean, env: Env, resul
 
       loaded[found] = found_result
       modules[module_name] = found_result.type
+      result.dependencies[module_name] = found
 
       return found_result.type, true
    end
@@ -4983,6 +4996,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       type_errors = {},
       unknowns = {},
       warnings = {},
+      dependencies = {},
    }
 
    local st: {{string:Variable}} = { env.globals }
@@ -4996,6 +5010,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    local warnings: {Error} = result.warnings or {}
    local errors: {Error} = result.type_errors or {}
    local unknowns: {Error} = result.unknowns or {}
+   -- local dependencies: {string:string} = result.dependencies or {}
    local module_type: Type
 
    local function find_var(name: string, raw: boolean): Variable
@@ -8740,6 +8755,7 @@ function tl.process_string(input: string, is_lua: boolean, env: Env, result: Res
       syntax_errors = result and result.syntax_errors or {},
       type_errors = result and result.type_errors or {},
       unknowns = result and result.unknowns or {},
+      dependencies = result and result.dependencies or {}
    }
    preload_modules = preload_modules or {}
    filename = filename or ""

--- a/tl.tl
+++ b/tl.tl
@@ -115,6 +115,8 @@ local record tl
       tr: TypeReport
    end
 
+
+
    load: function(string, string, LoadMode, {any:any}): LoadFunction, string
    process: function(string, Env, Result, {string}): (Result, string)
    process_string: function(string, boolean, Env, Result, {string}, string): (Result, string)
@@ -5011,12 +5013,12 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    local lax = opts.lax
    local filename = opts.filename
 
-   local result = opts.result or {
-      syntax_errors = {},
-      type_errors = {},
-      unknowns = {},
-      warnings = {},
-      dependencies = {},
+   local result = {
+      syntax_errors = opts.result and opts.result.syntax_errors or {},
+      type_errors = opts.result and opts.result.type_errors or {},
+      unknowns = opts.result and opts.result.unknowns or {},
+      warnings = opts.result and opts.result.warnings or {},
+      dependencies = opts.result and opts.result.dependencies or {},
    }
 
    local st: {{string:Variable}} = { env.globals }

--- a/tl.tl
+++ b/tl.tl
@@ -1799,14 +1799,19 @@ local function parse_literal(ps: ParseState, i: number): number, Node
 end
 
 local function node_is_require_call(n: Node): string
-   if n.e1 and n.e2
-      and n.e1.kind == "variable"
-      and n.e1.tk == "require"
-      and n.e2.kind == "expression_list"
-      and #n.e2 == 1
+   if n.e1 and n.e2 -- literal require call
+      and n.e1.kind == "variable" and n.e1.tk == "require"
+      and n.e2.kind == "expression_list" and #n.e2 == 1
       and n.e2[1].kind == "string"
    then
       return n.e2[1].conststr
+   elseif n.op and n.op.op == "@funcall" -- pcall(require, "str")
+      and n.e1 and n.e1.tk == "pcall"
+      and n.e2 and #n.e2 == 2
+      and n.e2[1].kind == "variable" and n.e2[1].tk == "require"
+      and n.e2[2].kind == "string" and n.e2[2].conststr
+   then
+      return n.e2[2].conststr
    else
       return nil -- table.insert cares about arity
    end

--- a/tl.tl
+++ b/tl.tl
@@ -1242,7 +1242,7 @@ local record ParseState
    errs: {Error}
    filename: string
 
-   require_calls: {Node}
+   required_modules: {string}
 end
 
 local enum ParseTypeListMode
@@ -1328,6 +1328,7 @@ local function failskip(ps: ParseState, i: number, msg: string, skip_fn: SkipFun
    local err_ps: ParseState = {
       tokens = ps.tokens,
       errs = {},
+      required_modules = {},
    }
    local skip_i = skip_fn(err_ps, starti or i)
    fail(ps, starti or i, msg)
@@ -1388,7 +1389,7 @@ local function parse_table_item(ps: ParseState, i: number, n: number): number, N
          filename = ps.filename,
          tokens = ps.tokens,
          errs = {},
-         require_calls = ps.require_calls,
+         required_modules = ps.required_modules,
       }
       i, node.key = verify_kind(try_ps, i, "identifier", "string")
       node.key.conststr = node.key.tk
@@ -1488,6 +1489,7 @@ local function parse_trying_list<T>(ps: ParseState, i: number, list: {T}, parse_
       filename = ps.filename,
       tokens = ps.tokens,
       errs = {},
+      required_modules = ps.required_modules,
    }
    local tryi, item = parse_item(try_ps, i)
    if not item then
@@ -1794,6 +1796,20 @@ local function parse_literal(ps: ParseState, i: number): number, Node
    return fail(ps, i, "syntax error")
 end
 
+local function node_is_require_call(n: Node): string
+   if n.e1 and n.e2
+      and n.e1.kind == "variable"
+      and n.e1.tk == "require"
+      and n.e2.kind == "expression_list"
+      and #n.e2 == 1
+      and n.e2[1].kind == "string"
+   then
+      return n.e2[1].conststr
+   else
+      return nil -- table.insert cares about arity
+   end
+end
+
 local an_operator: function(Node, number, string): Operator
 
 do
@@ -1929,9 +1945,11 @@ do
             end
 
             table.insert(args, argument)
-            e1 = { y = tkop.y, x = tkop.x, kind = "op", op = op, e1 = e1, e2 = args }
-         elseif tkop.tk == "(" then
-            local op: Operator = new_operator(tkop, 2, "@funcall")
+            e1 = { y = args.y, x = args.x, kind = "op", op = op, e1 = e1, e2 = args }
+
+            table.insert(ps.required_modules, node_is_require_call(e1))
+         elseif ps.tokens[i].tk == "(" then
+            local op: Operator = new_operator(ps.tokens[i], 2, "@funcall")
 
             local prev_i = i
 
@@ -1944,8 +1962,10 @@ do
             end
 
             e1 = { y = args.y, x = args.x, kind = "op", op = op, e1 = e1, e2 = args }
-         elseif tkop.tk == "[" then
-            local op: Operator = new_operator(tkop, 2, "@index")
+
+            table.insert(ps.required_modules, node_is_require_call(e1))
+         elseif ps.tokens[i].tk == "[" then
+            local op: Operator = new_operator(ps.tokens[i], 2, "@index")
 
             local prev_i = i
 
@@ -2886,19 +2906,19 @@ local function clear_redundant_errors(errors: {Error})
    end
 end
 
-function tl.parse_program(tokens: {Token}, errs: {Error}, filename: string): number, Node, {Node}
+function tl.parse_program(tokens: {Token}, errs: {Error}, filename: string): number, Node, {string}
    errs = errs or {}
    local ps: ParseState = {
       tokens = tokens,
       errs = errs,
       filename = filename,
-      require_calls = {},
+      required_modules = {},
    }
    local last = ps.tokens[#ps.tokens] or { y = 1, x = 1, tk = "" }
    table.insert(ps.tokens, { y = last.y, x = last.x + #last.tk, tk = "$EOF$", kind = "$EOF$" })
    local i, node = parse_statements(ps, 1, filename, true)
    clear_redundant_errors(errs)
-   return i, node, ps.require_calls
+   return i, node, ps.required_modules
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This PR contains the parser changes that track `require` calls as it parses, plus other minar changes outside of `tl` and `spec/cli`from #362.

@euclidianAce I have the commit that exposes `require_module` ready as well, but I chose not to add it because I wanted to discuss that a bit further: is it really necessary? From what I could follow in #362 it seems it was exposed in order to do "preload modules" outside of `tl.process`. I'm thinking it might make more sense to move the "preload modules" functionality into `tl.init_env` instead, what do you think?