### PR TITLE
Catch implicit redeclarations

### DIFF
--- a/spec/error_reporting/warning_spec.lua
+++ b/spec/error_reporting/warning_spec.lua
@@ -93,6 +93,26 @@ describe("warnings", function()
          end
          foo()
       ]], { }))
+
+      it("reports when implicitly declared variables redeclare a local (for loop)", util.check_warnings([[
+         local i = 1
+         for i = 1, 10 do
+            print(i)
+         end
+      ]], {
+         { y = 2, msg = "redeclaration of variable 'i' (originally declared at 1:16)" },
+         { y = 1, msg = "unused variable i: integer" },
+      }))
+
+      it("reports when implicitly declared variables redeclare a local (function arg)", util.check_warnings([[
+         local i = 1
+         local function _foo(i: integer)
+            print(i)
+         end
+      ]], {
+         { y = 2, msg = "redeclaration of variable 'i' (originally declared at 1:16)" },
+         { y = 1, msg = "unused variable i: integer" },
+      }))
    end)
 
    describe("on goto labels", function()

--- a/tl.lua
+++ b/tl.lua
@@ -2154,8 +2154,8 @@ end
 parse_argument_list = function(ps, i)
    local node = new_node(ps.tokens, i, "argument_list")
    i, node = parse_bracket_list(ps, i, node, "(", ")", "sep", parse_argument)
-   for a, arg in ipairs(node) do
-      if arg.tk == "..." and a ~= #node then
+   for a, fnarg in ipairs(node) do
+      if fnarg.tk == "..." and a ~= #node then
          fail(ps, i, "'...' can only be last argument")
       end
    end
@@ -3438,7 +3438,7 @@ function tl.pretty_print_ast(ast, mode)
       end
    end
 
-   local function add_child(out, child, space, indent)
+   local function add_child(out, child, space, current_indent)
       if #child == 0 then
          return
       end
@@ -3456,11 +3456,11 @@ function tl.pretty_print_ast(ast, mode)
             if space ~= "" then
                table.insert(out, space)
             end
-            indent = nil
+            current_indent = nil
          end
       end
-      if indent and opts.preserve_indent then
-         table.insert(out, ("   "):rep(indent))
+      if current_indent and opts.preserve_indent then
+         table.insert(out, ("   "):rep(current_indent))
       end
       table.insert(out, child)
       out.h = out.h + child.h
@@ -4278,8 +4278,8 @@ local function show_type_base(t, short, seen)
    end
    seen[t] = "..."
 
-   local function show(t)
-      return show_type(t, short, seen)
+   local function show(typ)
+      return show_type(typ, short, seen)
    end
 
    if t.typename == "nominal" then
@@ -5905,9 +5905,9 @@ tl.type_check = function(ast, opts)
          local upper = st[#st - 1]["@unresolved"]
          if upper then
             for name, nodes in pairs(unresolved.t.labels) do
-               for _, node in ipairs(nodes) do
+               for _, n in ipairs(nodes) do
                   upper.t.labels[name] = upper.t.labels[name] or {}
-                  table.insert(upper.t.labels[name], node)
+                  table.insert(upper.t.labels[name], n)
                end
             end
             for name, types in pairs(unresolved.t.nominals) do
@@ -6670,9 +6670,9 @@ tl.type_check = function(ast, opts)
 
       local function revert_typeargs(func)
          if func.typeargs then
-            for _, arg in ipairs(func.typeargs) do
-               if st[#st][arg.typearg] then
-                  st[#st][arg.typearg] = nil
+            for _, fnarg in ipairs(func.typeargs) do
+               if st[#st][fnarg.typearg] then
+                  st[#st][fnarg.typearg] = nil
                end
             end
          end
@@ -6904,8 +6904,8 @@ tl.type_check = function(ast, opts)
 
    local function add_function_definition_for_recursion(node)
       local args = a_type({ typename = "tuple" })
-      for _, arg in ipairs(node.args) do
-         table.insert(args, arg.type)
+      for _, fnarg in ipairs(node.args) do
+         table.insert(args, fnarg.type)
       end
 
       add_var(nil, node.name.tk, a_type({
@@ -7167,8 +7167,8 @@ tl.type_check = function(ast, opts)
    local FACT_TRUTHY
    do
       setmetatable(Fact, {
-         __call = function(_, f)
-            return setmetatable(f, {
+         __call = function(_, fact)
+            return setmetatable(fact, {
                __tostring = function(f)
                   if f.fact == "is" then
                      return ("(%s is %s)"):format(f.var, show_type(f.typ))
@@ -7512,8 +7512,8 @@ tl.type_check = function(ast, opts)
          if #b == 0 then
 
             print("-----------------------------------------")
-            for i, s in ipairs(st) do
-               for s, v in pairs(s) do
+            for i, scope in ipairs(st) do
+               for s, v in pairs(scope) do
                   print(("%2d %-14s %-11s %s"):format(i, s, v.t.typename, show_type(v.t):sub(1, 50)))
                end
             end
@@ -9078,13 +9078,13 @@ function tl.get_types(result, trenv)
 
    local function store_function(ti, rt)
       local args = {}
-      for _, arg in ipairs(rt.args) do
-         table.insert(args, mark_array({ get_typenum(arg), nil }))
+      for _, fnarg in ipairs(rt.args) do
+         table.insert(args, mark_array({ get_typenum(fnarg), nil }))
       end
       ti.args = mark_array(args)
       local rets = {}
-      for _, arg in ipairs(rt.rets) do
-         table.insert(rets, mark_array({ get_typenum(arg), nil }))
+      for _, fnarg in ipairs(rt.rets) do
+         table.insert(rets, mark_array({ get_typenum(fnarg), nil }))
       end
       ti.rets = mark_array(rets)
       ti.vararg = not not rt.is_va
@@ -9262,12 +9262,12 @@ function tl.get_types(result, trenv)
 end
 
 function tl.symbols_in_scope(tr, y, x)
-   local function find(symbols, y, x)
+   local function find(symbols, at_y, at_x)
       local function le(a, b)
          return a[1] < b[1] or
          (a[1] == b[1] and a[2] <= b[2])
       end
-      return binary_search(symbols, { y, x }, le) or 0
+      return binary_search(symbols, { at_y, at_x }, le) or 0
    end
 
    local ret = {}

--- a/tl.tl
+++ b/tl.tl
@@ -2154,8 +2154,8 @@ end
 parse_argument_list = function(ps: ParseState, i: integer): integer, Node
    local node = new_node(ps.tokens, i, "argument_list")
    i, node = parse_bracket_list(ps, i, node, "(", ")", "sep", parse_argument)
-   for a, arg in ipairs(node) do
-      if arg.tk == "..." and a ~= #node then
+   for a, fnarg in ipairs(node) do
+      if fnarg.tk == "..." and a ~= #node then
          fail(ps, i, "'...' can only be last argument")
       end
    end
@@ -3438,7 +3438,7 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
       end
    end
 
-   local function add_child(out: Output, child: Output, space: string, indent: integer): integer
+   local function add_child(out: Output, child: Output, space: string, current_indent: integer): integer
       if #child == 0 then
          return
       end
@@ -3456,11 +3456,11 @@ function tl.pretty_print_ast(ast: Node, mode: boolean | PrettyPrintOpts): string
             if space ~= "" then
                table.insert(out, space)
             end
-            indent = nil
+            current_indent = nil
          end
       end
-      if indent and opts.preserve_indent then
-         table.insert(out, ("   "):rep(indent))
+      if current_indent and opts.preserve_indent then
+         table.insert(out, ("   "):rep(current_indent))
       end
       table.insert(out, child as string)
       out.h = out.h + child.h
@@ -4278,8 +4278,8 @@ local function show_type_base(t: Type, short: boolean, seen: {Type:string}): str
    end
    seen[t] = "..."
 
-   local function show(t: Type): string
-      return show_type(t, short, seen)
+   local function show(typ: Type): string
+      return show_type(typ, short, seen)
    end
 
    if t.typename == "nominal" then
@@ -5905,9 +5905,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
          local upper = st[#st - 1]["@unresolved"]
          if upper then
             for name, nodes in pairs(unresolved.t.labels) do
-               for _, node in ipairs(nodes) do
+               for _, n in ipairs(nodes) do
                   upper.t.labels[name] = upper.t.labels[name] or {}
-                  table.insert(upper.t.labels[name], node)
+                  table.insert(upper.t.labels[name], n)
                end
             end
             for name, types in pairs(unresolved.t.nominals) do
@@ -6670,9 +6670,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
 
       local function revert_typeargs(func: Type)
          if func.typeargs then
-            for _, arg in ipairs(func.typeargs) do
-               if st[#st][arg.typearg] then
-                  st[#st][arg.typearg] = nil
+            for _, fnarg in ipairs(func.typeargs) do
+               if st[#st][fnarg.typearg] then
+                  st[#st][fnarg.typearg] = nil
                end
             end
          end
@@ -6904,8 +6904,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
 
    local function add_function_definition_for_recursion(node: Node)
       local args: Type = a_type { typename = "tuple" }
-      for _, arg in ipairs(node.args) do
-         table.insert(args, arg.type)
+      for _, fnarg in ipairs(node.args) do
+         table.insert(args, fnarg.type)
       end
 
       add_var(nil, node.name.tk, a_type {
@@ -7167,8 +7167,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
    local FACT_TRUTHY: Fact
    do
       setmetatable(Fact, {
-         __call = function(_: Fact, f: Fact): Fact
-            return setmetatable(f, {
+         __call = function(_: Fact, fact: Fact): Fact
+            return setmetatable(fact, {
                __tostring = function(f: Fact): string
                   if f.fact == "is" then
                      return ("(%s is %s)"):format(f.var, show_type(f.typ))
@@ -7512,8 +7512,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
          if #b == 0 then
             -- when called with no arguments, print all variables currently in scope and their types.
             print("-----------------------------------------")
-            for i, s in ipairs(st) do
-               for s, v in pairs(s) do
+            for i, scope in ipairs(st) do
+               for s, v in pairs(scope) do
                   print(("%2d %-14s %-11s %s"):format(i, s, v.t.typename, show_type(v.t):sub(1, 50)))
                end
             end
@@ -9078,13 +9078,13 @@ function tl.get_types(result: Result, trenv: TypeReportEnv): TypeReport, TypeRep
 
    local function store_function(ti: TypeInfo, rt: Type)
       local args: {{integer, string}} = {}
-      for _, arg in ipairs(rt.args) do
-         table.insert(args, mark_array { get_typenum(arg), nil })
+      for _, fnarg in ipairs(rt.args) do
+         table.insert(args, mark_array { get_typenum(fnarg), nil })
       end
       ti.args = mark_array(args)
       local rets: {{integer, string}} = {}
-      for _, arg in ipairs(rt.rets) do
-         table.insert(rets, mark_array { get_typenum(arg), nil })
+      for _, fnarg in ipairs(rt.rets) do
+         table.insert(rets, mark_array { get_typenum(fnarg), nil })
       end
       ti.rets = mark_array(rets)
       ti.vararg = not not rt.is_va
@@ -9262,12 +9262,12 @@ function tl.get_types(result: Result, trenv: TypeReportEnv): TypeReport, TypeRep
 end
 
 function tl.symbols_in_scope(tr: TypeReport, y: integer, x: integer): {string:integer}
-   local function find(symbols: {{integer, integer, string, integer}}, y: integer, x: integer): integer
+   local function find(symbols: {{integer, integer, string, integer}}, at_y: integer, at_x: integer): integer
       local function le(a: {integer, integer}, b: {integer, integer}): boolean
          return a[1] < b[1]
             or (a[1] == b[1] and a[2] <= b[2])
       end
-      return binary_search(symbols, {y, x}, le) or 0
+      return binary_search(symbols, {at_y, at_x}, le) or 0
    end
 
    local ret: {string:integer} = {}

--- a/tl.tl
+++ b/tl.tl
@@ -5614,6 +5614,13 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
       end
    end
 
+   local function check_if_redeclaration(new_name: string, at: Node)
+      local old <const> = find_var(new_name, true)
+      if old then
+         redeclaration_warning(at, old)
+      end
+   end
+
    local function unused_warning(name: string, var: Variable)
       local prefix <const> = name:sub(1,1)
       if var.declared_at
@@ -5652,7 +5659,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
       node.symbol_list_slot = symbol_list_n
    end
 
-   local function add_var(node: Node, var: string, valtype: Type, is_const: boolean, is_narrowing: boolean): Variable
+   local function add_var(node: Node, var: string, valtype: Type, is_const: boolean, is_narrowing: boolean, dont_check_redeclaration): Variable
       if lax and node and is_unknown(valtype) and (var ~= "self" and var ~= "...") and not is_narrowing then
          add_unknown(node, var)
       end
@@ -5669,6 +5676,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
          old_var.is_narrowed = true
          old_var.t = valtype
       else
+         if not dont_check_redeclaration
+            and node
+            and not is_narrowing
+            and var ~= "self"
+            and var ~= "..."
+            and var:sub(1, 1) ~= "@"
+         then
+            check_if_redeclaration(var, node)
+         end
          scope[var] = { t = valtype, is_const = is_const, is_narrowed = is_narrowing, declared_at = node }
          if old_var then
             -- the old var is removed from the scope and won't be checked when it closes,
@@ -7883,15 +7899,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
                end
                t.inferred_len = nil
 
-               do
-                  local old_var <const> = find_var(var.tk, true)
-                  if old_var and not is_localizing_a_variable(node, i) then
-                     redeclaration_warning(var, old_var)
-                  end
-               end
-
                assert(var)
-               add_var(var, var.tk, t, var.is_const)
+               add_var(var, var.tk, t, var.is_const, is_localizing_a_variable(node, i))
 
                dismiss_unresolved(var.tk)
             end


### PR DESCRIPTION
This moves the check for redeclarations into `add_var` so implicit declarations in things like for loops and function arguments get caught