### PR TITLE
docs: global_env_def is a string, not a table

### DIFF
--- a/docs/compiler_options.md
+++ b/docs/compiler_options.md
@@ -113,7 +113,7 @@ To make the Teal compiler aware of such predefined globals, you can specify a
 module name that resolves to a definition file (a Teal module ending with a
 `.d.tl` extension), and tell the compiler to predefine it into its own type
 checking environment, using the `--global-env-def` flag in the CLI or the
-`global_env_def` array in tlconfig.lua. For example, if you have a file called
+`global_env_def` string in tlconfig.lua. For example, if you have a file called
 `love.d.tl` containing the definitions of Love2D, you can put
 `global_env_def = "love"` in your tlconfig.lua file, and `tl` will assume
 that any globals declared in that file are available to other modules being


### PR DESCRIPTION
Follow-up to https://github.com/teal-language/tl/commit/9407fb46cb25c5ae51ccaaf1b71aa8cee41ef215.