### PR TITLE
docs: add more details on use of .d.tl files (cont.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Once `tl` is in your path, there are a few subcommands:
 * `tl build` will compile your project via the rules defined in `tlconfig.lua`.
 * `tl warnings` will list all warnings the compiler can generate.
 
+`tl` also supports some [compiler options](docs/compiler_options.md).
+These can either be specified on the command line or inside a tlconfig.lua file at the root of your project.
+
 ## Loading Teal code from Lua
 
 You can either pre-compile your `.tl` files into `.lua`, or you can add
@@ -83,9 +86,11 @@ You can learn more about programming with Teal in the [tutorial](docs/tutorial.m
 
 ## Type definitions
 
-We have a collaborative repository for type definitions of Lua libraries
-at https://github.com/teal-language/teal-types — check it out and make your
-contribution!
+`tl` supports [declaration files](docs/declaration_files.md), which can be used to annotate the types
+of third-party Lua libraries.
+
+We have a collaborative repository for declaration files at
+https://github.com/teal-language/teal-types — check it out and make your contribution!
 
 ## Text editor support
 

--- a/docs/compiler_options.md
+++ b/docs/compiler_options.md
@@ -35,7 +35,7 @@ return {
 | `--run-build-script` | `run_build_script` | `boolean` | `run` `check` `gen`| Runs the build script as if `tl build` was being run
 | | `build_file_output_dir` | `string` | `run` `check` `gen` `build` | Folder where the generated files from the build script will be accessible in
 | | `internal_compiler_output` | `string` |`run` `check` `gen` `build` | Folder to store cache files for use by the compiler
-| `--global-env-def`  | `global_env_def` | `string` | `build` `check` `gen` `run` | Specify a definition module declaring any custom globals predefined in your Lua environment. See [below](#global-environment-definition) for details. |
+| `--global-env-def`  | `global_env_def` | `string` | `build` `check` `gen` `run` | Specify a definition module declaring any custom globals predefined in your Lua environment. See the [declaration files](declaration_files.md#global-environment-definition) page for details. |
 
 ### Generated code
 
@@ -102,27 +102,11 @@ flag (and `--gen-compat` CLI option):
 
 ### Global environment definition
 
-Some customized Lua environments predefine some values into the Lua VM
-space as global variables. An example of an environment
-which presents this behavior is <a href="https://love2d.org">Love2D</a>,
-which predefines a `love` global table containing its API. This global is
-just "there", and code written for that environment assumes it is available,
-even if you don't load it with `require`.
+To make the Teal compiler aware of global variables in your execution environment,
+you may pass a declaration module to the compiler using the `--global-env-def` flag
+in the CLI or the `global_env_def` string in `tlconfig.lua`.
 
-To make the Teal compiler aware of such predefined globals, you can specify a
-module name that resolves to a definition file (a Teal module ending with a
-`.d.tl` extension), and tell the compiler to predefine it into its own type
-checking environment, using the `--global-env-def` flag in the CLI or the
-`global_env_def` string in tlconfig.lua. For example, if you have a file called
-`love.d.tl` containing the definitions of Love2D, you can put
-`global_env_def = "love"` in your tlconfig.lua file, and `tl` will assume
-that any globals declared in that file are available to other modules being
-compiled.
-
-Not that when using `tl gen`, this option does not generate code for the
-global environment module, and when using `tl run` it does not execute the
-module either. This option is only meant to make the compiler aware of any
-global definitions that were already loaded into a customized Lua VM.
+For more information, see the [declaration files](declaration_files.md#global-environment-definition) page.
 
 ### Include/Exclude patterns
 

--- a/docs/declaration_files.md
+++ b/docs/declaration_files.md
@@ -16,7 +16,7 @@ There are two ways to define these types:
 
 ```
 local record MyCompositeType
-   MyPointType = record
+   record MyPointType
       x: number
       y: number
    end
@@ -34,12 +34,12 @@ This will mean that references to `MyPointType` must be qualified (or locally de
 ### Global Types
 
 ```
-global MyPointType = record
+global record MyPointType
    x: number
    y: number
 end
 
-global MyCompositeType = record
+global record MyCompositeType
    center: MyPointType
 end
 ```

--- a/docs/declaration_files.md
+++ b/docs/declaration_files.md
@@ -58,5 +58,5 @@ return {
 }
 ```
 
-You can find more information about global environment definition in the [compiler options](docs/compiler_options.md#global-environment-definition) page.
+You can find more information about global environment definition in the [compiler options](compiler_options.md#global-environment-definition) page.
 

--- a/docs/declaration_files.md
+++ b/docs/declaration_files.md
@@ -104,3 +104,10 @@ Note that when using `tl gen`, this option does not generate code for the
 global environment module, and when using `tl run` it does not execute the
 module either. This option is only meant to make the compiler aware of any
 global definitions that were already loaded into a customized Lua VM.
+
+## Reusing existing declaration files (and contributing new ones!)
+
+The [Teal Types](https://github.com/teal-language/teal-types) repo contains
+declaration files for some commonly-used Lua libraries.
+
+Feel free to check it out and make your contribution!

--- a/docs/declaration_files.md
+++ b/docs/declaration_files.md
@@ -50,13 +50,37 @@ These can now be used unqualified in any file that requires them.
 
 If the third party library is "globally available" in your execution environment,
 i.e., if you do not need to explicitly `require` it in your code, you can tell the compiler
-to predefine it into its own type checking environment using a `tlconfig.lua` file:
+to predefine it into its own type checking environment.
+
+For instance, assuming you have the following declaration file, called `love-example.d.tl`:
 
 ```
+-- love-example.d.tl
+
+global record love
+   record graphics
+      print: function(text: string, x: number, y: number)
+   end
+end
+```
+
+You can predefine the `love` module by creating a `tlconfig.lua` file at the root of your project:
+
+```
+-- tlconfig.lua
+
 return {
-   global_env_def = "love"
+   global_env_def = "love-example"
 }
 ```
 
-You can find more information about global environment definition in the [compiler options](compiler_options.md#global-environment-definition) page.
+This makes the compiler aware of the `love` global record.
+You may then freely refer to this variable in your code:
 
+```
+-- main.tl
+
+love.graphics.print("hello!", 0, 0)
+```
+
+You can find more information about global environment definition in the [compiler options](compiler_options.md#global-environment-definition) page.

--- a/docs/declaration_files.md
+++ b/docs/declaration_files.md
@@ -48,11 +48,20 @@ These can now be used unqualified in any file that requires them.
 
 #### Global environment definition
 
-If the third party library is "globally available" in your execution environment,
-i.e., if you do not need to explicitly `require` it in your code, you can tell the compiler
-to predefine it into its own type checking environment.
+Some customized Lua environments predefine some values into the Lua VM
+space as global variables. An example of an environment
+which presents this behavior is [LÖVE](https://love2d.org),
+which predefines a `love` global table containing its API. This global is
+just "there", and code written for that environment assumes it is available,
+even if you don't load it with `require`.
 
-For instance, assuming you have the following declaration file, called `love-example.d.tl`:
+To make the Teal compiler aware of such globals, you can define them
+inside a declaration file, and tell the compiler to load the declaration module into its own type
+checking environment, using the `--global-env-def` flag in the CLI or the
+`global_env_def` string in `tlconfig.lua`.
+
+For example, if you have a file called `love-example.d.tl` containing the
+definitions for LÖVE:
 
 ```
 -- love-example.d.tl
@@ -64,7 +73,9 @@ global record love
 end
 ```
 
-You can predefine the `love` module by creating a `tlconfig.lua` file at the root of your project:
+You can put `global_env_def = "love-example"` in a `tlconfig.lua` file at
+the root of your project, and `tl` will now assume that any globals declared
+in `love-example.d.tl` are available to other modules being compiled:
 
 ```
 -- tlconfig.lua
@@ -74,8 +85,7 @@ return {
 }
 ```
 
-This makes the compiler aware of the `love` global record.
-You may then freely refer to this variable in your code:
+Example usage:
 
 ```
 -- main.tl
@@ -83,4 +93,14 @@ You may then freely refer to this variable in your code:
 love.graphics.print("hello!", 0, 0)
 ```
 
-You can find more information about global environment definition in the [compiler options](compiler_options.md#global-environment-definition) page.
+```
+$ tl check main.tl
+========================================
+Type checked main.tl
+0 errors detected
+```
+
+Note that when using `tl gen`, this option does not generate code for the
+global environment module, and when using `tl run` it does not execute the
+module either. This option is only meant to make the compiler aware of any
+global definitions that were already loaded into a customized Lua VM.

--- a/docs/declaration_files.md
+++ b/docs/declaration_files.md
@@ -1,0 +1,62 @@
+# Type definitions for third party libraries
+
+You can create declaration files to annotate the types of third-party Lua
+modules, including C Lua modules. To do so, create a file with the .d.tl
+extension and require it as normal, i.e. `local lfs = require("lfs")`.
+
+Types defined in this module will will be used as a source of type information 
+checking with `tl check`, even though the real Lua module will be loaded
+instead when requiring the module from Lua or `tl run`.
+
+## Visibility
+
+There are two ways to define these types:
+
+### Composite Types
+
+```
+local record MyCompositeType
+   MyPointType = record
+      x: number
+      y: number
+   end
+
+   center: MyPointType
+    -- insert more stuff here
+end
+
+return MyCompositeType
+```
+
+This will mean that references to `MyPointType` must be qualified (or locally declared) as
+`MyCompositeType.MyPointType`.
+
+### Global Types
+
+```
+global MyPointType = record
+   x: number
+   y: number
+end
+
+global MyCompositeType = record
+   center: MyPointType
+end
+```
+
+These can now be used unqualified in any file that requires them.
+
+#### Global environment definition
+
+If the third party library is "globally available" in your execution environment,
+i.e., if you do not need to explicitly `require` it in your code, you can tell the compiler
+to predefine it into its own type checking environment using a `tlconfig.lua` file:
+
+```
+return {
+   global_env_def = "love"
+}
+```
+
+You can find more information about global environment definition in the [compiler options](docs/compiler_options.md#global-environment-definition) page.
+

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -947,61 +947,10 @@ Note that even though adding type annotations to .lua files makes it invalid
 Lua, you can still do so and load them from the Lua VM once the Teal package
 loader is installed by calling tl.loader().
 
+### Further reading
 
-### Type definitions for third party libraries
+#### Type definitions for third party libraries
 
 You can also create declaration files to annotate the types of third-party Lua
-modules, including C Lua modules. To do so, create a file with the .d.tl
-extension and require it as normal, i.e. `local lfs = require("lfs")`.
+modules, including C Lua modules. For more information, see the [declaration files](docs/declaration_files.md) page.
 
-Types defined in this module will will be used as a source of type information 
-checking with `tl check`, even though the real Lua module will be loaded
-instead when requiring the module from Lua or `tl run`.
-
-If the third party library is "globally available" in your execution environment, i.e., if you do not explicitly
-`require` it, you can inject the types without affecting your generated code
-with a `tlconfig.lua`:
-
-```
-return {
-   global_env_def = "love"
-}
-```
-
-#### Visibility
-
-There are two ways to define these types:
-
-##### Composite Types
-
-```
-local MyCompositeType = record
-   MyPointType = record
-      x: number
-      y: number
-   end
-
-   center: MyPointType
-    -- insert more stuff here
-end
-
-return MyCompositeType
-```
-
-This will mean that references to `MyPointType` must be qualified (or locally declared) as
-`MyCompositeType.MyPointType`.
-
-##### Global Types
-
-```
-global MyPointType = record
-   x: number
-   y: number
-end
-
-global MyCompositeType = record
-   center: MyPointType
-end
-```
-
-These can now be used unqualified in any file that requires them.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -952,5 +952,5 @@ loader is installed by calling tl.loader().
 #### Type definitions for third party libraries
 
 You can also create declaration files to annotate the types of third-party Lua
-modules, including C Lua modules. For more information, see the [declaration files](docs/declaration_files.md) page.
+modules, including C Lua modules. For more information, see the [declaration files](declaration_files.md) page.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -952,62 +952,36 @@ loader is installed by calling tl.loader().
 
 You can also create declaration files to annotate the types of third-party Lua
 modules, including C Lua modules. To do so, create a file with the .d.tl
-extension and require it as normal, i.e. `require("minetest")`.
+extension and require it as normal, i.e. `local lfs = require("lfs")`.
 
 Types defined in this module will will be used as a source of type information 
 checking with `tl check`, even though the real Lua module will be loaded
 instead when requiring the module from Lua or `tl run`.
 
-If the third party library is "globally available", i.e. you do not explicitly
+If the third party library is "globally available" in your execution environment, i.e., if you do not explicitly
 `require` it, you can inject the types without affecting your generated code
 with a `tlconfig.lua`:
 
-```lua
+```
 return {
-    preload_modules = {
-        "minetest" -- Execute the equivalent of require('minetest') before type-checking the tl script(s)
-    }
+   global_env_def = "love"
 }
 ```
 
 #### Visibility
 
-It should be noted that local references in type definition files (or any files
-containing types for that matter) are not available in the requiring module.
-
-This means that constructs like:
-
-```lua
-local MyPointType = record
-    x :number
-    y :number
-end
-
-local MyCompositeType = record
-    center: MyPointType
-end
-
-return {
-    MyPointType = MyPointType,
-    MyCompositeType = MyCompositeType,
-}
-```
-
-will give errors when accessing `MyCompositeType::center`, as `MyPointType` is not
-visible.
-
 There are two ways to define these types:
 
 ##### Composite Types
 
-```lua
+```
 local MyCompositeType = record
-    MyPointType = record
-        x :number
-        y :number
-    end
+   MyPointType = record
+      x: number
+      y: number
+   end
 
-    center :MyPointType
+   center: MyPointType
     -- insert more stuff here
 end
 
@@ -1019,17 +993,14 @@ This will mean that references to `MyPointType` must be qualified (or locally de
 
 ##### Global Types
 
-While perhaps discouraged in general, for types that are provided as part of the
-execution environment it may be more hygeinic to declare them as global.
-
-```lua
+```
 global MyPointType = record
-    x :number
-    y :number
+   x: number
+   y: number
 end
 
 global MyCompositeType = record
-    center: MyPointType
+   center: MyPointType
 end
 ```
 


### PR DESCRIPTION
This PR does a few things:

- Merge https://github.com/teal-language/tl/pull/143
- Apply suggested tweaks to the PR
- Add a concrete example which shows how to use `global_env_dev`
- Put this new information regarding declaration files in a separate document (`declaration_files.md`)
- Add a link to this document in the README
- Add a mention about tlconfig.lua and the [compiler options](https://github.com/teal-language/tl/blob/master/docs/compiler_options.md) page in the README (since `include_dir` and `global_env_def` can be good to know when working with declaration files)