### PR TITLE
Fix tlconfig def env

### DIFF
--- a/spec/cli/global_env_def_spec.lua
+++ b/spec/cli/global_env_def_spec.lua
@@ -56,7 +56,7 @@ describe("--global-env-def argument", function()
          assert.match("Error:", output, 1, true)
       end)
    end)
-   pending("reads global_env_def from tlconfig.lua", function ()
+   it("reads global_env_def from tlconfig.lua", function ()
       util.do_in(util.write_tmp_dir(finally, {
          mod = {
             ["add.tl"] = [[

--- a/spec/cli/global_env_def_spec.lua
+++ b/spec/cli/global_env_def_spec.lua
@@ -56,4 +56,32 @@ describe("--global-env-def argument", function()
          assert.match("Error:", output, 1, true)
       end)
    end)
+   pending("reads global_env_def from tlconfig.lua", function ()
+      util.do_in(util.write_tmp_dir(finally, {
+         mod = {
+            ["add.tl"] = [[
+               function add(n: number, m: number): number
+                   return n + m
+               end
+
+               return add
+            ]],
+         },
+         ["test.tl"] = [[
+            print(add(10, 20))
+         ]],
+         ["tlconfig.lua"] = [[
+         return {
+            global_env_def = "mod.add",
+         }
+         ]],
+      }), function()
+         local pd = io.popen(util.tl_cmd("check", "test.tl"), "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(0, pd:close())
+         assert.match("0 errors detected", output, 1, true)
+      end)
+
+   end);
+
 end)

--- a/tl
+++ b/tl
@@ -948,8 +948,9 @@ local function merge_config_and_args(tlconfig, args)
    if args["global_env_def"] then
       if #args["global_env_def"] > 1 then
          die("Error: --global-env-def can be used only once.")
+      elseif args["global_env_def"][1] then
+         tlconfig["global_env_def"] = args["global_env_def"][1]
       end
-      tlconfig["global_env_def"] = args["global_env_def"][1]
    end
 
    for _, include_dir_cli in ipairs(args["include_dir"]) do


### PR DESCRIPTION
`global_env_def` in `tlconfig.lua` had no effect, but the `--global-env-def` option worked. Found that the value from the config file was getting overwritten with the first item from the command line argument, even if there were zero such arguments.

Test case copied and modified version of the first test case in that spec file.

Curious that `args[]` fields end up with empty arrays like this.

Alternate solution could be to set `:count("?")`, but this behaves slightly differently.