### PR TITLE
Allows error() arg1 to be anything, not just a string.

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -4733,7 +4733,7 @@ local function init_globals(lax)
          },
       }),
       ["dofile"] = a_type({ typename = "function", args = TUPLE({ OPT_STRING }), rets = VARARG({ ANY }) }),
-      ["error"] = a_type({ typename = "function", args = TUPLE({ STRING, NUMBER }), rets = TUPLE({}) }),
+      ["error"] = a_type({ typename = "function", args = TUPLE({ ANY, NUMBER }), rets = TUPLE({}) }),
       ["getmetatable"] = a_type({ typename = "function", typeargs = TUPLE({ ARG_ALPHA }), args = TUPLE({ ALPHA }), rets = TUPLE({ NOMINAL_METATABLE_OF_ALPHA }) }),
       ["ipairs"] = a_type({ typename = "function", typeargs = TUPLE({ ARG_ALPHA }), args = TUPLE({ ARRAY_OF_ALPHA }), rets = TUPLE({
          a_type({ typename = "function", args = TUPLE({}), rets = TUPLE({ INTEGER, ALPHA }) }),

--- a/tl.tl
+++ b/tl.tl
@@ -4733,7 +4733,7 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
          }
       },
       ["dofile"] = a_type { typename = "function", args = TUPLE { OPT_STRING }, rets = VARARG { ANY } },
-      ["error"] = a_type { typename = "function", args = TUPLE { STRING, NUMBER }, rets = TUPLE {} },
+      ["error"] = a_type { typename = "function", args = TUPLE { ANY, NUMBER }, rets = TUPLE {} },
       ["getmetatable"] = a_type { typename = "function", typeargs = TUPLE { ARG_ALPHA }, args = TUPLE { ALPHA }, rets = TUPLE { NOMINAL_METATABLE_OF_ALPHA } },
       ["ipairs"] = a_type { typename = "function", typeargs = TUPLE { ARG_ALPHA }, args = TUPLE { ARRAY_OF_ALPHA }, rets = TUPLE {
          a_type { typename = "function", args = TUPLE {}, rets = TUPLE { INTEGER, ALPHA } },


### PR DESCRIPTION
Addresses Issue #436.

I can supply an example file demonstrating that with the fix error() will accept a table as arg1.