### PR TITLE
numeric literals allow '_' as separator

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -480,8 +480,6 @@ do
          else
 
          end
-         print("JRP: debug strip_under(): kind = ", kind)
-         print("JRP: debug strip_under(): res/tk = ", res, tk)
          return res
       end
 
@@ -508,10 +506,6 @@ do
             tk = tk,
             kind = keywords[tk] and "keyword" or "identifier",
          }
-         print("JRP: debug end_token_identifier(): kind = ",
-         tokens[nt].kind)
-         print("JRP: debug end_token_identifier(): tk = ",
-         tokens[nt].tk)
          in_token = false
       end
 

--- a/tl.lua
+++ b/tl.lua
@@ -369,6 +369,7 @@ do
    for c = string.byte("0"), string.byte("9") do
       lex_decimals[string.char(c)] = true
    end
+   lex_decimals["_"] = true
 
    local lex_hexadecimals = {}
    for c = string.byte("0"), string.byte("9") do
@@ -380,6 +381,7 @@ do
    for c = string.byte("A"), string.byte("F") do
       lex_hexadecimals[string.char(c)] = true
    end
+   lex_hexadecimals["_"] = true
 
    local lex_any_char_kinds = {}
    local single_char_kinds = { "[", "]", "(", ")", "{", "}", ",", "#", "`", ";" }
@@ -470,7 +472,19 @@ do
          in_token = true
       end
 
+
+      local function strip_under(kind, tk)
+         local res = tk
+         if kind == "integer" or kind == "number" then
+            res = tk:gsub("_", "")
+         else
+
+         end
+         return res
+      end
+
       local function end_token(kind, tk)
+         tk = strip_under(kind, tk)
          nt = nt + 1
          tokens[nt] = {
             x = tx,
@@ -497,6 +511,7 @@ do
 
       local function end_token_prev(kind)
          local tk = input:sub(ti, i - 1)
+         tk = strip_under(kind, tk)
          nt = nt + 1
          tokens[nt] = {
             x = tx,
@@ -510,6 +525,7 @@ do
 
       local function end_token_here(kind)
          local tk = input:sub(ti, i)
+         tk = strip_under(kind, tk)
          nt = nt + 1
          tokens[nt] = {
             x = tx,

--- a/tl.lua
+++ b/tl.lua
@@ -480,6 +480,8 @@ do
          else
 
          end
+         print("JRP: debug strip_under(): kind = ", kind)
+         print("JRP: debug strip_under(): res/tk = ", res, tk)
          return res
       end
 
@@ -506,6 +508,10 @@ do
             tk = tk,
             kind = keywords[tk] and "keyword" or "identifier",
          }
+         print("JRP: debug end_token_identifier(): kind = ",
+         tokens[nt].kind)
+         print("JRP: debug end_token_identifier(): tk = ",
+         tokens[nt].tk)
          in_token = false
       end
 
@@ -619,7 +625,8 @@ do
          elseif state == "got ." then
             if c == "." then
                state = "got .."
-            elseif lex_decimals[c] then
+            elseif lex_decimals[c] and state == "number dec" then
+
                state = "number decfloat"
             else
                end_token(".", ".")

--- a/tl.tl
+++ b/tl.tl
@@ -480,6 +480,8 @@ do
         else
           -- not applicable 
         end
+        print("JRP: debug strip_under(): kind = ", kind)
+        print("JRP: debug strip_under(): res/tk = ", res, tk)
         return res
       end  -- JRP added helper
 
@@ -506,6 +508,10 @@ do
             tk = tk,
             kind = keywords[tk] and "keyword" or "identifier"
          }
+         print("JRP: debug end_token_identifier(): kind = ", 
+               tokens[nt].kind)
+         print("JRP: debug end_token_identifier(): tk = ",
+               tokens[nt].tk)
          in_token = false
       end
 
@@ -619,7 +625,8 @@ do
          elseif state == "got ." then
             if c == "." then
                state = "got .."
-            elseif lex_decimals[c] then
+            elseif lex_decimals[c] and state == "number dec" then --JRP: added
+                                                                  --  "and..."
                state = "number decfloat"
             else
                end_token(".", ".")

--- a/tl.tl
+++ b/tl.tl
@@ -480,8 +480,6 @@ do
         else
           -- not applicable 
         end
-        print("JRP: debug strip_under(): kind = ", kind)
-        print("JRP: debug strip_under(): res/tk = ", res, tk)
         return res
       end  -- JRP added helper
 
@@ -508,10 +506,6 @@ do
             tk = tk,
             kind = keywords[tk] and "keyword" or "identifier"
          }
