### PR TITLE
added integer examples and a section on integers to docs/tutorial.md

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -12,7 +12,7 @@ part. :)
 
 The data in your program has types: Lua is a high-level language, so each
 piece of data stored in the memory of the Lua virtual machine has a type:
-integer, number, string, function, boolean, userdata, thread, nil or table.
+number, string, function, boolean, userdata, thread, nil or table.
 
 Your program is basically a series of manipulations of data of various types.
 The program is correct when it does what it is supposed to do, and that will
@@ -134,10 +134,13 @@ These are the basic types in Teal:
 * `any`
 * `nil`
 * `boolean`
-* `integer` (sub-type of number)
+* `integer`
 * `number`
 * `string`
 * `thread` (coroutine)
+
+Note: An `integer` is a sub-type of number; it is of undefined precision,
+deferring to the Lua VM.
 
 You can also declare more types using type constructors. This is the summary
 list with a few examples of each; we'll discuss them in more detail below:
@@ -880,51 +883,6 @@ local function do_something(p: MyPoint)
    -- ...
 end
 ```
-## Integers and numbers
-
-The integer sub-type was added with release 0.13.0. It is of undefined
-precision, deferring to the Lua VM.
-
-* integer constants without a dot (e.g. 123) are of type integer
-* operations preserve the integer type according to Lua 5.4 semantics (e.g.
-  `integer + integer = integer`, `integer + number = number`, etc.)
-* `integer` is a subtype of `number`
-   * this generally means that an `integer` is accepted everywhere a `number` is
-     expected
-   * note that this does not extend to type variables in generics, which are
-     invariant: `Foo<integer>` is not the same as `Foo<number>`
-   * if a variable is of type `integer`, then an arbitrary `number` is not
-     accepted
-     * `local x: integer = 1.0` doesn't work, even though the floating-point
-       number has a valid integer representation
-* variables (and type variables) are inferred as integer when initialized with
-  integers
-  * this can happen directly (`local x = 1`) or indirectly (`local x =
-    math.min(i, j)`)
-  * to infer an integral value as a `number`, use .0: `local x = 1.0` infers a
-    `number`
-
-### Integers and the standard library
-
-The standard library was annotated for integers.
-
-* it returns integers and numbers as it makes sense. Recall that integers are
-  numbers in Lua and will be reported as such when using the function `type()`.
-  Using `math.type()` will report "integer".
- 
-* For example:
-  * `local x = math.random(1,6)` returns an integer; using the "is" operator we
-    see:
-     * `x is integer    -- true`
-     * `x is number     -- true` 
-  * `math.sin(x)` returns a number
-
-* it always accepts floats in arguments that must be integral — this matches the
-  behavior of the Lua standard library implementation: wherever you need to pass
-  an integral value, you can pass an equivalent float with an integer
-  representation, e.g.  `table.insert(t, 1.0, "hello")` — therefore, this is
-  also valid in Teal, but note that the validity of the float is not checked at
-  compile time, this is a Lua standard library API check.
 
 ## The Teal Standard Library and Lua compatibility
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -12,7 +12,7 @@ part. :)
 
 The data in your program has types: Lua is a high-level language, so each
 piece of data stored in the memory of the Lua virtual machine has a type:
-number, string, function, boolean, userdata, thread, nil or table.
+integer, number, string, function, boolean, userdata, thread, nil or table.
 
 Your program is basically a series of manipulations of data of various types.
 The program is correct when it does what it is supposed to do, and that will
@@ -134,6 +134,7 @@ These are the basic types in Teal:
 * `any`
 * `nil`
 * `boolean`
+* `integer` (sub-type of number)
 * `number`
 * `string`
 * `thread` (coroutine)
@@ -142,7 +143,7 @@ You can also declare more types using type constructors. This is the summary
 list with a few examples of each; we'll discuss them in more detail below:
 
 * arrays - `{number}`, `{{number}}`
-* tuples - `{number, number, string}`
+* tuples - `{number, integer, string}`
 * maps - `{string:boolean}`
 * functions - `function(number, string): {number}, string`
 
@@ -297,7 +298,7 @@ Another common usage of tables in Lua are tuples: tables containing an ordered s
 of elements of known types assigned to its integer keys.
 
 ```
