### PR TITLE
Error messages now report proper `...`

### DIFF
--- a/spec/varargs/type_base_spec.lua
+++ b/spec/varargs/type_base_spec.lua
@@ -8,6 +8,6 @@ describe("type base", function()
 
       f = 2
    ]], {
-      { msg = "in assignment: got integer, expected function(number, string...): string..." }
+      { msg = "in assignment: got integer, expected function(number, ...: string): string..." }
    }))
 end)

--- a/spec/varargs/type_base_spec.lua
+++ b/spec/varargs/type_base_spec.lua
@@ -1,0 +1,13 @@
+local util = require("spec.util")
+
+describe("type base", function()
+   it("reports vararg functions with proper `...` within errors (regression test for #340)", util.check_type_error([[
+      local function f(x: number, ...: string): string...
+         return ...
+      end
+
+      f = 2
+   ]], {
+      { msg = "in assignment: got integer, expected function(number, string...): string..." }
+   }))
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -4370,7 +4370,7 @@ local function show_type_base(t, short, seen)
       end
       for i, v in ipairs(t.args) do
          if not t.is_method or i > 1 then
-            table.insert(args, show(v))
+            table.insert(args, show(v) .. (i == #t.args and t.args.is_va and "..." or ""))
          end
       end
       table.insert(out, table.concat(args, ", "))
@@ -4378,8 +4378,8 @@ local function show_type_base(t, short, seen)
       if #t.rets > 0 then
          table.insert(out, ": ")
          local rets = {}
-         for _, v in ipairs(t.rets) do
-            table.insert(rets, show(v))
+         for i, v in ipairs(t.rets) do
+            table.insert(rets, show(v) .. (i == #t.rets and t.rets.is_va and "..." or ""))
          end
          table.insert(out, table.concat(rets, ", "))
       end

--- a/tl.lua
+++ b/tl.lua
@@ -4370,7 +4370,7 @@ local function show_type_base(t, short, seen)
       end
       for i, v in ipairs(t.args) do
          if not t.is_method or i > 1 then
-            table.insert(args, show(v) .. (i == #t.args and t.args.is_va and "..." or ""))
+            table.insert(args, (i == #t.args and t.args.is_va and "...: " or "") .. show(v))
          end
       end
       table.insert(out, table.concat(args, ", "))

--- a/tl.tl
+++ b/tl.tl
@@ -4370,7 +4370,7 @@ local function show_type_base(t: Type, short: boolean, seen: {Type:string}): str
       end
       for i, v in ipairs(t.args) do
          if not t.is_method or i > 1 then
-            table.insert(args, show(v))
+            table.insert(args, show(v) .. (i == #t.args and t.args.is_va and "..." or ""))
          end
       end
       table.insert(out, table.concat(args, ", "))
@@ -4378,8 +4378,8 @@ local function show_type_base(t: Type, short: boolean, seen: {Type:string}): str
       if #t.rets > 0 then
          table.insert(out, ": ")
          local rets = {}
-         for _, v in ipairs(t.rets) do
-            table.insert(rets, show(v))
+         for i, v in ipairs(t.rets) do
+            table.insert(rets, show(v) .. (i == #t.rets and t.rets.is_va and "..." or ""))
          end
          table.insert(out, table.concat(rets, ", "))
       end

--- a/tl.tl
+++ b/tl.tl
@@ -4370,7 +4370,7 @@ local function show_type_base(t: Type, short: boolean, seen: {Type:string}): str
       end
       for i, v in ipairs(t.args) do
          if not t.is_method or i > 1 then
-            table.insert(args, show(v) .. (i == #t.args and t.args.is_va and "..." or ""))
+            table.insert(args, (i == #t.args and t.args.is_va and "...: " or "") .. show(v))
          end
       end
       table.insert(out, table.concat(args, ", "))


### PR DESCRIPTION
This PR tweaks the output of `show_type_base` to fix issue #340.

Before:
```lua
function(number, string): string
```

After:
```lua
function(number, string...): string...
```