### PR TITLE
metamethod support for __tostring, __pairs, __gc

### DIFF
--- a/spec/metamethods/tostring_spec.lua
+++ b/spec/metamethods/tostring_spec.lua
@@ -1,0 +1,36 @@
+local util = require("spec.util")
+
+describe("unary metamethod __tostring", function()
+   it("can be set on a record", util.check [[
+      local type Rec = record
+         x: number
+         metamethod __tostring: function(Rec): string
+      end
+
+      local rec_mt: metatable<Rec>
+      rec_mt = {
+         __tostring = function(self: Rec): string
+            return "Rec {x: " .. tostring(self.x) .. "}"
+         end,
+      }
+
+      local r = setmetatable({ x = 10 } as Rec, rec_mt)
+      print(r)
+   ]])
+
+   it("can be used on a record prototype", util.check [[
+      local record A
+         value: number
+         metamethod __tostring: function(A): string
+      end
+      local A_mt: metatable<A>
+      A_mt = {
+         __tostring = function(a: A): string
+            return "A { value: " .. tostring(a.value) .. " }"
+         end,
+      }
+
+      A.value = 10
+      print(A)
+   ]])
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -2508,6 +2508,9 @@ local metamethod_names = {
    ["__index"] = true,
    ["__newindex"] = true,
    ["__call"] = true,
+   ["__tostring"] = true,
+   ["__pairs"] = true,
+   ["__gc"] = true,
 }
 
 parse_record_body = function(ps, i, def, node)

--- a/tl.tl
+++ b/tl.tl
@@ -2508,6 +2508,9 @@ local metamethod_names: {string:boolean} = {
    ["__index"] = true,
    ["__newindex"] = true,
    ["__call"] = true,
+   ["__tostring"] = true,
+   ["__pairs"] = true,
+   ["__gc"] = true,
 }
 
 parse_record_body = function(ps: ParseState, i: integer, def: Type, node: Node): integer, Node


### PR DESCRIPTION
This seems like an omission in #299. I couldn't find an obvious reason why it wasn't included on that PR. But the tests seem happy, so here it is :)

Related with #224 