### PR TITLE
[wip] tl.tl: Include a tk: string field in tl.Error + expose Token

### DIFF
--- a/spec/declaration/local_spec.lua
+++ b/spec/declaration/local_spec.lua
@@ -118,8 +118,8 @@ describe("local", function()
 
          assert.same({}, result.syntax_errors)
          assert.same({
-            { y = 3, x = 42, filename = "main.tl", msg = "in local declaration: var: unknown field dato" },
-            { y = 4, x = 26, filename = "main.tl", msg = "invalid key 'dato' in record 'var' of type Boo" },
+            { y = 3, x = 42, filename = "main.tl", msg = "in local declaration: var: unknown field dato", tk = "0" },
+            { y = 4, x = 26, filename = "main.tl", msg = "invalid key 'dato' in record 'var' of type Boo", tk = "dato" },
          }, result.type_errors)
       end)
 

--- a/spec/stdlib/require_spec.lua
+++ b/spec/stdlib/require_spec.lua
@@ -30,8 +30,8 @@ describe("require", function()
 
       assert.same(0, #result.syntax_errors)
       assert.same({
-         { filename = "foo.tl", y = 1, x = 33, msg = "no type information for required module: 'box'" },
-         { filename = "foo.tl", y = 3, x = 17, msg = "cannot index a value of unknown type" },
+         { filename = "foo.tl", y = 1, x = 33, msg = "no type information for required module: 'box'", tk = '"box"' },
+         { filename = "foo.tl", y = 3, x = 17, msg = "cannot index a value of unknown type", tk = "foo"  },
       }, result.type_errors)
       assert.same(0, #result.unknowns)
    end)

--- a/tl.lua
+++ b/tl.lua
@@ -1,7 +1,30 @@
 local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local io = _tl_compat and _tl_compat.io or io; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local load = _tl_compat and _tl_compat.load or load; local math = _tl_compat and _tl_compat.math or math; local os = _tl_compat and _tl_compat.os or os; local package = _tl_compat and _tl_compat.package or package; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local _tl_table_unpack = unpack or table.unpack
 
 
-local tl = {TypeCheckOptions = {}, Env = {}, Symbol = {}, Result = {}, Error = {}, TypeInfo = {}, TypeReport = {}, TypeReportEnv = {}, }
+local tl = {TypeCheckOptions = {}, Env = {}, Symbol = {}, Result = {}, Error = {}, TypeInfo = {}, TypeReport = {}, TypeReportEnv = {}, Token = {}, }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -198,29 +221,8 @@ local TypeInfo = tl.TypeInfo
 local TypeReport = tl.TypeReport
 local TypeReportEnv = tl.TypeReportEnv
 local Symbol = tl.Symbol
-
-
-
-
-
-local TokenKind = {}
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-local Token = {}
-
-
+local TokenKind = tl.TokenKind
+local Token = tl.Token
 
 
 
@@ -1933,6 +1935,9 @@ do
 
       while true do
          local tkop = ps.tokens[i]
+         if tkop.tk and not e1.tk then
+            e1.tk = tkop.tk
+         end
          if tkop.kind == "string" or tkop.kind == "{" then
             local op = new_operator(tkop, 2, "@funcall")
 
@@ -5143,6 +5148,7 @@ tl.type_check = function(ast, opts)
          x = where.x,
          msg = msg,
          filename = where.filename or filename,
+         tk = where.tk,
       }
    end
 
@@ -5434,6 +5440,7 @@ tl.type_check = function(ast, opts)
          msg = fmt:format(...),
          filename = filename,
          tag = tag,
+         tk = node.tk,
       })
    end
 
@@ -7309,14 +7316,14 @@ tl.type_check = function(ast, opts)
                if not found then
                   node_error(node, "module not found: '" .. module_name .. "'")
                elseif not lax and is_unknown(t) then
-                  node_error(node, "no type information for required module: '" .. module_name .. "'")
+                  node_error(node.e2[1], "no type information for required module: '" .. module_name .. "'")
                end
                return t
             else
-               node_error(node, "don't know how to resolve a dynamic require")
+               node_error(node.e2[1], "don't know how to resolve a dynamic require")
             end
          else
-            node_error(node, "require expects one literal argument")
+            node_error(node.e1, "require expects one literal argument")
          end
          return UNKNOWN
       end,

--- a/tl.tl
+++ b/tl.tl
@@ -75,6 +75,7 @@ local record tl
       x: number
       msg: string
       filename: string
+      tk: string
 
       tag: WarningKind
 
@@ -116,6 +117,28 @@ local record tl
       tr: TypeReport
    end
 
+   enum TokenKind
+      "keyword"
+      "op"
+      "string"
+      "[" "]" "(" ")" "{" "}" "," ":" "#" "`" "." ";"
+      "::"
+      "..."
+      "identifier"
+      "number"
+      "$invalid_string$"
+      "$invalid_number$"
+      "$invalid$"
+      "$EOF$"
+   end
+
+   record Token
+      x: number
+      y: number
+      i: number
+      tk: string
+      kind: TokenKind
+   end
 
 
    load: function(string, string, LoadMode, {any:any}): LoadFunction, string
@@ -198,33 +221,12 @@ local TypeInfo = tl.TypeInfo
 local TypeReport = tl.TypeReport
 local TypeReportEnv = tl.TypeReportEnv
 local Symbol = tl.Symbol
+local TokenKind = tl.TokenKind
+local Token = tl.Token
 
 --------------------------------------------------------------------------------
 -- Lexer
 --------------------------------------------------------------------------------
-
-local enum TokenKind
-   "keyword"
-   "op"
-   "string"
-   "[" "]" "(" ")" "{" "}" "," ":" "#" "`" "." ";"
-   "::"
-   "..."
-   "identifier"
-   "number"
-   "$invalid_string$"
-   "$invalid_number$"
-   "$invalid$"
-   "$EOF$"
-end
-
-local record Token
-   x: number
-   y: number
-   i: number
-   tk: string
-   kind: TokenKind
-end
 
 do
    local enum LexState
@@ -1933,6 +1935,9 @@ do
 
       while true do
          local tkop = ps.tokens[i]
+         if tkop.tk and not e1.tk then
+            e1.tk = tkop.tk
+         end
          if tkop.kind == "string" or tkop.kind == "{" then
             local op: Operator = new_operator(tkop, 2, "@funcall")
 
@@ -5143,6 +5148,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          x = where.x,
          msg = msg,
          filename = where.filename or filename,
+         tk = where.tk,
       }
    end
 
@@ -5434,6 +5440,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
          msg = fmt:format(...),
          filename = filename,
          tag = tag,
+         tk = node.tk,
       })
    end
 
@@ -7309,14 +7316,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): {Error}, {Error}, T
                if not found then
                   node_error(node, "module not found: '" .. module_name .. "'")
                elseif not lax and is_unknown(t) then
-                  node_error(node, "no type information for required module: '" .. module_name .. "'")
+                  node_error(node.e2[1], "no type information for required module: '" .. module_name .. "'")
                end
                return t
             else
-               node_error(node, "don't know how to resolve a dynamic require")
+               node_error(node.e2[1], "don't know how to resolve a dynamic require")
             end
          else
-            node_error(node, "require expects one literal argument")
+            node_error(node.e1, "require expects one literal argument")
          end
          return UNKNOWN
       end,


### PR DESCRIPTION
Most of the token information was already present in tl.Error, now just
include the string as well for tooling like cyan, so they don't have to
search for the token to get the length/content of it.

Also expose Token and TokenKind as tl.Token and tl.TokenKind since they
are relatively simple types.