### PR TITLE
Changes in the resolution of nominals

### DIFF
--- a/spec/declaration/global_spec.lua
+++ b/spec/declaration/global_spec.lua
@@ -199,4 +199,53 @@ describe("global", function()
       end)
    end)
 
+   describe("with types", function()
+      it("nominal types can take type arguments", util.check [[
+         global record Foo<R>
+            item: R
+         end
+
+         global type Foo2 = Foo
+         global type Bla = Foo<number>
+
+         global x: Bla = { item = 123 }
+         global y: Foo2<number> = { item = 123 }
+      ]])
+
+      it("nested types can be resolved as aliases", util.check [[
+         global record Foo<R>
+            enum LocalEnum
+               "loc"
+            end
+
+            record Nested
+               x: {LocalEnum}
+               y: R
+            end
+
+            item: R
+         end
+
+         global type Nested = Foo.Nested
+      ]])
+
+      it("types declared as nominal types are aliases", util.check [[
+         global record Foo<R>
+            item: R
+         end
+
+         global type Foo2 = Foo
+         global type FooNumber = Foo<number>
+
+         global x: FooNumber = { item = 123 }
+         global y: Foo2<number> = { item = 123 }
+
+         global type Foo3 = Foo
+         global type Foo4 = Foo2
+
+         global zep: Foo2<string> = { item = "hello" }
+         global zip: Foo3<string> = zep
+         global zup: Foo4<string> = zip
+      ]])
+   end)
 end)

--- a/spec/declaration/local_spec.lua
+++ b/spec/declaration/local_spec.lua
@@ -123,6 +123,54 @@ describe("local", function()
          }, result.type_errors)
       end)
 