--- Tuples of type {string, number} containing names and ages
+-- Tuples of type {string, integer} containing names and ages
 local p1 = { "Anna", 15 }
 local p2 = { "Bob", 37 }
 local p3 = { "Chris", 65 }
@@ -308,7 +309,8 @@ inferred, and trying to go out of range will produce an error.
 
 ```
 local age_of_p1: number = p1[2] -- no type errors here
-local nonsense = p1[3] -- error! index 3 out of range for tuple {1: string, 2: number}
+local nonsense = p1[3] -- error! index 3 out of range for tuple {1: string, 2:
+integer}
 ```
 
 When indexing with a `number` variable, Teal will do its best by making a
@@ -330,7 +332,7 @@ elements than they expect (as long as their length is explicitly annotated and n
 inferred).
 
 ```
-local p4: {string, number} = { "Delilah", 32, false } -- error! expected maximum length of 2, got 3
+local p4: {string, integer} = { "Delilah", 32, false } -- error! expected maximum length of 2, got 3
 ```
 
 One thing to keep in mind when using tuples versus arrays is type inference,
@@ -878,6 +880,51 @@ local function do_something(p: MyPoint)
    -- ...
 end
 ```
+## Integers and numbers
+
+The integer sub-type was added with release 0.13.0. It is of undefined
+precision, deferring to the Lua VM.
+
+* integer constants without a dot (e.g. 123) are of type integer
+* operations preserve the integer type according to Lua 5.4 semantics (e.g.
+  `integer + integer = integer`, `integer + number = number`, etc.)
+* `integer` is a subtype of `number`
+   * this generally means that an `integer` is accepted everywhere a `number` is
+     expected
+   * note that this does not extend to type variables in generics, which are
+     invariant: `Foo<integer>` is not the same as `Foo<number>`
+   * if a variable is of type `integer`, then an arbitrary `number` is not
+     accepted
+     * `local x: integer = 1.0` doesn't work, even though the floating-point
+       number has a valid integer representation
+* variables (and type variables) are inferred as integer when initialized with
+  integers
+  * this can happen directly (`local x = 1`) or indirectly (`local x =
+    math.min(i, j)`)
+  * to infer an integral value as a `number`, use .0: `local x = 1.0` infers a
+    `number`
+
+### Integers and the standard library
+
+The standard library was annotated for integers.
+
+* it returns integers and numbers as it makes sense. Recall that integers are
+  numbers in Lua and will be reported as such when using the function `type()`.
+  Using `math.type()` will report "integer".
+ 
+* For example:
+  * `local x = math.random(1,6)` returns an integer; using the "is" operator we
+    see:
+     * `x is integer    -- true`
+     * `x is number     -- true` 
+  * `math.sin(x)` returns a number
+
+* it always accepts floats in arguments that must be integral — this matches the
+  behavior of the Lua standard library implementation: wherever you need to pass
+  an integral value, you can pass an equivalent float with an integer
+  representation, e.g.  `table.insert(t, 1.0, "hello")` — therefore, this is
+  also valid in Teal, but note that the validity of the float is not checked at
+  compile time, this is a Lua standard library API check.
 
 ## The Teal Standard Library and Lua compatibility
 


### PR DESCRIPTION
Updated docs/tutorial.md to include references to integers. The *vast* majority of the added language is from Hisham's 0.13.0 release notes. Any mistakes in interpreting them are mine and not his.

The kinds of changes:
* In a few places that had examples, replaced 'number' with 'integer'
* Add a section near the end; the body of which is moslty release note text.