### PR TITLE
Correct table.concat arg type to {string | number} (Fixes #450)

### DIFF
--- a/spec/stdlib/table_spec.lua
+++ b/spec/stdlib/table_spec.lua
@@ -12,4 +12,11 @@ describe("table", function()
       ]])
    end)
 
+   describe("concat", function()
+      it("can concat a mixed list of strings and numbers", util.check [[
+         local t = { "a", 1, "b", 2 }
+         print(table.concat(t))
+      ]])
+   end)
+
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -4014,6 +4014,7 @@ local MAP_OF_ALPHA_TO_BETA = a_type({ typename = "map", keys = ALPHA, values = B
 local NOMINAL_METATABLE_OF_ALPHA = a_type({ typename = "nominal", names = { "metatable" }, typevals = { ALPHA } })
 
 local ARRAY_OF_STRING = a_type({ typename = "array", elements = STRING })
+local ARRAY_OF_STRING_OR_NUMBER = a_type({ typename = "array", elements = UNION({ STRING, NUMBER }) })
 
 local FUNCTION = a_type({ typename = "function", args = VARARG({ ANY }), rets = VARARG({ ANY }) })
 
@@ -5116,7 +5117,7 @@ rets = TUPLE({ a_type({ typename = "function", args = TUPLE({}), rets = TUPLE({ 
       ["table"] = a_type({
          typename = "record",
          fields = {
-            ["concat"] = a_type({ typename = "function", args = TUPLE({ ARRAY_OF_STRING, OPT_STRING, OPT_NUMBER, OPT_NUMBER }), rets = TUPLE({ STRING }) }),
+            ["concat"] = a_type({ typename = "function", args = TUPLE({ ARRAY_OF_STRING_OR_NUMBER, OPT_STRING, OPT_NUMBER, OPT_NUMBER }), rets = TUPLE({ STRING }) }),
             ["insert"] = a_type({
                typename = "poly",
                types = {

--- a/tl.tl
+++ b/tl.tl
@@ -4014,6 +4014,7 @@ local MAP_OF_ALPHA_TO_BETA = a_type { typename = "map", keys = ALPHA, values = B
 local NOMINAL_METATABLE_OF_ALPHA = a_type { typename = "nominal", names = {"metatable"}, typevals = { ALPHA } }
 
 local ARRAY_OF_STRING = a_type { typename = "array", elements = STRING }
+local ARRAY_OF_STRING_OR_NUMBER = a_type { typename = "array", elements = UNION { STRING, NUMBER } }
 
 local FUNCTION = a_type { typename = "function", args = VARARG { ANY }, rets = VARARG { ANY } }
 
@@ -5116,7 +5117,7 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
       ["table"] = a_type {
          typename = "record",
          fields = {
-            ["concat"] = a_type { typename = "function", args = TUPLE { ARRAY_OF_STRING, OPT_STRING, OPT_NUMBER, OPT_NUMBER }, rets = TUPLE { STRING } },
+            ["concat"] = a_type { typename = "function", args = TUPLE { ARRAY_OF_STRING_OR_NUMBER, OPT_STRING, OPT_NUMBER, OPT_NUMBER }, rets = TUPLE { STRING } },
             ["insert"] = a_type {
                typename = "poly",
                types = {


### PR DESCRIPTION
Fixes #450

Started looking into this project, looks awesome for what I want to do with Lua (after spending way too much time looking into something statically typed to replace/augment Lua with!)

Decided to try fixing this to let myself get a better idea of the language, seemed like an easy enough fix. 

Let me know if the style isn't what you would expect, I wasn't exactly sure if it would be cleaner to just add the type inline where it was needed since its only used once. (Also since ARRAY_OF_STRING is only used once now as well)

Thanks for making Teal & supporting the Lua community!