### PR TITLE
Adding support for record + __call in forin

### DIFF
--- a/spec/statement/forin_spec.lua
+++ b/spec/statement/forin_spec.lua
@@ -89,6 +89,26 @@ describe("forin", function()
       end
    ]])
 
+   it("with a callable record interator", util.check [[
+      local record R
+         metamethod __call: function(): integer
+      end
+
+      function foo(): R
+         local x = 1
+         return setmetatable({}, {
+            __call = function(): integer
+               x = x + 1
+               return x < 4 and x or nil
+            end
+         })
+      end
+
+      for i in foo() do
+         print(i + 1)
+      end
+   ]])
+
    it("catches when too many values are passed", util.check_type_error([[
       local function it(): function(): string
          return nil

--- a/tl.lua
+++ b/tl.lua
@@ -8094,6 +8094,10 @@ tl.type_check = function(ast, opts)
          before_statements = function(node)
             local exp1 = node.exps[1]
             local exp1type = resolve_tuple_and_nominal(exp1.type)
+            if exp1type.typename == "record" and exp1type.meta_fields and exp1type.meta_fields["__call"] then
+               exp1type = exp1type.meta_fields["__call"]
+            end
+
             if exp1type.typename == "function" then
 
                if exp1.op and exp1.op.op == "@funcall" then

--- a/tl.tl
+++ b/tl.tl
@@ -6600,33 +6600,33 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
       end
    end
 
+   local function resolve_for_call(node: Node, func: Type, args: {Type}, is_method: boolean): Type, boolean
+      -- resolve unknown in lax mode, produce a general unknown function
+      if lax and is_unknown(func) then
+         func = a_type { typename = "function", args = VARARG { UNKNOWN }, rets = VARARG { UNKNOWN } }
+         if node.e1.op and node.e1.op.op == ":" and node.e1.e1.kind == "variable" then
+            add_unknown_dot(node, node.e1.e1.tk .. "." .. node.e1.e2.tk)
+         end
+      end
+      -- unwrap if tuple, resolve if nominal
+      func = resolve_tuple_and_nominal(func)
+      if func.typename ~= "function" and func.typename ~= "poly" then
+         -- resolve if prototype
+         if is_typetype(func) and func.def.typename == "record" then
+            func = func.def
+         end
+         -- resolve if metatable
+         if func.meta_fields and func.meta_fields["__call"] then
+            table.insert(args, 1, func)
+            func = func.meta_fields["__call"]
+            is_method = true
+         end
+      end
+      return func, is_method
+   end
+
    local type_check_function_call: function(Node, Type, {Type}, boolean, integer): Type
    do
-      local function resolve_for_call(node: Node, func: Type, args: {Type}, is_method: boolean): Type, boolean
-         -- resolve unknown in lax mode, produce a general unknown function
-         if lax and is_unknown(func) then
-            func = a_type { typename = "function", args = VARARG { UNKNOWN }, rets = VARARG { UNKNOWN } }
-            if node.e1.op and node.e1.op.op == ":" and node.e1.e1.kind == "variable" then
-               add_unknown_dot(node, node.e1.e1.tk .. "." .. node.e1.e2.tk)
-            end
-         end
-         -- unwrap if tuple, resolve if nominal
-         func = resolve_tuple_and_nominal(func)
-         if func.typename ~= "function" and func.typename ~= "poly" then
-            -- resolve if prototype
-            if is_typetype(func) and func.def.typename == "record" then
-               func = func.def
-            end
-            -- resolve if metatable
-            if func.meta_fields and func.meta_fields["__call"] then
-               table.insert(args, 1, func)
-               func = func.meta_fields["__call"]
-               is_method = true
-            end
-         end
-         return func, is_method
-      end
-
       local function mark_invalid_typeargs(f: Type)
          if f.typeargs then
             for _, a in ipairs(f.typeargs) do
@@ -8093,10 +8093,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
          end,
          before_statements = function(node: Node)
             local exp1 = node.exps[1]
-            local exp1type = resolve_tuple_and_nominal(exp1.type)
-            if exp1type.typename == "record" and exp1type.meta_fields and exp1type.meta_fields["__call"] then
-               exp1type = exp1type.meta_fields["__call"]
-            end
+            local args = {node.exps[2] and node.exps[2].type,
+                          node.exps[3] and node.exps[3].type}
+            local exp1type = resolve_for_call(exp1, exp1.type, args)
 
             if exp1type.typename == "function" then
                -- check common errors:
@@ -8131,6 +8130,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
                   end
                end
 
+               -- TODO: check that exp1's arguments match with (optional self, explicit iterator, state)
                local last: Type
                local rets = exp1type.rets
                for i, v in ipairs(node.vars) do

--- a/tl.tl
+++ b/tl.tl
@@ -8094,6 +8094,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
          before_statements = function(node: Node)
             local exp1 = node.exps[1]
             local exp1type = resolve_tuple_and_nominal(exp1.type)
+            if exp1type.typename == "record" and exp1type.meta_fields and exp1type.meta_fields["__call"] then
+               exp1type = exp1type.meta_fields["__call"]
+            end
+
             if exp1type.typename == "function" then
                -- check common errors:
                if exp1.op and exp1.op.op == "@funcall" then


### PR DESCRIPTION
So, I realized this was a problem when I was writing the type definition for [luafun](https://github.com/luafun/luafun/blob/master/fun.lua#L47-L71) which in many cases it returns "iterable" callable records that have a ton of utility functions.

I'm not very familiar with teal's code, so I wouldn't be surprised if I'm missing something or if there's a better way to fix this.  However I tested this change and it seems to be working.