### PR TITLE
Bidirectional inference of table literals

### DIFF
--- a/spec/arguments/array_spec.lua
+++ b/spec/arguments/array_spec.lua
@@ -11,7 +11,7 @@ describe("array argument", function()
          a(100)
       end
    ]], {
-      { y = 6, msg = 'argument 1: got {string | number} (from {string, number}), expected {string}' },
+      { y = 6, msg = 'expected an array: at index 2: got number, expected string' },
       { y = 7, msg = 'argument 1: got number, expected {string}' },
    }))
 
@@ -26,7 +26,9 @@ describe("array argument", function()
          {id = "yo"},
       })
    ]], {
-      { y = 5, "got {number | string}, expected {string}"}
+      { y = 5, "got {number | string}, expected {string}"},
+      { y = 7, "in array: at index 2: got {number | string}, expected {string}"},
+      { y = 8, "in array: at index 3: got {number | string}, expected {string}"},
    }))
 
 end)

--- a/spec/assignment/to_array_spec.lua
+++ b/spec/assignment/to_array_spec.lua
@@ -54,4 +54,14 @@ describe("assignment to array", function()
       { y = 7, msg = "syntax error, expected one of: '}', ','" },
       { y = 10, msg = "syntax error" },
    }))
+
+   it("a tuple resolves to an array without nominals producing duplicates (#337)", util.check_warnings([[
+      local type Alias = string
+      local t = {"a", "a"} as {Alias, Alias}
+      local a, b = table.unpack(t)
+   ]], {
+      { msg = "unused variable a: Alias" },
+      { msg = "unused variable b: Alias" },
+   }))
+
 end)

