### PR TITLE
teal now accepts table as input to os.time

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -5035,7 +5035,13 @@ rets = TUPLE({ a_type({ typename = "function", args = TUPLE({}), rets = TUPLE({ 
             ["remove"] = a_type({ typename = "function", args = TUPLE({ STRING }), rets = TUPLE({ BOOLEAN, STRING }) }),
             ["rename"] = a_type({ typename = "function", args = TUPLE({ STRING, STRING }), rets = TUPLE({ BOOLEAN, STRING }) }),
             ["setlocale"] = a_type({ typename = "function", args = TUPLE({ STRING, OPT_STRING }), rets = TUPLE({ STRING }) }),
-            ["time"] = a_type({ typename = "function", args = TUPLE({}), rets = TUPLE({ INTEGER }) }),
+            ["time"] = a_type({
+               typename = "poly",
+               types = {
+                  a_type({ typename = "function", args = TUPLE({}), rets = TUPLE({ INTEGER }) }),
+                  a_type({ typename = "function", args = TUPLE({ OS_DATE_TABLE }), rets = TUPLE({ INTEGER }) }),
+               },
+            }),
             ["tmpname"] = a_type({ typename = "function", args = TUPLE({}), rets = TUPLE({ STRING }) }),
          },
       }),

--- a/tl.tl
+++ b/tl.tl
@@ -5035,7 +5035,13 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
             ["remove"] = a_type { typename = "function", args = TUPLE { STRING }, rets = TUPLE { BOOLEAN, STRING } },
             ["rename"] = a_type { typename = "function", args = TUPLE { STRING, STRING}, rets = TUPLE { BOOLEAN, STRING } },
             ["setlocale"] = a_type { typename = "function", args = TUPLE { STRING, OPT_STRING}, rets = TUPLE { STRING } },
-            ["time"] = a_type { typename = "function", args = TUPLE {}, rets = TUPLE { INTEGER } }, -- TODO table argument
+            ["time"] = a_type {
+               typename = "poly",
+               types = {
+                  a_type { typename = "function", args = TUPLE {}, rets = TUPLE { INTEGER } },
+                  a_type { typename = "function", args = TUPLE {OS_DATE_TABLE}, rets = TUPLE { INTEGER } },
+               }
+            },
             ["tmpname"] = a_type { typename = "function", args = TUPLE {}, rets = TUPLE { STRING } },
          },
       },


### PR DESCRIPTION
This addresses #443.
In tl.tl used os.date as template; now os.time fulfills the Lua 5.4 manual:
os.time([table])