+      it("nominal types can take type arguments", util.check [[
+         local record Foo<R>
+            item: R
+         end
+
+         local type Foo2 = Foo
+         local type Bla = Foo<number>
+
+         local x: Bla = { item = 123 }
+         local y: Foo2<number> = { item = 123 }
+      ]])
+
+      it("types declared as nominal types are aliases", util.check [[
+         local record Foo<R>
+            item: R
+         end
+
+         local type Foo2 = Foo
+         local type FooNumber = Foo<number>
+
+         local x: FooNumber = { item = 123 }
+         local y: Foo2<number> = { item = 123 }
+
+         local type Foo3 = Foo
+         local type Foo4 = Foo2
+
+         local zep: Foo2<string> = { item = "hello" }
+         local zip: Foo3<string> = zep
+         local zup: Foo4<string> = zip
+      ]])
+
+      it("nested types can be resolved as aliases", util.check [[
+         local record Foo<R>
+            enum LocalEnum
+               "loc"
+            end
+
+            record Nested
+               x: {LocalEnum}
+               y: R
+            end
+
+            item: R
+         end
+
+         local type Nested = Foo.Nested
+      ]])
+
       it("'type', 'record' and 'enum' are not reserved keywords", util.check [[
          local type = type
          local record: string = "hello"

--- a/tl.lua
+++ b/tl.lua
@@ -1227,6 +1227,7 @@ local Node = {}
 
 
 
+
 local function is_array_type(t)
    return t.typename == "array" or t.typename == "arrayrecord"
 end
@@ -3803,7 +3804,9 @@ function tl.pretty_print_ast(ast, mode)
       ["newtype"] = {
          after = function(node, _children)
             local out = { y = node.y, h = 0 }
-            if is_record_type(node.newtype.def) then
+            if node.is_alias then
+               table.insert(out, table.concat(node.newtype.def.names, "."))
+            elseif is_record_type(node.newtype.def) then
                table.insert(out, print_record_def(node.newtype.def))
             else
                table.insert(out, "{}")
@@ -5734,6 +5737,7 @@ tl.type_check = function(ast, opts)
          if not typetype then
             type_error(t, "unknown type %s", t)
          elseif is_typetype(typetype) then
+            assert(typetype.def.typename ~= "nominal")
             resolved = match_typevals(t, typetype.def)
          else
             type_error(t, table.concat(t.names, ".") .. " is not a type")
@@ -6681,8 +6685,9 @@ tl.type_check = function(ast, opts)
    resolve_tuple_and_nominal = function(t)
       t = resolve_tuple(t)
       if t.typename == "nominal" then
-         return resolve_nominal(t)
+         t = resolve_nominal(t)
       end
+      assert(t.typename ~= "nominal")
       return t
    end
 
@@ -7313,6 +7318,24 @@ tl.type_check = function(ast, opts)
       node.exps[i].tk == node.vars[i].tk
    end
 
+   local function resolve_nominal_typetype(typetype)
+      if typetype.def.typename == "nominal" then
+         if typetype.def.typevals then
+            typetype.def = resolve_nominal(typetype.def)
+            typetype.def.typeargs = nil
+         else
+            local names = typetype.def.names
+            local found = find_type(names)
+            if not is_typetype(found) then
+               type_error(typetype, "%s is not a type", typetype)
+               found = a_type({ typename = "bad_nominal", names = names })
+            end
+            return found, true
+         end
+      end
+      return typetype, false
+   end
+
    local visit_node = {}
 
    visit_node.cbs = {
@@ -7336,16 +7359,19 @@ tl.type_check = function(ast, opts)
       },
       ["local_type"] = {
          before = function(node)
-            add_var(node.var, node.var.tk, node.value.newtype, node.var.is_const)
+            node.value.type, node.value.is_alias = resolve_nominal_typetype(node.value.newtype)
+            add_var(node.var, node.var.tk, node.value.type, node.var.is_const)
          end,
          after = function(node, _children)
             dismiss_unresolved(node.var.tk)
             node.type = NONE
+            node.var.type = node.value.type
             return node.type
          end,
       },
       ["global_type"] = {
          before = function(node)
+            node.value.newtype, node.value.is_alias = resolve_nominal_typetype(node.value.newtype)
             add_global(node.var, node.var.tk, node.value.newtype, node.var.is_const)
          end,
          after = function(node, _children)
@@ -7364,6 +7390,7 @@ tl.type_check = function(ast, opts)
             end
             dismiss_unresolved(var.tk)
             node.type = NONE
+            node.var.type = node.value.newtype
             return node.type
          end,
       },
@@ -8292,7 +8319,7 @@ tl.type_check = function(ast, opts)
       },
       ["newtype"] = {
          after = function(node, _children)
-            node.type = node.newtype
+            node.type = node.type or node.newtype
             return node.type
          end,
       },
@@ -8401,6 +8428,10 @@ tl.type_check = function(ast, opts)
          },
          ["nominal"] = {
             after = function(typ, _children)
+               if typ.found then
+                  return typ
+               end
+
                local t = find_type(typ.names, true)
                if t then
                   if t.typename == "typearg" then

--- a/tl.tl
+++ b/tl.tl
@@ -185,18 +185,18 @@ tl.typecodes = {
    IS_VALID               = 0x00000fff,
 }
 
-local Result = tl.Result
-local Env = tl.Env
-local Error = tl.Error
-local CompatMode = tl.CompatMode
-local TypeCheckOptions = tl.TypeCheckOptions
-local LoadMode = tl.LoadMode
-local LoadFunction = tl.LoadFunction
-local TargetMode = tl.TargetMode
-local TypeInfo = tl.TypeInfo
-local TypeReport = tl.TypeReport
-local TypeReportEnv = tl.TypeReportEnv
-local Symbol = tl.Symbol
+local type Result = tl.Result
+local type Env = tl.Env
+local type Error = tl.Error
+local type CompatMode = tl.CompatMode
+local type TypeCheckOptions = tl.TypeCheckOptions
+local type LoadMode = tl.LoadMode
+local type LoadFunction = tl.LoadFunction
+local type TargetMode = tl.TargetMode
+local type TypeInfo = tl.TypeInfo
+local type TypeReport = tl.TypeReport
+local type TypeReportEnv = tl.TypeReportEnv
+local type Symbol = tl.Symbol
 
 --------------------------------------------------------------------------------
 -- Lexer

--- a/tl.tl
+++ b/tl.tl
@@ -1207,6 +1207,7 @@ local record Node
 
    -- newtype
    newtype: Type
+   is_alias: boolean
 
    -- expressions
    op: Operator
@@ -3803,7 +3804,9 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
       ["newtype"] = {
          after = function(node: Node, _children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
-            if is_record_type(node.newtype.def) then
+            if node.is_alias then
+               table.insert(out, table.concat(node.newtype.def.names, "."))
+            elseif is_record_type(node.newtype.def) then
                table.insert(out, print_record_def(node.newtype.def))
             else
                table.insert(out, "{}")
@@ -5734,6 +5737,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          if not typetype then
             type_error(t, "unknown type %s", t)
          elseif is_typetype(typetype) then
+            assert(typetype.def.typename ~= "nominal")
             resolved = match_typevals(t, typetype.def)
          else
             type_error(t, table.concat(t.names, ".") .. " is not a type")
@@ -6681,8 +6685,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    resolve_tuple_and_nominal = function(t: Type): Type
       t = resolve_tuple(t)
       if t.typename == "nominal" then
-         return resolve_nominal(t)
+         t = resolve_nominal(t)
       end
+      assert(t.typename ~= "nominal")
       return t
    end
 
@@ -7313,6 +7318,24 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          and node.exps[i].tk == node.vars[i].tk
    end
 
+   local function resolve_nominal_typetype(typetype: Type): Type, boolean
+      if typetype.def.typename == "nominal" then
+         if typetype.def.typevals then
+            typetype.def = resolve_nominal(typetype.def)
+            typetype.def.typeargs = nil
+         else
+            local names = typetype.def.names
+            local found = find_type(names)
+            if not is_typetype(found) then
+               type_error(typetype, "%s is not a type", typetype)
+               found = a_type { typename = "bad_nominal", names = names }
+            end
+            return found, true
+         end
+      end
+      return typetype, false
+   end
+
    local visit_node: Visitor<NodeKind, Node, Type> = {}
 
    visit_node.cbs = {
@@ -7336,16 +7359,19 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       },
       ["local_type"] = {
          before = function(node: Node)
-            add_var(node.var, node.var.tk, node.value.newtype, node.var.is_const)
+            node.value.type, node.value.is_alias = resolve_nominal_typetype(node.value.newtype)
+            add_var(node.var, node.var.tk, node.value.type, node.var.is_const)
          end,
          after = function(node: Node, _children: {Type}): Type
             dismiss_unresolved(node.var.tk)
             node.type = NONE
+            node.var.type = node.value.type
             return node.type
          end,
       },
       ["global_type"] = {
          before = function(node: Node)
+            node.value.newtype, node.value.is_alias = resolve_nominal_typetype(node.value.newtype)
             add_global(node.var, node.var.tk, node.value.newtype, node.var.is_const)
          end,
          after = function(node: Node, _children: {Type}): Type
@@ -7364,6 +7390,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
             dismiss_unresolved(var.tk)
             node.type = NONE
+            node.var.type = node.value.newtype
             return node.type
          end,
       },
@@ -8292,7 +8319,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       },
       ["newtype"] = {
          after = function(node: Node, _children: {Type}): Type
-            node.type = node.newtype
+            node.type = node.type or node.newtype
             return node.type
          end,
       },
@@ -8401,6 +8428,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          },
          ["nominal"] = {
             after = function(typ: Type, _children: {Type}): Type
+               if typ.found then
+                  return typ
+               end
+
                local t = find_type(typ.names, true)
                if t then
                   if t.typename == "typearg" then


### PR DESCRIPTION
* Avoid producing nominal types that map to other nominal types; `resolve_tuple_and_nominal` (formerly `resolve_unary`) always results in a non-nominal.
* Nominals without type arguments declared with `local type` or `global type` now work as aliases. That means that if you do `local type Foo2 = Foo` then `Foo2` is the same type as `Foo`.
* For now at least, type constructors with arguments resolve to new distinct types. That means that if you do `local type FooNumber = Foo<number>` then `FooNumber` is a new distinct type from `Foo<number>` and not an alias.

Fixes #269.