--- a/spec/assignment/to_array_spec.lua
+++ b/spec/assignment/to_array_spec.lua
@@ -8,7 +8,7 @@ describe("assignment to array", function()
       a = {"a", 100}
    ]], {
       { y = 2, msg = "got number, expected {string}" },
-      { y = 3, msg = "got {string | number} (from {string, number}), expected {string}" },
+      { y = 3, msg = "expected an array: at index 2: got number, expected string" },
    }))
 
    it("resolves arity of function returns", util.check [[
@@ -25,7 +25,7 @@ describe("assignment to array", function()
       local a: {string}
       a = { f() }
    ]], {
-      { y = 5, msg = "in assignment: got {string | number} (from {string, number}), expected {string}" },
+      { y = 5, msg = "expected an array: at index 2: got number, expected string" },
    }))
 
    it("accept expression", util.check [[

--- a/spec/assignment/to_tuple_spec.lua
+++ b/spec/assignment/to_tuple_spec.lua
@@ -10,7 +10,7 @@ describe("assignment to tuple", function()
       local t: {number, number}
       t = {1, 2, 3}
    ]], {
-      { msg = "incompatible length, expected maximum length of 2, got 3", y = 2 },
+      { y = 2, msg = "unexpected index 3 in tuple {number, number}" },
    }))
    it("should allow an array literal when its length fits the tuple type", util.check([[
       local t: {number, number, string}

--- a/spec/call/generic_function_spec.lua
+++ b/spec/call/generic_function_spec.lua
@@ -392,8 +392,8 @@ describe("generic function", function()
       assert.same("string",  ast[2].exps[1].type[1].typename)
       assert.same("boolean", ast[2].exps[1].type[2].typename)
       -- unresolved
-      assert.same("unknown", ast[3].exps[1].type[1].typename)
-      assert.same("unknown", ast[3].exps[1].type[2].typename)
+      assert.same("invalid", ast[3].exps[1].type[1].typename)
+      assert.same("invalid", ast[3].exps[1].type[2].typename)
    end)
 
    it("does not produce a recursive type", util.lax_check([[

--- a/spec/declaration/global_spec.lua
+++ b/spec/declaration/global_spec.lua
@@ -199,4 +199,53 @@ describe("global", function()
       end)
    end)
 
+   describe("with types", function()
+      it("nominal types can take type arguments", util.check [[
+         global record Foo<R>
+            item: R
+         end
+
+         global type Foo2 = Foo
+         global type Bla = Foo<number>
+
+         global x: Bla = { item = 123 }
+         global y: Foo2<number> = { item = 123 }
+      ]])
+
+      it("nested types can be resolved as aliases", util.check [[
+         global record Foo<R>
+            enum LocalEnum
+               "loc"
+            end
+
+            record Nested
+               x: {LocalEnum}
+               y: R
+            end
+
+            item: R
+         end
+
+         global type Nested = Foo.Nested
+      ]])
+
+      it("types declared as nominal types are aliases", util.check [[
+         global record Foo<R>
+            item: R
+         end
+
+         global type Foo2 = Foo
+         global type FooNumber = Foo<number>
+
+         global x: FooNumber = { item = 123 }
+         global y: Foo2<number> = { item = 123 }
+
+         global type Foo3 = Foo
+         global type Foo4 = Foo2
+
+         global zep: Foo2<string> = { item = "hello" }
+         global zip: Foo3<string> = zep
+         global zup: Foo4<string> = zip
+      ]])
+   end)
 end)

--- a/spec/declaration/local_spec.lua
+++ b/spec/declaration/local_spec.lua
@@ -118,7 +118,7 @@ describe("local", function()
 
          assert.same({}, result.syntax_errors)
          assert.same({
-            { y = 3, x = 42, filename = "main.tl", msg = "in local declaration: var: unknown field dato" },
+            { y = 3, x = 35, filename = "main.tl", msg = "in local declaration: var: unknown field dato" },
             { y = 4, x = 26, filename = "main.tl", msg = "invalid key 'dato' in record 'var' of type Boo" },
          }, result.type_errors)
       end)

--- a/spec/declaration/local_spec.lua
+++ b/spec/declaration/local_spec.lua
@@ -123,6 +123,54 @@ describe("local", function()
          }, result.type_errors)
       end)
 
+      it("nominal types can take type arguments", util.check [[
+         local record Foo<R>
+            item: R
+         end
+
+         local type Foo2 = Foo
+         local type Bla = Foo<number>
+
+         local x: Bla = { item = 123 }
+         local y: Foo2<number> = { item = 123 }
+      ]])
+
+      it("types declared as nominal types are aliases", util.check [[
+         local record Foo<R>
+            item: R
+         end
+
+         local type Foo2 = Foo
+         local type FooNumber = Foo<number>
+
+         local x: FooNumber = { item = 123 }
+         local y: Foo2<number> = { item = 123 }
+
+         local type Foo3 = Foo
+         local type Foo4 = Foo2
+
+         local zep: Foo2<string> = { item = "hello" }
+         local zip: Foo3<string> = zep
+         local zup: Foo4<string> = zip
+      ]])
+
+      it("nested types can be resolved as aliases", util.check [[
+         local record Foo<R>
+            enum LocalEnum
+               "loc"
+            end
+
+            record Nested
+               x: {LocalEnum}
+               y: R
+            end
+
+            item: R
+         end
+
+         local type Nested = Foo.Nested
+      ]])
+
       it("'type', 'record' and 'enum' are not reserved keywords", util.check [[
          local type = type
          local record: string = "hello"

--- a/spec/declaration/tuple_spec.lua
+++ b/spec/declaration/tuple_spec.lua
@@ -13,7 +13,7 @@ describe("tuple declarations", function()
    it("should report when an array literal is too long to fit within tuple type", util.check_type_error([[
       local a: {number, number} = {1, 2, 3}
    ]], {
-      { y = 1, msg = "in local declaration: a: incompatible length, expected maximum length of 2, got 3" }
+      { y = 1, msg = "in local declaration: a: unexpected index 3 in tuple {number, number}" }
    }))
 
    it("should report when an array is of incorrect type of a tuple entry", util.check_type_error([[
@@ -21,9 +21,9 @@ describe("tuple declarations", function()
       local b: {number, string} = { "hi" } -- infers to {string} with a length of 1, which is incompatible with {number, string}
       local c: {string, number} = { [-1] = "hi" } -- infers to {string} with a length of 0, which should maybe be compatible with {string, number}?
    ]], {
-      { y = 1, msg = "in local declaration: a: tuple entry 1 of type number does not match type of array elements, which is string" },
-      { y = 2, msg = "in local declaration: b: tuple entry 1 of type number does not match type of array elements, which is string" },
-      { y = 3, msg = "in local declaration: c: tuple entry 2 of type number does not match type of array elements, which is string" },
+      { y = 1, msg = "in local declaration: a: unknown index in tuple {number, string}" },
+      { y = 2, msg = "in local declaration: b: in tuple: at index 1: got string \"hi\", expected number" },
+      { y = 3, msg = "in local declaration: c: unknown index in tuple {string, number}" },
    }))
 
    it("should allow array literals that fit within then tuple length", util.check [[
@@ -35,13 +35,13 @@ describe("tuple declarations", function()
    it("should report when a tuple has incompatible entries", util.check_type_error([[
       local b: {number, string} = { 1, false }
    ]], {
-      { y = 1, msg = "in local declaration: b: in tuple entry 2: got boolean, expected string" },
+      { y = 1, msg = "in local declaration: b: in tuple: at index 2: got boolean, expected string" },
    }))
 
    it("should report when a tuple literal is longer than annotated type", util.check_type_error([[
      local c: {number, string} = { 1, "hello", 10 }
    ]], {
-      { y = 1, msg = "in local declaration: c: tuple {number, string, number} is too big for tuple {number, string}" },
+      { y = 1, msg = "in local declaration: c: unexpected index 3 in tuple {number, string}" },
    }))
 
    it("should work with explicit integer indices", util.check [[

--- a/spec/inference/table_literal_spec.lua
+++ b/spec/inference/table_literal_spec.lua
@@ -1,0 +1,20 @@
+local util = require("spec.util")
+
+describe("bidirectional inference for table literals", function()
+   it("declaration directs inference of table (regression test for #375)", util.check_type_error([[
+      local record Container
+         enum TypeEnum
+            "number"
+         end
+         type: TypeEnum
+      end
+
+      local x: {Container} = {
+         { type = 'number' },
+         { type = 'who'    },
+      }
+      print(x)
+   ]], {
+      { msg = "in record field: type: string 'who' is not a member of enum" },
+   }))
+end)

--- a/spec/inference/table_literal_spec.lua
+++ b/spec/inference/table_literal_spec.lua
@@ -17,4 +17,21 @@ describe("bidirectional inference for table literals", function()
    ]], {
       { msg = "in record field: type: string 'who' is not a member of enum" },
    }))
+
+   it("directed inference produces correct results for incomplete records (regression test for #348)", util.check [[
+      local record test_t
+         a: number
+         b: number
+      end
+
+      local _: {test_t} = {
+         {
+            a=1,
+         },
+         {
+            a=1,
+            b=2
+         }
+      }
+   ]])
 end)

--- a/spec/statement/forin_spec.lua
+++ b/spec/statement/forin_spec.lua
@@ -47,8 +47,6 @@ describe("forin", function()
       ]], {
          { msg = "attempting ipairs loop" },
          { msg = "attempting ipairs loop" },
-         { msg = "argument 1: got <unknown type>" },
-         { msg = "cannot use operator '..'" },
       }))
    end)
 

--- a/spec/stdlib/ipairs_spec.lua
+++ b/spec/stdlib/ipairs_spec.lua
@@ -1,8 +1,16 @@
 local util = require("spec.util")
 
 describe("ipairs", function()
-   it("should report when a tuple can't be converted to an array", util.check_type_error([[
+   it("should report when a tuple can't be converted to an array (literal)", util.check_type_error([[
       for i, v in ipairs({{1}, {"a"}}) do
+      end
+   ]], {
+      { msg = [[expected an array: at index 2: got {string "a"}, expected {number}]] },
+   }))
+
+   it("should report when a tuple can't be converted to an array (variable)", util.check_type_error([[
+      local my_tuple = {{1}, {"a"}}
+      for i, v in ipairs(my_tuple) do
       end
    ]], {
       { msg = [[attempting ipairs loop on tuple that's not a valid array: ({{number}, {string "a"}})]] },

--- a/spec/stdlib/require_spec.lua
+++ b/spec/stdlib/require_spec.lua
@@ -31,7 +31,6 @@ describe("require", function()
       assert.same(0, #result.syntax_errors)
       assert.same({
          { filename = "foo.tl", y = 1, x = 33, msg = "no type information for required module: 'box'" },
-         { filename = "foo.tl", y = 3, x = 17, msg = "cannot index a value of unknown type" },
       }, result.type_errors)
       assert.same(0, #result.unknowns)
    end)

--- a/tl.lua
+++ b/tl.lua
@@ -5716,11 +5716,26 @@ tl.type_check = function(ast, opts)
       end
    end
 
-   local function check_for_unused_vars(vars)
+   local Unused = {}
 
+
+
+
+
+
+   local function check_for_unused_vars(vars)
+      local list = {}
       for name, var in pairs(vars) do
-         if not var.used then
-            unused_warning(name, var)
+         if var.declared_at and not var.used then
+            table.insert(list, { y = var.declared_at.y, x = var.declared_at.x, name = name, var = var })
+         end
+      end
+      if list[1] then
+         table.sort(list, function(a, b)
+            return a.y < a.y or (a.y == b.y and a.x < b.x)
+         end)
+         for _, u in ipairs(list) do
+            unused_warning(u.name, u.var)
          end
       end
    end

--- a/tl.lua
+++ b/tl.lua
@@ -5669,10 +5669,24 @@ tl.type_check = function(ast, opts)
       end
    end
 
+   local function close_nested_records(t)
+      for _, ft in pairs(t.fields) do
+         if is_typetype(ft) then
+            ft.closed = true
+            if is_record_type(ft.def) then
+               close_nested_records(ft.def)
+            end
+         end
+      end
+   end
+
    local function close_types(vars)
       for _, var in pairs(vars) do
          if is_typetype(var.t) then
             var.t.closed = true
+            if is_record_type(var.t.def) then
+               close_nested_records(var.t.def)
+            end
          end
       end
    end

--- a/tl.lua
+++ b/tl.lua
@@ -8047,6 +8047,36 @@ tl.type_check = function(ast, opts)
          end,
       },
       ["table_literal"] = {
+         before = function(node)
+            if node.expected then
+               if node.expected.typename == "tupletable" then
+                  for _, child in ipairs(node) do
+                     if child.key.constnum then
+                        child.value.expected = node.expected.types[child.key.constnum]
+                     end
+                  end
+               elseif is_array_type(node.expected) then
+                  for _, child in ipairs(node) do
+                     if child.key.constnum then
+                        child.value.expected = node.expected.elements
+                     end
+                  end
+               elseif node.expected.typename == "map" then
+                  for _, child in ipairs(node) do
+                     child.key.expected = node.expected.keys
+                     child.value.expected = node.expected.values
+                  end
+               end
+
+               if is_record_type(node.expected) then
+                  for _, child in ipairs(node) do
+                     if child.key.conststr then
+                        child.value.expected = node.expected.fields[child.key.conststr]
+                     end
+                  end
+               end
+            end
+         end,
          after = function(node, children)
             node.known = FACT_TRUTHY
 

--- a/tl.lua
+++ b/tl.lua
@@ -3892,7 +3892,7 @@ function tl.pretty_print_ast(ast, mode)
    visit_type.cbs["bad_nominal"] = visit_type.cbs["string"]
    visit_type.cbs["emptytable"] = visit_type.cbs["string"]
    visit_type.cbs["table_item"] = visit_type.cbs["string"]
-   visit_type.cbs["unknown_emptytable_value"] = visit_type.cbs["string"]
+   visit_type.cbs["unresolved_emptytable_value"] = visit_type.cbs["string"]
    visit_type.cbs["tuple"] = visit_type.cbs["string"]
    visit_type.cbs["poly"] = visit_type.cbs["string"]
    visit_type.cbs["any"] = visit_type.cbs["string"]
@@ -4157,7 +4157,7 @@ local binop_to_metamethod = {
 
 local function is_unknown(t)
    return t.typename == "unknown" or
-   t.typename == "unknown_emptytable_value"
+   t.typename == "unresolved_emptytable_value"
 end
 
 local show_type
@@ -4397,7 +4397,7 @@ local function require_module(module_name, lax, env, result)
       end
       return modules[module_name], true
    end
-   modules[module_name] = UNKNOWN
+   modules[module_name] = INVALID
 
    local found, fd = tl.search_module(module_name, true)
    if found and (lax or found:match("tl$")) then
@@ -4416,7 +4416,7 @@ local function require_module(module_name, lax, env, result)
       return found_result.type, true
    end
 
-   return UNKNOWN, found ~= nil
+   return INVALID, found ~= nil
 end
 
 local compat_code_cache = {}
@@ -5055,7 +5055,7 @@ tl.init_env = function(lax, gen_compat, gen_target, preload_modules)
       for _, name in ipairs(preload_modules) do
          local module_type = require_module(name, lax, env, { dependencies = {} })
 
-         if module_type == UNKNOWN then
+         if module_type == INVALID then
             return nil, string.format("Error: could not preload module '%s'", name)
          end
       end
@@ -5287,7 +5287,7 @@ tl.type_check = function(ast, opts)
             t = find_var_type(t.typevar)
             local rt
             if not t then
-               rt = UNKNOWN
+               rt = lax and UNKNOWN or INVALID
             elseif t.typename == "string" then
 
                rt = STRING
@@ -6351,7 +6351,7 @@ tl.type_check = function(ast, opts)
 
       if t1.typename == "nil" then
          return
-      elseif t2.typename == "unknown_emptytable_value" then
+      elseif t2.typename == "unresolved_emptytable_value" then
          if same_type(t2.emptytable_type.keys, NUMBER) then
             infer_var(t2.emptytable_type, a_type({ typename = "array", elements = t1 }), node)
          else
@@ -6685,7 +6685,7 @@ tl.type_check = function(ast, opts)
 
    local function get_rets(rets)
       if lax and (#rets == 0) then
-         return VARARG({ a_type({ typename = "unknown" }) })
+         return VARARG({ UNKNOWN })
       end
       local t = rets
       if not t.typename then
@@ -6837,7 +6837,7 @@ tl.type_check = function(ast, opts)
             local array_type = arraytype_from_tuple(idxnode, a)
             if not array_type then
                type_error(a, "cannot index this tuple with a variable because it would produce a union type that cannot be discriminated at runtime")
-               return UNKNOWN
+               return INVALID
             end
             return array_type.elements
          end
@@ -6854,7 +6854,7 @@ tl.type_check = function(ast, opts)
                return node_error(idxnode, "inconsistent index type: %s, expected %s" .. inferred, b, a.keys)
             end
          end
-         return a_type({ y = node.y, x = node.x, typename = "unknown_emptytable_value", emptytable_type = a })
+         return a_type({ y = node.y, x = node.x, typename = "unresolved_emptytable_value", emptytable_type = a })
       elseif a.typename == "map" then
          if is_a(b, a.keys) then
             return a.values
@@ -7296,7 +7296,7 @@ tl.type_check = function(ast, opts)
             end
          else
             node_error(node, "rawget expects two arguments")
-            return UNKNOWN
+            return INVALID
          end
       end,
 
@@ -7327,8 +7327,12 @@ tl.type_check = function(ast, opts)
                local t, found = require_module(module_name, lax, env, result)
                if not found then
                   node_error(node, "module not found: '" .. module_name .. "'")
-               elseif not lax and is_unknown(t) then
-                  node_error(node, "no type information for required module: '" .. module_name .. "'")
+               elseif t.typename == "invalid" then
+                  if lax then
+                     t = UNKNOWN
+                  else
+                     node_error(node, "no type information for required module: '" .. module_name .. "'")
+                  end
                end
                return t
             else
@@ -7337,7 +7341,7 @@ tl.type_check = function(ast, opts)
          else
             node_error(node, "require expects one literal argument")
          end
-         return UNKNOWN
+         return INVALID
       end,
 
       ["pcall"] = special_pcall_xpcall,
@@ -7390,6 +7394,19 @@ tl.type_check = function(ast, opts)
          end
       end
       return typetype, false
+   end
+
+   local function missing_initializer(node, i, name)
+      if lax then
+         return UNKNOWN
+      else
+         if node.exps then
+            node_error(node.vars[i], "assignment in declaration did not produce an initial value for variable '" .. name .. "'")
+         else
+            node_error(node.vars[i], "variable '" .. name .. "' has no type or initial value")
+         end
+         return INVALID
+      end
    end
 
    local visit_node = {}
@@ -7469,14 +7486,7 @@ tl.type_check = function(ast, opts)
                end
                local t = decltype or infertype
                if t == nil then
-                  t = a_type({ typename = "unknown" })
-                  if not lax then
-                     if node.exps then
-                        node_error(node.vars[i], "assignment in declaration did not produce an initial value for variable '" .. var.tk .. "'")
-                     else
-                        node_error(node.vars[i], "variable '" .. var.tk .. "' has no type or initial value")
-                     end
-                  end
+                  t = missing_initializer(node, i, var.tk)
                elseif t.typename == "emptytable" then
                   t.declared_at = node
                   t.assigned_to = var.tk
@@ -7529,7 +7539,7 @@ tl.type_check = function(ast, opts)
                   end
                else
                   if t == nil then
-                     t = a_type({ typename = "unknown" })
+                     t = missing_initializer(node, i, var.tk)
                   elseif t.typename == "emptytable" then
                      t.declared_at = node
                      t.assigned_to = var.tk
@@ -7732,7 +7742,7 @@ tl.type_check = function(ast, opts)
                      if rets.is_va then
                         r = last
                      else
-                        r = UNKNOWN
+                        r = lax and UNKNOWN or INVALID
                      end
                   end
                   add_var(v, v.tk, r)
@@ -8080,7 +8090,7 @@ tl.type_check = function(ast, opts)
                   node_error(node, "cannot add undeclared function '" .. node.name.tk .. "' outside of the scope where '" .. name .. "' was originally declared")
                end
             else
-               if (not lax) or (rtype.typename ~= "unknown") then
+               if not (lax and rtype.typename == "unknown") then
                   node_error(node, "not a module: %s", rtype)
                end
             end
@@ -8295,6 +8305,7 @@ tl.type_check = function(ast, opts)
                      node.type = UNKNOWN
                   else
                      node_error(node, "cannot use operator '" .. node.op.op:gsub("%%", "%%%%") .. "' for types %s and %s", resolve_tuple(orig_a), resolve_tuple(orig_b))
+                     node.type = INVALID
                   end
                end
 
@@ -8326,18 +8337,19 @@ tl.type_check = function(ast, opts)
             if node.tk == "..." then
                local va_sentinel = find_var_type("@is_va")
                if not va_sentinel or va_sentinel.typename == "nil" then
-                  node.type = UNKNOWN
                   node_error(node, "cannot use '...' outside a vararg function")
+                  node.type = INVALID
                end
             end
 
             node.type, node.is_const = find_var_type(node.tk)
             if node.type == nil then
-               node.type = a_type({ typename = "unknown" })
                if lax then
+                  node.type = UNKNOWN
                   add_unknown(node, node.tk)
                else
                   node_error(node, "unknown variable: " .. node.tk)
+                  node.type = INVALID
                end
             end
             return node.type
@@ -8347,7 +8359,7 @@ tl.type_check = function(ast, opts)
          after = function(node, _children)
             local t = node.decltype
             if not t then
-               t = a_type({ typename = "unknown" })
+               t = UNKNOWN
             end
             if node.tk == "..." then
                t = a_type({ typename = "tuple", is_va = true, t })
@@ -8545,7 +8557,7 @@ tl.type_check = function(ast, opts)
    visit_type.cbs["bad_nominal"] = visit_type.cbs["string"]
    visit_type.cbs["emptytable"] = visit_type.cbs["string"]
    visit_type.cbs["table_item"] = visit_type.cbs["string"]
-   visit_type.cbs["unknown_emptytable_value"] = visit_type.cbs["string"]
+   visit_type.cbs["unresolved_emptytable_value"] = visit_type.cbs["string"]
    visit_type.cbs["tuple"] = visit_type.cbs["string"]
    visit_type.cbs["poly"] = visit_type.cbs["string"]
    visit_type.cbs["any"] = visit_type.cbs["string"]
@@ -8589,7 +8601,7 @@ local typename_to_typecode = {
    ["union"] = tl.typecodes.IS_UNION,
    ["nominal"] = tl.typecodes.NOMINAL,
    ["emptytable"] = tl.typecodes.EMPTY_TABLE,
-   ["unknown_emptytable_value"] = tl.typecodes.EMPTY_TABLE,
+   ["unresolved_emptytable_value"] = tl.typecodes.EMPTY_TABLE,
    ["poly"] = tl.typecodes.IS_POLY,
    ["any"] = tl.typecodes.ANY,
    ["unknown"] = tl.typecodes.UNKNOWN,

--- a/tl.lua
+++ b/tl.lua
@@ -6022,9 +6022,15 @@ tl.type_check = function(ast, opts)
                   types_seen[t.typename] = true
                   table.insert(ts, t)
                end
-            elseif not types_seen[t.typeid] then
-               types_seen[t.typeid] = true
-               table.insert(ts, t)
+            else
+               local typeid = t.typeid
+               if t.typename == "nominal" then
+                  typeid = resolve_nominal(t).typeid
+               end
+               if not types_seen[typeid] then
+                  types_seen[typeid] = true
+                  table.insert(ts, t)
+               end
             end
          end
       end

--- a/tl.tl
+++ b/tl.tl
@@ -186,18 +186,18 @@ tl.typecodes = {
    IS_VALID               = 0x00000fff,
 }
 
-local Result = tl.Result
-local Env = tl.Env
-local Error = tl.Error
-local CompatMode = tl.CompatMode
-local TypeCheckOptions = tl.TypeCheckOptions
-local LoadMode = tl.LoadMode
-local LoadFunction = tl.LoadFunction
-local TargetMode = tl.TargetMode
-local TypeInfo = tl.TypeInfo
-local TypeReport = tl.TypeReport
-local TypeReportEnv = tl.TypeReportEnv
-local Symbol = tl.Symbol
+local type Result = tl.Result
+local type Env = tl.Env
+local type Error = tl.Error
+local type CompatMode = tl.CompatMode
+local type TypeCheckOptions = tl.TypeCheckOptions
+local type LoadMode = tl.LoadMode
+local type LoadFunction = tl.LoadFunction
+local type TargetMode = tl.TargetMode
+local type TypeInfo = tl.TypeInfo
+local type TypeReport = tl.TypeReport
+local type TypeReportEnv = tl.TypeReportEnv
+local type Symbol = tl.Symbol
 
 --------------------------------------------------------------------------------
 -- Lexer

--- a/tl.tl
+++ b/tl.tl
@@ -8047,6 +8047,36 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["table_literal"] = {
+         before = function(node: Node)
+            if node.expected then
+               if node.expected.typename == "tupletable" then
+                  for _, child in ipairs(node) do
+                     if child.key.constnum then
+                        child.value.expected = node.expected.types[child.key.constnum]
+                     end
+                  end
+               elseif is_array_type(node.expected) then
+                  for _, child in ipairs(node) do
+                     if child.key.constnum then
+                        child.value.expected = node.expected.elements
+                     end
+                  end
+               elseif node.expected.typename == "map" then
+                  for _, child in ipairs(node) do
+                     child.key.expected = node.expected.keys
+                     child.value.expected = node.expected.values
+                  end
+               end
+
+               if is_record_type(node.expected) then
+                  for _, child in ipairs(node) do
+                     if child.key.conststr then
+                        child.value.expected = node.expected.fields[child.key.conststr]
+                     end
+                  end
+               end
+            end
+         end,
          after = function(node: Node, children: {Type}): Type
             node.known = FACT_TRUTHY
 

--- a/tl.tl
+++ b/tl.tl
@@ -5669,10 +5669,24 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
+   local function close_nested_records(t: Type)
+      for _, ft in pairs(t.fields) do
+         if is_typetype(ft) then
+            ft.closed = true
+            if is_record_type(ft.def) then
+               close_nested_records(ft.def)
+            end
+         end
+      end
+   end
+
    local function close_types(vars: {string:Variable})
       for _, var in pairs(vars) do
          if is_typetype(var.t) then
             var.t.closed = true
+            if is_record_type(var.t.def) then
+               close_nested_records(var.t.def)
+            end
          end
       end
    end

--- a/tl.tl
+++ b/tl.tl
@@ -3129,6 +3129,7 @@ local function recurse_node<T>(ast: Node,
    end
 
    visit_before(ast, ast.kind, visit_node)
+
    local xs: {T} = {}
    if ast.kind == "statements"
       or ast.kind == "variables"
@@ -3626,24 +3627,6 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
          after = function(node: Node, _children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
             table.insert(out, "break")
-            return out
-         end,
-      },
-      ["elseif"] = {
-         after = function(node: Node, children: {Output}): Output
-            local out: Output = { y = node.y, h = 0 }
-            table.insert(out, "elseif")
-            add_child(out, children[1], " ")
-            table.insert(out, " then")
-            add_child(out, children[2], " ")
-            return out
-         end,
-      },
-      ["else"] = {
-         after = function(node: Node, children: {Output}): Output
-            local out: Output = { y = node.y, h = 0 }
-            table.insert(out, "else")
-            add_child(out, children[1], " ")
             return out
          end,
       },
@@ -5347,6 +5330,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             copy.def = resolve(t.def)
          elseif t.typename == "nominal" then
             copy.typevals = resolve(t.typevals)
+            copy.found = t.found
          elseif t.typename == "function" then
             if t.typeargs then
                copy.typeargs = {}
@@ -7457,21 +7441,24 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
-   local function set_expected_types_to_decltypes(node: Node, _children: {Type})
-      if node.decltype and node.exps then
-         local ndecl = #node.decltype
+   local function set_expected_types_to_decltypes(node: Node, children: {Type})
+      local decls = node.kind == "assignment" and children[1] or node.decltype
+      if decls and node.exps then
+         local ndecl = #decls
          local nexps = #node.exps
          for i = 1, nexps do
             local typ: Type
-            typ = node.decltype[i]
-            if i == nexps and ndecl > nexps then
-               typ = a_type { y = node.y, x = node.x, filename = filename, typename = "tuple", types = {} }
-               for a = i, ndecl do
-                  table.insert(typ.types, node.decltype[a])
+            typ = decls[i]
+            if typ then
+               if i == nexps and ndecl > nexps then
+                  typ = a_type { y = node.y, x = node.x, filename = filename, typename = "tuple", types = {} }
+                  for a = i, ndecl do
+                     table.insert(typ.types, decls[a])
+                  end
                end
+               node.exps[i].expected = typ
+               node.exps[i].expected_context = { kind = node.kind, name = node.vars[i].tk }
             end
-            node.exps[i].expected = typ
-            node.exps[i].expected_context = { kind = node.kind, name = node.vars[i].tk }
          end
       end
    end
@@ -7784,6 +7771,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["assignment"] = {
+         before_expressions = set_expected_types_to_decltypes,
          after = function(node: Node, children: {Type}): Type
             local vals: {Type} = get_assignment_values(children[3], #children[1])
             local exps = flatten_list(vals)
@@ -8151,7 +8139,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                         assert_is_a(node[i], cvtype, dt, in_context(node.expected_context, "in tuple"), "at index " .. tostring(n))
                      end
                   elseif is_array and child.ktype.typename == "number" then
-                     assert_is_a(node[i], cvtype, decltype.elements, in_context(node.expected_context, "expected an array"), "at index " .. tostring(n))
+                     if child.vtype.typename == "tuple" and i == #children and node[i].key_parsed == "implicit" then
+                        -- need to expand last item in an array (e.g { 1, 2, 3, f() })
+                        for ti, tt in ipairs(child.vtype) do
+                           assert_is_a(node[i], tt, decltype.elements, in_context(node.expected_context, "expected an array"), "at index " .. tostring(i + ti - 1))
+                        end
+                     else
+                        assert_is_a(node[i], cvtype, decltype.elements, in_context(node.expected_context, "expected an array"), "at index " .. tostring(n))
+                     end
                   elseif node[i].key_parsed == "implicit" then
                      force_array = expand_type(node[i], force_array, child.ktype)
                   elseif is_map then

--- a/tl.tl
+++ b/tl.tl
@@ -972,12 +972,12 @@ local enum TypeName
    "bad_nominal"
    "emptytable"
    "table_item"
-   "unknown_emptytable_value"
+   "unresolved_emptytable_value"
    "tuple"
    "poly" -- intersection types, currently restricted to polymorphic functions defined inside records
    "any"
-   "unknown"
-   "invalid"
+   "unknown" -- to be used in lax mode only
+   "invalid" -- producing a new value of this type (not propagating) must always produce a type error
    "unresolved"
    "none"
 end
@@ -3892,7 +3892,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
    visit_type.cbs["bad_nominal"] = visit_type.cbs["string"]
    visit_type.cbs["emptytable"] = visit_type.cbs["string"]
    visit_type.cbs["table_item"] = visit_type.cbs["string"]
-   visit_type.cbs["unknown_emptytable_value"] = visit_type.cbs["string"]
+   visit_type.cbs["unresolved_emptytable_value"] = visit_type.cbs["string"]
    visit_type.cbs["tuple"] = visit_type.cbs["string"]
    visit_type.cbs["poly"] = visit_type.cbs["string"]
    visit_type.cbs["any"] = visit_type.cbs["string"]
@@ -4157,7 +4157,7 @@ local binop_to_metamethod: {string:string} = {
 
 local function is_unknown(t: Type): boolean
    return t.typename == "unknown"
-       or t.typename == "unknown_emptytable_value"
+       or t.typename == "unresolved_emptytable_value"
 end
 
 local show_type: function(Type, boolean, {Type:string}): string
@@ -4397,7 +4397,7 @@ local function require_module(module_name: string, lax: boolean, env: Env, resul
       end
       return modules[module_name], true
    end
-   modules[module_name] = UNKNOWN
+   modules[module_name] = INVALID
 
    local found, fd = tl.search_module(module_name, true)
    if found and (lax or found:match("tl$") as boolean) then
@@ -4416,7 +4416,7 @@ local function require_module(module_name: string, lax: boolean, env: Env, resul
       return found_result.type, true
    end
 
-   return UNKNOWN, found ~= nil
+   return INVALID, found ~= nil
 end
 
 local compat_code_cache: {string:Node} = {}
@@ -5055,7 +5055,7 @@ tl.init_env = function(lax: boolean, gen_compat: boolean | CompatMode, gen_targe
       for _, name in ipairs(preload_modules) do
          local module_type = require_module(name, lax, env, { dependencies = {} })
 
-         if module_type == UNKNOWN then
+         if module_type == INVALID then
             return nil, string.format("Error: could not preload module '%s'", name)
          end
       end
@@ -5287,7 +5287,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             t = find_var_type(t.typevar)
             local rt: Type
             if not t then
-               rt = UNKNOWN
+               rt = lax and UNKNOWN or INVALID
             elseif t.typename == "string" then
                -- tk is not propagated
                rt = STRING
@@ -6351,7 +6351,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       -- some flow-based inference
       if t1.typename == "nil" then
          return
-      elseif t2.typename == "unknown_emptytable_value" then
+      elseif t2.typename == "unresolved_emptytable_value" then
          if same_type(t2.emptytable_type.keys, NUMBER) then
             infer_var(t2.emptytable_type, a_type { typename = "array", elements = t1 }, node)
          else
@@ -6685,7 +6685,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    local function get_rets(rets: {Type}): Type
       if lax and (#rets == 0) then
-         return VARARG { a_type { typename = "unknown" }}
+         return VARARG { UNKNOWN }
       end
       local t: Type = rets as Type
       if not t.typename then
@@ -6837,7 +6837,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             local array_type = arraytype_from_tuple(idxnode, a)
             if not array_type then
                type_error(a, "cannot index this tuple with a variable because it would produce a union type that cannot be discriminated at runtime")
-               return UNKNOWN
+               return INVALID
             end
             return array_type.elements
          end
@@ -6854,7 +6854,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                return node_error(idxnode, "inconsistent index type: %s, expected %s" .. inferred, b, a.keys)
             end
          end
-         return a_type { y = node.y, x = node.x, typename = "unknown_emptytable_value", emptytable_type = a }
+         return a_type { y = node.y, x = node.x, typename = "unresolved_emptytable_value", emptytable_type = a }
       elseif a.typename == "map" then
          if is_a(b, a.keys) then
             return a.values
@@ -7296,7 +7296,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
          else
             node_error(node, "rawget expects two arguments")
-            return UNKNOWN
+            return INVALID
          end
       end,
 
@@ -7327,8 +7327,12 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                local t, found = require_module(module_name, lax, env, result)
                if not found then
                   node_error(node, "module not found: '" .. module_name .. "'")
-               elseif not lax and is_unknown(t) then
-                  node_error(node, "no type information for required module: '" .. module_name .. "'")
+               elseif t.typename == "invalid" then
+                  if lax then
+                     t = UNKNOWN
+                  else
+                     node_error(node, "no type information for required module: '" .. module_name .. "'")
+                  end
                end
                return t
             else
@@ -7337,7 +7341,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          else
             node_error(node, "require expects one literal argument")
          end
-         return UNKNOWN
+         return INVALID
       end,
 
       ["pcall"] = special_pcall_xpcall,
@@ -7390,6 +7394,19 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end
       end
       return typetype, false
+   end
+
+   local function missing_initializer(node: Node, i: number, name: string): Type
+      if lax then
+         return UNKNOWN
+      else
+         if node.exps then
+            node_error(node.vars[i], "assignment in declaration did not produce an initial value for variable '" .. name .. "'")
+         else
+            node_error(node.vars[i], "variable '" .. name .. "' has no type or initial value")
+         end
+         return INVALID
+      end
    end
 
    local visit_node: Visitor<NodeKind, Node, Type> = {}
@@ -7469,14 +7486,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
                local t = decltype or infertype
                if t == nil then
-                  t = a_type { typename = "unknown" }
-                  if not lax then
-                     if node.exps then
-                        node_error(node.vars[i], "assignment in declaration did not produce an initial value for variable '" .. var.tk .. "'")
-                     else
-                        node_error(node.vars[i], "variable '" .. var.tk .. "' has no type or initial value")
-                     end
-                  end
+                  t = missing_initializer(node, i, var.tk)
                elseif t.typename == "emptytable" then
                   t.declared_at = node
                   t.assigned_to = var.tk
@@ -7529,7 +7539,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   end
                else
                   if t == nil then
-                     t = a_type { typename = "unknown" }
+                     t = missing_initializer(node, i, var.tk)
                   elseif t.typename == "emptytable" then
                      t.declared_at = node
                      t.assigned_to = var.tk
@@ -7732,7 +7742,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                      if rets.is_va then
                         r = last
                      else
-                        r = UNKNOWN
+                        r = lax and UNKNOWN or INVALID
                      end
                   end
                   add_var(v, v.tk, r)
@@ -8080,7 +8090,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   node_error(node, "cannot add undeclared function '" .. node.name.tk .. "' outside of the scope where '" .. name .. "' was originally declared")
                end
             else
-               if (not lax) or (rtype.typename ~= "unknown") then
+               if not (lax and rtype.typename == "unknown") then
                   node_error(node, "not a module: %s", rtype)
                end
             end
@@ -8295,6 +8305,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                      node.type = UNKNOWN
                   else
                      node_error(node, "cannot use operator '" .. node.op.op:gsub("%%", "%%%%") .. "' for types %s and %s", resolve_tuple(orig_a), resolve_tuple(orig_b))
+                     node.type = INVALID
                   end
                end
 
@@ -8326,18 +8337,19 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             if node.tk == "..." then
                local va_sentinel = find_var_type("@is_va")
                if not va_sentinel or va_sentinel.typename == "nil" then
-                  node.type = UNKNOWN
                   node_error(node, "cannot use '...' outside a vararg function")
+                  node.type = INVALID
                end
             end
 
             node.type, node.is_const = find_var_type(node.tk)
             if node.type == nil then
-               node.type = a_type { typename = "unknown" }
                if lax then
+                  node.type = UNKNOWN
                   add_unknown(node, node.tk)
                else
                   node_error(node, "unknown variable: " .. node.tk)
+                  node.type = INVALID
                end
             end
             return node.type
@@ -8347,7 +8359,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          after = function(node: Node, _children: {Type}): Type
             local t = node.decltype
             if not t then
-               t = a_type { typename = "unknown" }
+               t = UNKNOWN
             end
             if node.tk == "..." then
                t = a_type { typename = "tuple", is_va = true, t }
@@ -8545,7 +8557,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    visit_type.cbs["bad_nominal"] = visit_type.cbs["string"]
    visit_type.cbs["emptytable"] = visit_type.cbs["string"]
    visit_type.cbs["table_item"] = visit_type.cbs["string"]
-   visit_type.cbs["unknown_emptytable_value"] = visit_type.cbs["string"]
+   visit_type.cbs["unresolved_emptytable_value"] = visit_type.cbs["string"]
    visit_type.cbs["tuple"] = visit_type.cbs["string"]
    visit_type.cbs["poly"] = visit_type.cbs["string"]
    visit_type.cbs["any"] = visit_type.cbs["string"]
@@ -8589,7 +8601,7 @@ local typename_to_typecode: {TypeName:number} = {
    ["union"] = tl.typecodes.IS_UNION,
    ["nominal"] = tl.typecodes.NOMINAL,
    ["emptytable"] = tl.typecodes.EMPTY_TABLE,
-   ["unknown_emptytable_value"] = tl.typecodes.EMPTY_TABLE,
+   ["unresolved_emptytable_value"] = tl.typecodes.EMPTY_TABLE,
    ["poly"] = tl.typecodes.IS_POLY,
    ["any"] = tl.typecodes.ANY,
    ["unknown"] = tl.typecodes.UNKNOWN,

--- a/tl.tl
+++ b/tl.tl
@@ -6022,9 +6022,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   types_seen[t.typename] = true
                   table.insert(ts, t)
                end
-            elseif not types_seen[t.typeid] then
-               types_seen[t.typeid] = true
-               table.insert(ts, t)
+            else
+               local typeid = t.typeid
+               if t.typename == "nominal" then
+                  typeid = resolve_nominal(t).typeid
+               end
+               if not types_seen[typeid] then
+                  types_seen[typeid] = true
+                  table.insert(ts, t)
+               end
             end
          end
       end

--- a/tl.tl
+++ b/tl.tl
@@ -1105,6 +1105,7 @@ local enum NodeKind
    "values"
    "newtype"
    "argument"
+   "type_identifier"
    "variable"
    "variables"
    "statements"
@@ -1156,6 +1157,12 @@ end
 
 local record Node
    {Node}
+
+   record ExpectedContext
+      kind: NodeKind
+      name: string
+   end
+
    y: number
    x: number
    tk: string
@@ -1169,6 +1176,10 @@ local record Node
    xend: number
 
    known: Fact
+
+   -- bidirectional inference
+   expected: Type
+   expected_context: Node.ExpectedContext
 
    key: Node
    value: Node
@@ -2235,7 +2246,7 @@ local function parse_global_function(ps: ParseState, i: number): number, Node
    if #names > 1 then
       fn.kind = "record_function"
       local owner = names[1]
-      owner.kind = "variable"
+      owner.kind = "type_identifier"
       for i2 = 2, #names - 1 do
          local dot = an_operator(names[i2], 2, ".")
          names[i2].kind = "identifier"
@@ -2447,7 +2458,7 @@ local function parse_nested_type(ps: ParseState, i: number, def: Type, typename:
    i = i + 1 -- skip 'record' or 'enum'
 
    local v: Node
-   i, v = verify_kind(ps, i, "identifier", "variable")
+   i, v = verify_kind(ps, i, "identifier", "type_identifier")
    if not v then
       return fail(ps, i, "expected a variable name")
    end
@@ -2541,7 +2552,7 @@ parse_record_body = function(ps: ParseState, i: number, def: Type, node: Node): 
       elseif ps.tokens[i].tk == "type" and ps.tokens[i + 1].tk ~= ":" then
          i = i + 1
          local v: Node
-         i, v = verify_kind(ps, i, "identifier", "variable")
+         i, v = verify_kind(ps, i, "identifier", "type_identifier")
          if not v then
             return fail(ps, i, "expected a variable name")
          end
@@ -2959,6 +2970,7 @@ end
 
 local record VisitorCallbacks<N, T>
    before: function(N, {T})
+   before_expressions: function({N}, {T})
    before_statements: function({N}, {T})
    before_e2: function({N}, {T})
    after: function(N, {T}, T): T
@@ -2966,6 +2978,7 @@ end
 
 local enum VisitorExtraCallback
    "before_statements"
+   "before_expressions"
    "before_e2"
 end
 
@@ -3133,6 +3146,7 @@ local function recurse_node<T>(ast: Node,
       if ast.decltype then
          xs[2] = recurse_type(ast.decltype, visit_type)
       end
+      extra_callback("before_expressions", ast, xs, visit_node, ast.kind)
       if ast.exps then
          xs[3] = recurse_node(ast.exps, visit_node, visit_type)
       end
@@ -3222,6 +3236,7 @@ local function recurse_node<T>(ast: Node,
    elseif ast.kind == "newtype" then
       xs[1] = recurse_type(ast.newtype, visit_type)
    elseif ast.kind == "variable"
+          or ast.kind == "type_identifier"
           or ast.kind == "argument"
           or ast.kind == "identifier"
           or ast.kind == "string"
@@ -3911,6 +3926,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
    visit_node.cbs["boolean"] = visit_node.cbs["variable"]
    visit_node.cbs["..."] = visit_node.cbs["variable"]
    visit_node.cbs["argument"] = visit_node.cbs["variable"]
+   visit_node.cbs["type_identifier"] = visit_node.cbs["variable"]
 
    local out = recurse_node(ast, visit_node, visit_type)
    local code: Output
@@ -4698,9 +4714,10 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
                ["__len"] = a_type { typename = "function", args = TUPLE { ALPHA }, rets = TUPLE { ANY } },
                ["__mode"] = a_type { typename = "enum", enumset = { ["k"] = true, ["v"] = true, ["kv"] = true, } },
                ["__newindex"] = ANY, -- FIXME: function | table | anything with a __newindex metamethod
-               ["__pairs"] = a_type { typeargs = TUPLE { ARG_ALPHA, ARG_BETA }, typename = "function", args = TUPLE { a_type { typename = "map", keys = ALPHA, values = BETA } }, rets = TUPLE {
-                     a_type { typename = "function", args = TUPLE {}, rets = TUPLE { ALPHA, BETA } },
-               } },
+               ["__pairs"] = a_type { typename = "function", typeargs = TUPLE { ARG_ALPHA, ARG_BETA },
+                  args = TUPLE { a_type { typename = "map", keys = ALPHA, values = BETA } },
+                  rets = TUPLE { a_type { typename = "function", args = TUPLE {}, rets = TUPLE { ALPHA, BETA } } }
+               },
                ["__tostring"] = a_type { typename = "function", args = TUPLE { ALPHA }, rets = TUPLE { STRING } },
                ["__name"] = STRING,
                ["__add"] = a_type { typename = "function", args = TUPLE { ANY, ANY }, rets = TUPLE { ANY } },
@@ -5181,6 +5198,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end
          if is_typetype(typ) then
             return typ
+         elseif typ.typename == "nominal" and typ.found then
+            return typ.found
          end
       end
       return nil
@@ -5544,7 +5563,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
 
    local type CompareTypes = function(Type, Type, boolean): boolean, {Error}
 
-   local function compare_typevars(t1: Type, t2: Type, comp: CompareTypes): boolean, {Error}
+   local function compare_and_infer_typevars(t1: Type, t2: Type, comp: CompareTypes): boolean, {Error}
       local tv1 = find_var_type(t1.typevar)
       local tv2 = find_var_type(t2.typevar)
       if t1.typevar == t2.typevar then
@@ -5624,7 +5643,13 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    end
 
    local function match_fields_to_record(t1: Type, t2: Type, cmp: CompareTypes): boolean, {Error}
-      return match_record_fields(t1, function(k: string): Type return t2.fields[k] end, cmp)
+      local ok, fielderrs = match_record_fields(t1, function(k: string): Type return t2.fields[k] end, cmp)
+      if not ok then
+         local errs = {}
+         add_errs_prefixing(errs, fielderrs, show_type(t1) .. " is not a " .. show_type(t2) .. ": ")
+         return false, errs
+      end
+      return true
    end
 
    local function match_fields_to_map(t1: Type, t2: Type): boolean, {Error}
@@ -5877,7 +5902,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       assert(type(t2) == "table")
 
       if t1.typename == "typevar" or t2.typename == "typevar" then
-         return compare_typevars(t1, t2, same_type)
+         return compare_and_infer_typevars(t1, t2, same_type)
       end
 
       if t1.typename == "emptytable" and is_known_table_type(resolve_tuple_and_nominal(t2)) then
@@ -6084,7 +6109,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
 
       if t1.typename == "typevar" or t2.typename == "typevar" then
-         return compare_typevars(t1, t2, is_a)
+         return compare_and_infer_typevars(t1, t2, is_a)
       end
 
       -- ∀ t, t <: any
@@ -6341,34 +6366,35 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       return false, terr(t1, "got %s, expected %s", t1, t2)
    end
 
-   local function assert_is_a(node: Node, t1: Type, t2: Type, context: string, name: string)
+   local function assert_is_a(node: Node, t1: Type, t2: Type, context: string, name: string): boolean
       t1 = resolve_tuple(t1)
       t2 = resolve_tuple(t2)
       if lax and (is_unknown(t1) or is_unknown(t2)) then
-         return
+         return true
       end
 
       -- some flow-based inference
       if t1.typename == "nil" then
-         return
+         return true
       elseif t2.typename == "unresolved_emptytable_value" then
          if same_type(t2.emptytable_type.keys, NUMBER) then
             infer_var(t2.emptytable_type, a_type { typename = "array", elements = t1 }, node)
          else
             infer_var(t2.emptytable_type, a_type { typename = "map", keys = t2.emptytable_type.keys, values = t1 }, node)
          end
-         return
+         return true
       elseif t2.typename == "emptytable" then
          if is_known_table_type(t1) then
             infer_var(t2, shallow_copy(t1), node)
          elseif t1.typename ~= "emptytable" then
-            node_error(node, "in " .. context .. ": " .. (name and (name .. ": ") or "") .. "assigning %s to a variable declared with {}", t1)
+            node_error(node, context .. ": " .. (name and (name .. ": ") or "") .. "assigning %s to a variable declared with {}", t1)
          end
-         return
+         return true
       end
 
-      local _, match_errs = is_a(t1, t2)
-      add_errs_prefixing(match_errs, errors, "in " .. context .. ": ".. (name and (name .. ": ") or ""), node)
+      local ok, match_errs = is_a(t1, t2)
+      add_errs_prefixing(match_errs, errors, context .. ": ".. (name and (name .. ": ") or ""), node)
+      return ok
    end
 
    local unknown_dots: {string:boolean} = {}
@@ -6846,7 +6872,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       elseif a.typename == "emptytable" then
          if a.keys == nil then
             a.keys = b
-            a.keys_inferred_at = node
+            a.keys_inferred_at = assert(node)
             a.keys_inferred_at_file = filename
          else
             if not is_a(b, a.keys) then
@@ -6929,9 +6955,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       return old
    end
 
-   local function find_in_scope(exp: Node): Type
-      if exp.kind == "variable" then
+   local function find_record_to_extend(exp: Node): Type
+      if exp.kind == "type_identifier" then
          local t = find_var_type(exp.tk)
+         -- FIXME assert(t.def)
          if t.def then
             if not t.def.closed and not t.closed then
                return t.def
@@ -6941,7 +6968,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             return t
          end
       elseif exp.kind == "op" and exp.op.op == "." then
-         local t = find_in_scope(exp.e1)
+         local t = find_record_to_extend(exp.e1)
          if not t then
             return nil
          end
@@ -7261,7 +7288,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       if node.e1.tk == "xpcall" then
          base_nargs = 2
          local msgh = table.remove(b, 1)
-         assert_is_a(node.e2[2], msgh, XPCALL_MSGH_FUNCTION, "message handler")
+         assert_is_a(node.e2[2], msgh, XPCALL_MSGH_FUNCTION, "in message handler")
       end
       for i = base_nargs + 1, #node.e2 do
          table.insert(fe2, node.e2[i])
@@ -7409,6 +7436,184 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
+   local function set_expected_types_to_decltypes(node: Node, _children: {Type})
+      if node.decltype and node.exps then
+         local ndecl = #node.decltype
+         local nexps = #node.exps
+         for i = 1, nexps do
+            local typ: Type
+            typ = node.decltype[i]
+            if i == nexps and ndecl > nexps then
+               typ = a_type { y = node.y, x = node.x, filename = filename, typename = "tuple", types = {} }
+               for a = i, ndecl do
+                  table.insert(typ.types, node.decltype[a])
+               end
+            end
+            node.exps[i].expected = typ
+            node.exps[i].expected_context = { kind = node.kind, name = node.vars[i].tk }
+         end
+      end
+   end
+
+   local function is_positive_int(n: number): boolean
+      return n and n >= 1 and math.floor(n) == n
+   end
+
+   local function infer_table_literal(node: Node, children: {Type}): Type
+      local typ = a_type {
+         filename = filename,
+         y = node.y,
+         x = node.x,
+         typename = "emptytable",
+      }
+
+      local is_record = false
+      local is_array = false
+      local is_map = false
+
+      local is_tuple = false
+      local is_not_tuple = false
+
+      local last_array_idx = 1
+      local largest_array_idx = -1
+
+      for i, child in ipairs(children) do
+         assert(child.typename == "table_item")
+         local uvtype = resolve_tuple(child.vtype)
+         if child.kname then
+            is_record = true
+            if not typ.fields then
+               typ.fields = {}
+               typ.field_order = {}
+            end
+            typ.fields[child.kname] = uvtype
+            table.insert(typ.field_order, child.kname)
+         elseif child.ktype.typename == "number" then
+            is_array = true
+            if not is_not_tuple then
+               is_tuple = true
+            end
+            if not typ.types then
+               typ.types = {}
+            end
+
+            if node[i].key_parsed == "implicit" then
+               if i == #children and child.vtype.typename == "tuple" then
+                  -- need to expand last item in an array (e.g { 1, 2, 3, f() })
+                  for _, c in ipairs(child.vtype) do
+                     typ.elements = expand_type(node, typ.elements, c)
+                     typ.types[last_array_idx] = resolve_tuple(c)
+                     last_array_idx = last_array_idx + 1
+                  end
+               else
+                  typ.types[last_array_idx] = uvtype
+                  last_array_idx = last_array_idx + 1
+                  typ.elements = expand_type(node, typ.elements, uvtype)
+               end
+            else -- explicit
+               local n = node[i].key.constnum
+
+               if not is_positive_int(n) then
+                  typ.elements = expand_type(node, typ.elements, uvtype)
+                  is_not_tuple = true
+               elseif n then
+                  typ.types[n] = uvtype
+                  if n > largest_array_idx then
+                     largest_array_idx = n
+                  end
+                  typ.elements = expand_type(node, typ.elements, uvtype)
+               end
+            end
+
+            if last_array_idx > largest_array_idx then
+               largest_array_idx = last_array_idx
+            end
+            if not typ.elements then
+               is_array = false
+            end
+         else
+            is_map = true
+            child.ktype.tk = nil
+            typ.keys = expand_type(node, typ.keys, child.ktype)
+            typ.values = expand_type(node, typ.values, uvtype)
+         end
+      end
+
+      if is_array and is_map then
+         typ.typename = "map"
+         typ.keys = expand_type(node, typ.keys, NUMBER)
+         typ.values = expand_type(node, typ.values, typ.elements)
+         typ.elements = nil
+         node_error(node, "cannot determine type of table literal")
+      elseif is_record and is_array then
+         typ.typename = "arrayrecord"
+      elseif is_record and is_map then
+         if typ.keys.typename == "string" then
+            typ.typename = "map"
+            for _, ftype in fields_of(typ) do
+               typ.values = expand_type(node, typ.values, ftype)
+            end
+            typ.fields = nil
+            typ.field_order = nil
+         else
+            node_error(node, "cannot determine type of table literal")
+         end
+      elseif is_array then
+         if is_not_tuple then
+            typ.typename = "array"
+            typ.inferred_len = largest_array_idx - 1
+         else
+            local pure_array = true
+
+            local last_t: Type
+            for _, current_t in pairs(typ.types as {number:Type}) do
+               if last_t then
+                  if not same_type(last_t, current_t) then
+                     pure_array = false
+                     break
+                  end
+               end
+               last_t = current_t
+            end
+
+            if not pure_array then
+               typ.typename = "tupletable"
+            else
+               typ.typename = "array"
+               typ.inferred_len = largest_array_idx - 1
+            end
+         end
+      elseif is_record then
+         typ.typename = "record"
+      elseif is_map then
+         typ.typename = "map"
+      elseif is_tuple then
+         typ.typename = "tupletable"
+         if not typ.types or #typ.types == 0 then
+            node_error(node, "cannot determine type of tuple elements")
+         end
+      end
+
+      return typ
+   end
+
+   local context_name: {NodeKind: string} = {
+      ["local_declaration"] = "in local declaration",
+      ["global_declaration"] = "in global declaration",
+   }
+
+   local function in_context(ctx: Node.ExpectedContext, msg: string): string
+      if not ctx then
+         return msg
+      end
+      local where = context_name[ctx.kind]
+      if where then
+         return where .. ": " .. ctx.name .. ": " .. msg
+      else
+         return msg
+      end
+   end
+
    local visit_node: Visitor<NodeKind, Node, Type> = {}
 
    visit_node.cbs = {
@@ -7473,6 +7678,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                reserve_symbol_list_slot(var)
             end
          end,
+         before_expressions = set_expected_types_to_decltypes,
          after = function(node: Node, children: {Type}): Type
             local vals: {Type} = get_assignment_values(children[3], #node.vars)
             for i, var in ipairs(node.vars) do
@@ -7482,7 +7688,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   infertype = nil
                end
                if decltype and infertype then
-                  assert_is_a(node.vars[i], infertype, decltype, "local declaration", var.tk)
+                  assert_is_a(node.vars[i], infertype, decltype, "in local declaration", var.tk)
                end
                local t = decltype or infertype
                if t == nil then
@@ -7511,6 +7717,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          end,
       },
       ["global_declaration"] = {
+         before_expressions = set_expected_types_to_decltypes,
          after = function(node: Node, children: {Type}): Type
             local vals: {Type} = get_assignment_values(children[3], #node.vars)
             for i, var in ipairs(node.vars) do
@@ -7520,7 +7727,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   infertype = nil
                end
                if decltype and infertype then
-                  assert_is_a(node.vars[i], infertype, decltype, "global declaration", var.tk)
+                  assert_is_a(node.vars[i], infertype, decltype, "in global declaration", var.tk)
                end
                local t = decltype or infertype
                local existing, existing_is_const = find_global(var.tk)
@@ -7575,7 +7782,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   if is_typetype(resolve_tuple_and_nominal(vartype)) then
                      node_error(varnode, "cannot reassign a type")
                   elseif val then
-                     assert_is_a(varnode, val, vartype, "assignment")
+                     assert_is_a(varnode, val, vartype, "in assignment")
                      if varnode.kind == "variable" and vartype.typename == "union" then
                         -- narrow union
                         add_var(varnode, varnode.tk, val, false, true)
@@ -7789,7 +7996,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                module_type.tk = nil
                st[2]["@return"] = { t = rets }
             end
-            local what = "return value"
+            local what = "in return value"
             if rets.inferred_at then
                what = what .. inferred_msg(rets)
             end
@@ -7841,139 +8048,83 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       },
       ["table_literal"] = {
          after = function(node: Node, children: {Type}): Type
-            node.type = a_type {
-               filename = filename,
-               y = node.y,
-               x = node.x,
-               typename = "emptytable",
-            }
             node.known = FACT_TRUTHY
 
-            local function is_positive_int(n: number): boolean
-               return n and n >= 1 and math.floor(n) == n
-            end
+            if node.expected then
+               local decltype = resolve_tuple_and_nominal(node.expected)
 
-            local is_record = false
-            local is_array = false
-            local is_map = false
-
-            local is_tuple = false
-            local is_not_tuple = false
-
-            local last_array_idx = 1
-            local largest_array_idx = -1
-
-            for i, child in ipairs(children) do
-               assert(child.typename == "table_item")
-               local uvtype = resolve_tuple(child.vtype)
-               if child.kname then
-                  is_record = true
-                  if not node.type.fields then
-                     node.type.fields = {}
-                     node.type.field_order = {}
+               if decltype.typename == "union" then
+                  for _, t in ipairs(decltype.types) do
+                     t = resolve_tuple_and_nominal(t)
+                     if is_known_table_type(t) then
+                        decltype = t
+                        break
+                     end
                   end
-                  node.type.fields[child.kname] = uvtype
-                  table.insert(node.type.field_order, child.kname)
-               elseif child.ktype.typename == "number" then
-                  is_array = true
-                  if not is_not_tuple then
-                     is_tuple = true
+                  if decltype.typename == "union" then
+                     node_error(node, "unexpected table literal, expected: %s", decltype)
                   end
-                  if not node.type.types then
-                     node.type.types = {}
-                  end
+               end
 
-                  if node[i].key_parsed == "implicit" then
-                     if i == #children and child.vtype.typename == "tuple" then
-                        -- need to expand last item in an array (e.g { 1, 2, 3, f() })
-                        for _, c in ipairs(child.vtype) do
-                           node.type.elements = expand_type(node, node.type.elements, c)
-                           node.type.types[last_array_idx] = resolve_tuple(c)
-                           last_array_idx = last_array_idx + 1
-                        end
+               if not is_known_table_type(decltype) then
+                  node.type = infer_table_literal(node, children)
+                  return node.type
+               end
+
+               local is_record = is_record_type(decltype)
+               local is_array = is_array_type(decltype)
+               local is_tupletable = decltype.typename == "tupletable"
+               local is_map = decltype.typename == "map"
+
+               local force_array: Type = nil
+
+               for i, child in ipairs(children) do
+                  assert(child.typename == "table_item")
+                  local cvtype = resolve_tuple(child.vtype)
+                  local ck = child.kname
+                  local n = node[i].key.constnum
+                  if is_record and ck then
+                     local df = decltype.fields[ck]
+                     if not df then
+                        node_error(node[i], in_context(node.expected_context, "unknown field " .. ck))
                      else
-                        node.type.types[last_array_idx] = uvtype
-                        last_array_idx = last_array_idx + 1
-                        node.type.elements = expand_type(node, node.type.elements, uvtype)
+                        assert_is_a(node[i], cvtype, df, "in record field", ck)
                      end
-                  else -- explicit
-                     local n = node[i].key.constnum
-
-                     if not is_positive_int(n) then
-                        node.type.elements = expand_type(node, node.type.elements, uvtype)
-                        is_not_tuple = true
-                     elseif n then
-                        node.type.types[n] = uvtype
-                        if n > largest_array_idx then
-                           largest_array_idx = n
-                        end
-                        node.type.elements = expand_type(node, node.type.elements, uvtype)
+                  elseif is_tupletable and child.ktype.typename == "number" then
+                     local dt = decltype.types[n]
+                     if not n then
+                        node_error(node[i], in_context(node.expected_context, "unknown index in tuple %s"), decltype)
+                     elseif not dt then
+                        node_error(node[i], in_context(node.expected_context, "unexpected index " .. n .. " in tuple %s"), decltype)
+                     else
+                        assert_is_a(node[i], cvtype, dt, in_context(node.expected_context, "in tuple"), "at index " .. tostring(n))
                      end
-                  end
-
-                  if last_array_idx > largest_array_idx then
-                     largest_array_idx = last_array_idx
-                  end
-                  if not node.type.elements then
-                     is_array = false
-                  end
-               else
-                  is_map = true
-                  child.ktype.tk = nil
-                  node.type.keys = expand_type(node, node.type.keys, child.ktype)
-                  node.type.values = expand_type(node, node.type.values, uvtype)
-               end
-            end
-            if is_array and is_map then
-               node_error(node, "cannot determine type of table literal")
-            elseif is_record and is_array then
-               node.type.typename = "arrayrecord"
-            elseif is_record and is_map then
-               if node.type.keys.typename == "string" then
-                  node.type.typename = "map"
-                  for _, ftype in fields_of(node.type) do
-                     node.type.values = expand_type(node, node.type.values, ftype)
-                  end
-                  node.type.fields = nil
-                  node.type.field_order = nil
-               else
-                  node_error(node, "cannot determine type of table literal")
-               end
-            elseif is_array then
-               if is_not_tuple then
-                  node.type.typename = "array"
-                  node.type.inferred_len = largest_array_idx - 1
-               else
-                  local pure_array = true
-
-                  local last_t: Type
-                  for _, current_t in pairs(node.type.types as {number:Type}) do
-                     if last_t then
-                        if not same_type(last_t, current_t) then
-                           pure_array = false
-                           break
-                        end
-                     end
-                     last_t = current_t
-                  end
-
-                  if not pure_array then
-                     node.type.typename = "tupletable"
+                  elseif is_array and child.ktype.typename == "number" then
+                     assert_is_a(node[i], cvtype, decltype.elements, in_context(node.expected_context, "expected an array"), "at index " .. tostring(n))
+                  elseif node[i].key_parsed == "implicit" then
+                     force_array = expand_type(node[i], force_array, child.ktype)
+                  elseif is_map then
+                     assert_is_a(node[i], child.ktype, decltype.keys, in_context(node.expected_context, "in map key"))
+                     assert_is_a(node[i], cvtype, decltype.values, in_context(node.expected_context, "in map value"))
                   else
-                     node.type.typename = "array"
-                     node.type.inferred_len = largest_array_idx - 1
+                     node_error(node[i], in_context(node.expected_context, "unexpected key of type %s in table of type %s"), child.ktype, decltype)
                   end
                end
-            elseif is_record then
-               node.type.typename = "record"
-            elseif is_map then
-               node.type.typename = "map"
-            elseif is_tuple then
-               node.type.typename = "tupletable"
-               if not node.type.types or #node.type.types == 0 then
-                  node_error(node, "cannot determine type of tuple elements")
+
+               if force_array then
+                  node.type = a_type {
+                     inferred_at = node,
+                     inferred_at_file = filename,
+                     typename = "array",
+                     elements = force_array,
+                  }
+               else
+                  node.type = resolve_typevars_at(node.expected, node)
                end
+            else
+               node.type = infer_table_literal(node, children)
             end
+
             return node.type
          end,
       },
@@ -7984,7 +8135,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             local vtype = children[2]
             if node.decltype then
                vtype = node.decltype
-               assert_is_a(node.value, children[2], node.decltype, "table item")
+               assert_is_a(node.value, children[2], node.decltype, "in table item")
             end
             node.type = a_type {
                y = node.y,
@@ -8076,7 +8227,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                   ok = true
                elseif rtype.fields and rtype.fields[node.name.tk] and is_a(fn_type, rtype.fields[node.name.tk]) then
                   ok = true
-               elseif find_in_scope(node.fn_owner) == rtype then
+               elseif find_record_to_extend(node.fn_owner) == rtype then
                   ok = true
                end
 
@@ -8146,6 +8297,19 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                apply_facts(node, node.e1.known)
             elseif node.op.op == "or" then
                apply_facts(node, facts_not(node.e1.known, node))
+            elseif node.op.op == "@funcall" then
+               if node.e1.type.typename == "function" then
+                  for i, typ in ipairs(node.e1.type.args) do
+                     if node.e2[i] then
+                        node.e2[i].expected = typ
+                     end
+                  end
+               end
+               apply_facts(node, facts_not(node.e1.known, node))
+            elseif node.op.op == "@index" then
+               if node.e1.type.typename == "map" then
+                  node.e2.expected = node.e1.type.keys
+               end
             end
          end,
          after = function(node: Node, children: {Type}): Type
@@ -8342,6 +8506,30 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                end
             end
 
+            node.type, node.is_const = find_var_type(node.tk)
+            if node.type and is_typetype(node.type) then
+               node.type = a_type {
+                  y = node.y,
+                  x = node.x,
+                  typename = "nominal",
+                  names = { node.tk },
+                  found = node.type,
+                  resolved = node.type,
+               }
+            end
+            if node.type == nil then
+               node.type = a_type { typename = "unknown" }
+               if lax then
+                  add_unknown(node, node.tk)
+               else
+                  node_error(node, "unknown variable: " .. node.tk)
+               end
+            end
+            return node.type
+         end,
+      },
+      ["type_identifier"] = {
+         after = function(node: Node, _children: {Type}): Type
             node.type, node.is_const = find_var_type(node.tk)
             if node.type == nil then
                if lax then
@@ -8727,7 +8915,6 @@ function tl.get_types(result: Result, trenv: TypeReportEnv): TypeReport, TypeRep
       ["none"] = true,
       ["tuple"] = true,
       ["table_item"] = true,
-      ["enum_item"] = true,
    }
 
    local ft: {number:{number:number}} = {}

--- a/tl.tl
+++ b/tl.tl
@@ -5716,11 +5716,26 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       end
    end
 
+   local record Unused
+      y: number
+      x: number
+      name: string
+      var: Variable
+   end
+
    local function check_for_unused_vars(vars: {string:Variable})
-      -- do we need a stable order for these warnings?
+      local list: {Unused} = {}
       for name, var in pairs(vars) do
-         if not var.used then
-            unused_warning(name, var)
+         if var.declared_at and not var.used then
+            table.insert(list, { y = var.declared_at.y, x = var.declared_at.x, name = name, var = var })
+         end
+      end
+      if list[1] then
+         table.sort(list, function(a: Unused, b: Unused): boolean
+            return a.y < a.y or (a.y == b.y and a.x < b.x)
+         end)
+         for _, u in ipairs(list) do
+            unused_warning(u.name, u.var)
          end
       end
    end

--- a/tl.tl
+++ b/tl.tl
@@ -1207,6 +1207,7 @@ local record Node
 
    -- newtype
    newtype: Type
+   is_alias: boolean
 
    -- expressions
    op: Operator
@@ -3829,7 +3830,9 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
       ["newtype"] = {
          after = function(node: Node, _children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
-            if is_record_type(node.newtype.def) then
+            if node.is_alias then
+               table.insert(out, table.concat(node.newtype.def.names, "."))
+            elseif is_record_type(node.newtype.def) then
                table.insert(out, print_record_def(node.newtype.def))
             else
                table.insert(out, "{}")
@@ -5776,6 +5779,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          if not typetype then
             type_error(t, "unknown type %s", t)
          elseif is_typetype(typetype) then
+            assert(typetype.def.typename ~= "nominal")
             resolved = match_typevals(t, typetype.def)
          else
             type_error(t, table.concat(t.names, ".") .. " is not a type")
@@ -6723,8 +6727,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
    resolve_tuple_and_nominal = function(t: Type): Type
       t = resolve_tuple(t)
       if t.typename == "nominal" then
-         return resolve_nominal(t)
+         t = resolve_nominal(t)
       end
+      assert(t.typename ~= "nominal")
       return t
    end
 
@@ -7355,6 +7360,24 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          and node.exps[i].tk == node.vars[i].tk
    end
 
+   local function resolve_nominal_typetype(typetype: Type): Type, boolean
+      if typetype.def.typename == "nominal" then
+         if typetype.def.typevals then
+            typetype.def = resolve_nominal(typetype.def)
+            typetype.def.typeargs = nil
+         else
+            local names = typetype.def.names
+            local found = find_type(names)
+            if not is_typetype(found) then
+               type_error(typetype, "%s is not a type", typetype)
+               found = a_type { typename = "bad_nominal", names = names }
+            end
+            return found, true
+         end
+      end
+      return typetype, false
+   end
+
    local visit_node: Visitor<NodeKind, Node, Type> = {}
 
    visit_node.cbs = {
@@ -7378,16 +7401,19 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       },
       ["local_type"] = {
          before = function(node: Node)
-            add_var(node.var, node.var.tk, node.value.newtype, node.var.is_const)
+            node.value.type, node.value.is_alias = resolve_nominal_typetype(node.value.newtype)
+            add_var(node.var, node.var.tk, node.value.type, node.var.is_const)
          end,
          after = function(node: Node, _children: {Type}): Type
             dismiss_unresolved(node.var.tk)
             node.type = NONE
+            node.var.type = node.value.type
             return node.type
          end,
       },
       ["global_type"] = {
          before = function(node: Node)
+            node.value.newtype, node.value.is_alias = resolve_nominal_typetype(node.value.newtype)
             add_global(node.var, node.var.tk, node.value.newtype, node.var.is_const)
          end,
          after = function(node: Node, _children: {Type}): Type
@@ -7406,6 +7432,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
             end
             dismiss_unresolved(var.tk)
             node.type = NONE
+            node.var.type = node.value.newtype
             return node.type
          end,
       },
@@ -8325,7 +8352,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
       },
       ["newtype"] = {
          after = function(node: Node, _children: {Type}): Type
-            node.type = node.newtype
+            node.type = node.type or node.newtype
             return node.type
          end,
       },
@@ -8434,6 +8461,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          },
          ["nominal"] = {
             after = function(typ: Type, _children: {Type}): Type
+               if typ.found then
+                  return typ
+               end
+
                local t = find_type(typ.names, true)
                if t then
                   if t.typename == "typearg" then


### PR DESCRIPTION
Type inference of table literals in Teal has, until now, happened inside-out: `{{ x = 2 }}` infers `2` as `number`, then `{ x = 2 }` as a record, then `{{ x = 2 }}` as an array of that record type (or, more precisely, a tuple of length 1 where the first element is that record). When using that table in a larger statement, such as `local r: {Rec} = {{x = 2}}`, that type was then matched to check for compatibility with the declared type.

This PR introduces **bidirectional inference**. When a table literal is declared in a context that provides an expected type (such as `{Rec}` in the example above), the type inference then happens outside-in, propagating the expected type: the outer table is inferred as an array, then the inner table is inferred to be a `Rec`. This allows more precise information to be used when checking, such as comparing literal strings against enum types in record fields.

*Shouldn't both algorithms produce equivalent results?* — Yes, if the type system was sound and complete, but many type comparisons are [currently bivariant](https://stackoverflow.com/questions/57499459/what-is-bivariant-parameter-typescript#57499650), so the type checker does a better job if it uses the contextual information.

Fixes #117.
Fixes #269 (by way of #400 which is included in this PR).
Fixes #375.
Fixes #348.
A side commit also fixes #337.