-         print("JRP: debug end_token_identifier(): kind = ", 
-               tokens[nt].kind)
-         print("JRP: debug end_token_identifier(): tk = ",
-               tokens[nt].tk)
          in_token = false
       end
 

--- a/tl.tl
+++ b/tl.tl
@@ -369,6 +369,7 @@ do
    for c = string.byte("0"), string.byte("9") do
       lex_decimals[string.char(c)] = true
    end
+   lex_decimals["_"] = true           -- JRP: add support of "_" in nums
 
    local lex_hexadecimals: {string:boolean} = {}
    for c = string.byte("0"), string.byte("9") do
@@ -380,6 +381,7 @@ do
    for c = string.byte("A"), string.byte("F") do
       lex_hexadecimals[string.char(c)] = true
    end
+   lex_hexadecimals["_"] = true       -- JRP: add support of "_" in nums
 
    local lex_any_char_kinds: {string:TokenKind} = {}
    local single_char_kinds: {TokenKind} = {"[", "]", "(", ")", "{", "}", ",", "#", "`", ";"}
@@ -470,7 +472,19 @@ do
          in_token = true
       end
 
+      -- JRP: strip "_" from number and integer
+      local function strip_under(kind: TokenKind, tk: string): string
+        local res = tk
+        if kind == "integer" or kind == "number" then
+          res = tk:gsub("_", "")
+        else
+          -- not applicable 
+        end
+        return res
+      end  -- JRP added helper
+
       local function end_token(kind: TokenKind, tk: string)
+         tk = strip_under(kind, tk)    -- JRP
          nt = nt + 1
          tokens[nt] = {
             x = tx,
@@ -497,6 +511,7 @@ do
 
       local function end_token_prev(kind: TokenKind)
          local tk = input:sub(ti, i - 1)
+         tk = strip_under(kind, tk)    -- JRP
          nt = nt + 1
          tokens[nt] = {
             x = tx,
@@ -510,6 +525,7 @@ do
 
       local function end_token_here(kind: TokenKind)
          local tk = input:sub(ti, i)
+         tk = strip_under(kind, tk)    -- JRP
          nt = nt + 1
          tokens[nt] = {
             x = tx,


### PR DESCRIPTION
Many languages allow the use of '_' as separator in numeric literals. [1] [2] [3] [4] [5]
Allowing such a separator makes it easy to check your work, visually (e.g., distinguish words in hexadecimal and 000's in decimal).
`local x = 0xCAFE_F00D` 
`local y = 1_000_000`

To accomplish this required telling the lexer to accept '_'.
* lex_decimals["_"] = true
* lex_hexadecimals["_"] = true

And then to strip it out when ending a token:
* a helper function `strip_under()`
* calling helper from 3 "end_token" functions

Example:
```
$ cat 42_000.tl

local t1 = 42_000
local t2 = 42_000.0
local t3 = 42_
local t4 = 42_000.000_123
local t5 = 1_000E3
local t6 = 0xCAFE_F00D

print(t1)
print(t2)
print(t3)
print(t4)
print(t5)
print(t6)



$ tl run 42_000.tl

42000
42000.0
42
42000.000123
1000000.0
3405705229
```
Feel free to use this or to ignore it if it isn't high on your priority list.
-John



[1] rust -- https://doc.rust-lang.org/rust-by-example/primitives/literals.html
[2] C# -- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-7.2/leading-separator
[3] python -- https://www.python.org/dev/peps/pep-0515/
[4] java -- https://docs.oracle.com/javase/7/docs/technotes/guides/language/underscores-literals.html
[5] php --  https://wiki.php.net/rfc/numeric_literal_separator

