### PR TITLE
Record embed and const field syntax

### DIFF
--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -673,3 +673,91 @@ for i, name in ipairs({"records", "arrayrecords"}) do
       ]]))
    end)
 end
+
+describe("embedding", function()
+   it("embed is not a reserved word", util.check [[
+      local record A
+         embed: number
+      end
+   ]])
+   it("should make members of a record available to another", util.check [[
+      local record A
+         userdata
+         a_value: number
+      end
+      local record B
+         embed A
+         b_value: number
+      end
+      local record C
+         embed B
+         c_value: string
+      end
+      local b: B = {}
+      local c: C = {}
+      print(b.a_value, c.a_value + c.b_value, c.c_value)
+      local function f(a: A, b: B) end
+      f(b, b)
+      f(c, c)
+      local a: A = b
+      a = c
+   ]])
+   it("should allow for generics", util.check [[
+      local record A<T>
+         property_of_a: T
+      end
+      local record B<T>
+         embed A<T>
+         property_of_b: T
+      end
+      local record C<T>
+         embed B<T>
+         property_of_c: string
+      end
+      local b: B<number> = {}
+      local c: C<number> = {}
+      print(b.property_of_a + 1, c.property_of_b + c.property_of_a, c.property_of_c)
+      local function f(a: A<number>, b: B<number>) end
+      f(b, b)
+      f(c, c)
+      local a: A<number> = b
+      a = c
+   ]])
+   it("embed multiple records", util.check [[
+      local record A
+         x: number
+      end
+      local record B
+         y: string
+      end
+      local record C
+         embed A
+         embed B
+         z: boolean
+      end
+      local c: C = { x = 1, y = "hello", z = true }
+      print(c.x, c.y, c.z)
+      local function f(a: A, b: B, c: C) end
+      f(c, c, c)
+   ]])
+   it("share the same element type with embeded arrayrecord", util.check [[
+      local record A
+         { string }
+         x: number
+      end
+      local record B
+         embed A
+         y: string
+      end
+      local record C
+         embed B
+         z: boolean
+      end
+      local c: C = { x = 1, y = "hello", z = true }
+      local str: string = c[1]
+      print(c.x, c.y, c.z)
+      local strs: {string} = c
+      local b: B = c
+      strs = b
+   ]])
+end)

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -760,6 +760,24 @@ describe("embedding", function()
       local b: B = c
       strs = b
    ]])
+   it("subrecords should not be equal", util.check_type_error([[
+      local record A
+      end
+      local record B
+         embed A
+      end
+      local record C
+         embed A
+      end
+      local a: A
+      local b: B
+      local c: C
+      a = b
+      a = c
+      b = c
+   ]], {
+      { y = 14, msg = "in assignment: C is not a B" }
+   }))
 end)
 
 describe("const field", function()

--- a/tl.lua
+++ b/tl.lua
@@ -6074,6 +6074,7 @@ tl.type_check = function(ast, opts)
          if e.fields then
             for fname, f in pairs(e.fields) do
                t.fields[fname] = f
+               table.insert(t.field_order, fname)
             end
          end
          if e.readonlys then

--- a/tl.lua
+++ b/tl.lua
@@ -6154,14 +6154,16 @@ tl.type_check = function(ast, opts)
       end
    end
 
-   local function is_embedded(t1, t2, eq)
+   local function is_embedded(t1, t2)
       t2 = resolve_tuple_and_nominal(t2)
       t1 = resolve_tuple_and_nominal(t1)
       local embeds = t1.embeds
       if embeds and #embeds > 0 then
          for i = 1, #embeds do
-            if is_a(embeds[i], t2, eq) then
+            if embeds[i].typeid == t2.typeid then
                return true
+            elseif embeds[i].embeds then
+               return is_embedded(embeds[i], t2)
             end
          end
       end
@@ -6169,7 +6171,7 @@ tl.type_check = function(ast, opts)
    end
 
    local function are_same_nominals(t1, t2)
-      if is_embedded(t1, t2, false) then
+      if is_embedded(t1, t2) then
          return true
       end
 
@@ -6243,7 +6245,7 @@ tl.type_check = function(ast, opts)
          return false, terr(t1, "got %s, expected %s", t1, t2)
       end
 
-      if is_embedded(t1, t2, false) then
+      if is_embedded(t1, t2) then
          return true
       end
 
@@ -6499,7 +6501,7 @@ tl.type_check = function(ast, opts)
             end
          end
          return false, terr(t1, "cannot match against any alternatives of the polymorphic type")
-      elseif is_embedded(t1, t2, for_equality) then
+      elseif is_embedded(t1, t2) then
          return true
       elseif t1.typename == "nominal" and t2.typename == "nominal" then
          local same, err = are_same_nominals(t1, t2)

--- a/tl.lua
+++ b/tl.lua
@@ -1036,6 +1036,7 @@ local Type = {}
 
 
 
+
 local Operator = {}
 
 
@@ -2582,6 +2583,12 @@ parse_record_body = function(ps, i, def, node)
             i = i + 1
          end
 
+         local is_const = false
+         if ps.tokens[i].tk == "const" and ps.tokens[i + 1].tk ~= ":" then
+            is_const = true
+            i = i + 1
+         end
+
          local v
          if ps.tokens[i].tk == "[" then
             i, v = parse_literal(ps, i + 1)
@@ -2618,6 +2625,12 @@ parse_record_body = function(ps, i, def, node)
                if not metamethod_names[field_name] then
                   fail(ps, i - 1, "not a valid metamethod: " .. field_name)
                end
+            end
+            if is_const then
+               if not def.readonlys then
+                  def.readonlys = {}
+               end
+               def.readonlys[field_name] = true
             end
             store_field_in_record(ps, iv, field_name, t, fields, field_order)
          elseif ps.tokens[i].tk == "=" then
@@ -5558,6 +5571,8 @@ tl.type_check = function(ast, opts)
                   copy.meta_fields[k] = resolve(t.meta_fields[k])
                end
             end
+
+            copy.readonlys = t.readonlys
          elseif t.typename == "map" then
             copy.keys = resolve(t.keys)
             copy.values = resolve(t.values)
@@ -6016,7 +6031,7 @@ tl.type_check = function(ast, opts)
    end
 
    local function can_embed(t1, t2)
-      assert(is_record_type(t1), "Only records can have embeds")
+      assert(is_record_type(t1), "only records can have embeds")
       if is_record_type(t2) then
          local compat, fields = are_disjoint(t1, t2)
          if compat then
@@ -6043,7 +6058,7 @@ tl.type_check = function(ast, opts)
          local e = resolve_tuple_and_nominal(t.embeds[i])
          local compat, reason = can_embed(t, e)
          if not compat then
-            type_error(t, "Invalid embedding: " .. reason)
+            type_error(t, "invalid embedding: " .. reason)
          end
          if e.is_userdata then
             t.is_userdata = true
@@ -6059,6 +6074,14 @@ tl.type_check = function(ast, opts)
          if e.fields then
             for fname, f in pairs(e.fields) do
                t.fields[fname] = f
+            end
+         end
+         if e.readonlys then
+            if not t.readonlys then
+               t.readonlys = {}
+            end
+            for k, v in pairs(e.readonlys) do
+               t.readonlys[k] = v
             end
          end
       end
@@ -8115,6 +8138,15 @@ tl.type_check = function(ast, opts)
                   if is_typetype(resolve_tuple_and_nominal(vartype)) then
                      node_error(varnode, "cannot reassign a type")
                   elseif val then
+                     if varnode.kind == "op" and (varnode.op.op == "." or varnode.op.op == "@index") then
+                        local t = resolve_tuple_and_nominal(varnode.e1.type)
+                        if t.typename == "record" and t.readonlys then
+                           local key = varnode.e2.conststr or varnode.e2.tk
+                           if t.readonlys[key] then
+                              node_error(varnode, "cannot assign to const field \"" .. key .. '"')
+                           end
+                        end
+                     end
                      assert_is_a(varnode, val, vartype, "in assignment")
                      if varnode.kind == "variable" and vartype.typename == "union" then
 

--- a/tl.lua
+++ b/tl.lua
@@ -1034,6 +1034,8 @@ local Type = {}
 
 
 
+
+
 local Operator = {}
 
 
@@ -2563,6 +2565,16 @@ parse_record_body = function(ps, i, def, node)
          i = parse_nested_type(ps, i, def, "record", parse_record_body)
       elseif ps.tokens[i].tk == "enum" and ps.tokens[i + 1].tk ~= ":" then
          i = parse_nested_type(ps, i, def, "enum", parse_enum_body)
+      elseif ps.tokens[i].tk == "embed" and ps.tokens[i + 1].tk ~= ":" then
+         local t
+         i, t = parse_type(ps, i + 1)
+         if not t then
+            return fail(ps, i, "expected a type")
+         end
+         if not def.embeds then
+            def.embeds = {}
+         end
+         table.insert(def.embeds, t)
       else
          local is_metamethod = false
          if ps.tokens[i].tk == "metamethod" and ps.tokens[i + 1].tk ~= ":" then
@@ -3022,6 +3034,11 @@ local function recurse_type(ast, visit)
    end
    if ast.meta_fields then
       for _, child in fields_of(ast, "meta") do
+         table.insert(xs, recurse_type(child, visit))
+      end
+   end
+   if ast.embeds then
+      for _, child in ipairs(ast.embeds) do
          table.insert(xs, recurse_type(child, visit))
       end
    end
@@ -4349,6 +4366,13 @@ local function show_type_base(t, short, seen)
          if t.elements then
             table.insert(out, "{" .. show(t.elements) .. "}")
          end
+         if t.embeds then
+            local es = {}
+            for _, k in ipairs(t.embeds) do
+               table.insert(es, show(k))
+            end
+            table.insert(out, "(embed " .. table.concat(es, ", ") .. ")")
+         end
          local fs = {}
          for _, k in ipairs(t.field_order) do
             local v = t.fields[k]
@@ -5508,6 +5532,13 @@ tl.type_check = function(ast, opts)
                end
             end
 
+            if t.embeds then
+               copy.embeds = {}
+               for i, tf in ipairs(t.embeds) do
+                  copy.embeds[i] = resolve(tf)
+               end
+            end
+
             if t.elements then
                copy.elements = resolve(t.elements)
             end
@@ -5966,6 +5997,74 @@ tl.type_check = function(ast, opts)
       return typ
    end
 
+   local function are_disjoint(rec1, rec2)
+      local disjoint = true
+      local shared_fields = {}
+      for field, t in pairs(rec1.fields) do
+         if rec2.fields[field] and rec2.fields[field] ~= t then
+            shared_fields[field] = true
+            disjoint = false
+         end
+      end
+      for field, t in pairs(rec2.fields) do
+         if rec1.fields[field] and rec1.fields[field] ~= t then
+            shared_fields[field] = true
+            disjoint = false
+         end
+      end
+      return disjoint, shared_fields
+   end
+
+   local function can_embed(t1, t2)
+      assert(is_record_type(t1), "Only records can have embeds")
+      if is_record_type(t2) then
+         local compat, fields = are_disjoint(t1, t2)
+         if compat then
+            return compat
+         else
+            local str = {}
+            for f in pairs(fields) do
+               table.insert(str, f)
+            end
+            return nil, "records share fields: " .. table.concat(str, ", ")
+         end
+      end
+      return false, t2.typename .. " can't be embedded"
+   end
+
+   local resolve_tuple_and_nominal = nil
+
+   local function resolve_embeds(t)
+      if not t.embeds or t.embeds_resolved then
+         return t
+      end
+      t.embeds_resolved = true
+      for i = 1, #t.embeds do
+         local e = resolve_tuple_and_nominal(t.embeds[i])
+         local compat, reason = can_embed(t, e)
+         if not compat then
+            type_error(t, "Invalid embedding: " .. reason)
+         end
+         if e.is_userdata then
+            t.is_userdata = true
+         end
+         if t.elements == nil and e.elements ~= nil then
+            t.elements = e.elements
+            t.typename = "arrayrecord"
+         end
+         if t.elements and e.elements and not same_type(t.elements, e.elements) then
+            type_error(t, "Can not do embedding between arrayrecords with different element types")
+         end
+         t.embeds[i] = e
+         if e.fields then
+            for fname, f in pairs(e.fields) do
+               t.fields[fname] = f
+            end
+         end
+      end
+      return t
+   end
+
    local resolve_nominal
    do
       local function match_typevals(t, def)
@@ -6031,7 +6130,25 @@ tl.type_check = function(ast, opts)
       end
    end
 
+   local function is_embedded(t1, t2, eq)
+      t2 = resolve_tuple_and_nominal(t2)
+      t1 = resolve_tuple_and_nominal(t1)
+      local embeds = t1.embeds
+      if embeds and #embeds > 0 then
+         for i = 1, #embeds do
+            if is_a(embeds[i], t2, eq) then
+               return true
+            end
+         end
+      end
+      return false
+   end
+
    local function are_same_nominals(t1, t2)
+      if is_embedded(t1, t2, false) then
+         return true
+      end
+
       local same_names
       if t1.found and t2.found then
          same_names = t1.found.typeid == t2.found.typeid
@@ -6084,7 +6201,6 @@ tl.type_check = function(ast, opts)
    end
 
    local is_known_table_type
-   local resolve_tuple_and_nominal = nil
 
 
    same_type = function(t1, t2)
@@ -6102,6 +6218,11 @@ tl.type_check = function(ast, opts)
       if t1.typename ~= t2.typename then
          return false, terr(t1, "got %s, expected %s", t1, t2)
       end
+
+      if is_embedded(t1, t2, false) then
+         return true
+      end
+
       if t1.typename == "array" then
          return same_type(t1.elements, t2.elements)
       elseif t1.typename == "tupletable" then
@@ -6354,6 +6475,8 @@ tl.type_check = function(ast, opts)
             end
          end
          return false, terr(t1, "cannot match against any alternatives of the polymorphic type")
+      elseif is_embedded(t1, t2, for_equality) then
+         return true
       elseif t1.typename == "nominal" and t2.typename == "nominal" then
          local same, err = are_same_nominals(t1, t2)
          if same then
@@ -6959,6 +7082,7 @@ tl.type_check = function(ast, opts)
          t = resolve_nominal(t)
       end
       assert(t.typename ~= "nominal")
+      t = resolve_embeds(t)
       return t
    end
 

--- a/tl.tl
+++ b/tl.tl
@@ -6154,14 +6154,16 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
       end
    end
 
-   local function is_embedded(t1: Type, t2: Type, eq: boolean): boolean
+   local function is_embedded(t1: Type, t2: Type): boolean
       t2 = resolve_tuple_and_nominal(t2)
       t1 = resolve_tuple_and_nominal(t1)
       local embeds = t1.embeds
       if embeds and #embeds > 0 then
          for i = 1, #embeds do
-            if is_a(embeds[i], t2, eq) then
+            if embeds[i].typeid == t2.typeid then
                return true
+            elseif embeds[i].embeds then
+               return is_embedded(embeds[i], t2)
             end
          end
       end
@@ -6169,7 +6171,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
    end
 
    local function are_same_nominals(t1: Type, t2: Type): boolean, {Error}
-      if is_embedded(t1, t2, false) then
+      if is_embedded(t1, t2) then
          return true
       end
 
@@ -6243,7 +6245,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
          return false, terr(t1, "got %s, expected %s", t1, t2)
       end
 
-      if is_embedded(t1, t2, false) then
+      if is_embedded(t1, t2) then
          return true
       end
 
@@ -6499,7 +6501,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
             end
          end
          return false, terr(t1, "cannot match against any alternatives of the polymorphic type")
-      elseif is_embedded(t1, t2, for_equality) then
+      elseif is_embedded(t1, t2) then
          return true
       elseif t1.typename == "nominal" and t2.typename == "nominal" then
          local same, err = are_same_nominals(t1, t2)

--- a/tl.tl
+++ b/tl.tl
@@ -989,6 +989,7 @@ local record Type
    is_userdata: boolean
    embeds: {Type}
    embeds_resolved: boolean
+   readonlys: {string: boolean}
 
    -- array
    elements: Type
@@ -2582,6 +2583,12 @@ parse_record_body = function(ps: ParseState, i: integer, def: Type, node: Node):
             i = i + 1
          end
 
+         local is_const = false
+         if ps.tokens[i].tk == "const" and ps.tokens[i+1].tk ~= ":" then
+            is_const = true
+            i = i + 1
+         end
+
          local v: Node
          if ps.tokens[i].tk == "[" then
             i, v = parse_literal(ps, i+1)
@@ -2618,6 +2625,12 @@ parse_record_body = function(ps: ParseState, i: integer, def: Type, node: Node):
                if not metamethod_names[field_name] then
                   fail(ps, i - 1, "not a valid metamethod: " .. field_name)
                end
+            end
+            if is_const then
+               if not def.readonlys then
+                  def.readonlys = {}
+               end
+               def.readonlys[field_name] = true
             end
             store_field_in_record(ps, iv, field_name, t, fields, field_order)
          elseif ps.tokens[i].tk == "=" then
@@ -5558,6 +5571,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
                   copy.meta_fields[k] = resolve(t.meta_fields[k])
                end
             end
+
+            copy.readonlys = t.readonlys
          elseif t.typename == "map" then
             copy.keys = resolve(t.keys)
             copy.values = resolve(t.values)
@@ -6016,7 +6031,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
    end
 
    local function can_embed(t1: Type, t2: Type): boolean, string
-      assert(is_record_type(t1), "Only records can have embeds")
+      assert(is_record_type(t1), "only records can have embeds")
       if is_record_type(t2) then
          local compat, fields = are_disjoint(t1, t2)
          if compat then
@@ -6043,7 +6058,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
          local e = resolve_tuple_and_nominal(t.embeds[i])
          local compat, reason = can_embed(t, e)
          if not compat then
-            type_error(t, "Invalid embedding: " .. reason)
+            type_error(t, "invalid embedding: " .. reason)
          end
          if e.is_userdata then
             t.is_userdata = true
@@ -6059,6 +6074,14 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
          if e.fields then
             for fname, f in pairs(e.fields) do
                t.fields[fname] = f
+            end
+         end
+         if e.readonlys then
+            if not t.readonlys then
+               t.readonlys = {}
+            end
+            for k, v in pairs(e.readonlys) do
+               t.readonlys[k] = v
             end
          end
       end
@@ -8115,6 +8138,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
                   if is_typetype(resolve_tuple_and_nominal(vartype)) then
                      node_error(varnode, "cannot reassign a type")
                   elseif val then
+                     if varnode.kind == "op" and (varnode.op.op == "." or varnode.op.op == "@index") then
+                        local t = resolve_tuple_and_nominal(varnode.e1.type)
+                        if t.typename == "record" and t.readonlys then
+                           local key = varnode.e2.conststr or varnode.e2.tk
+                           if t.readonlys[key] then
+                              node_error(varnode, "cannot assign to const field \"" .. key .. '"')
+                           end
+                        end
+                     end
                      assert_is_a(varnode, val, vartype, "in assignment")
                      if varnode.kind == "variable" and vartype.typename == "union" then
                         -- narrow union

--- a/tl.tl
+++ b/tl.tl
@@ -987,6 +987,8 @@ local record Type
    meta_fields: {string: Type}
    meta_field_order: {string}
    is_userdata: boolean
+   embeds: {Type}
+   embeds_resolved: boolean
 
    -- array
    elements: Type
@@ -2563,6 +2565,16 @@ parse_record_body = function(ps: ParseState, i: integer, def: Type, node: Node):
          i = parse_nested_type(ps, i, def, "record", parse_record_body)
       elseif ps.tokens[i].tk == "enum" and ps.tokens[i+1].tk ~= ":" then
          i = parse_nested_type(ps, i, def, "enum", parse_enum_body)
+      elseif ps.tokens[i].tk == "embed" and ps.tokens[i+1].tk ~= ":" then
+         local t: Type
+         i, t = parse_type(ps, i + 1)
+         if not t then
+            return fail(ps, i, "expected a type")
+         end
+         if not def.embeds then
+            def.embeds = {}
+         end
+         table.insert(def.embeds, t)
       else
          local is_metamethod = false
          if ps.tokens[i].tk == "metamethod" and ps.tokens[i+1].tk ~= ":" then
@@ -3022,6 +3034,11 @@ local function recurse_type<T>(ast: Type, visit: Visitor<TypeName, Type, T>): T
    end
    if ast.meta_fields then
       for _, child in fields_of(ast, "meta") do
+         table.insert(xs, recurse_type(child, visit))
+      end
+   end
+   if ast.embeds then
+      for _, child in ipairs(ast.embeds) do
          table.insert(xs, recurse_type(child, visit))
       end
    end
@@ -4349,6 +4366,13 @@ local function show_type_base(t: Type, short: boolean, seen: {Type:string}): str
          if t.elements then
             table.insert(out, "{" .. show(t.elements) .. "}")
          end
+         if t.embeds then
+            local es = {}
+            for _, k in ipairs(t.embeds) do
+               table.insert(es, show(k))
+            end
+            table.insert(out, "(embed " .. table.concat(es, ", ") .. ")")
+         end
          local fs = {}
          for _, k in ipairs(t.field_order) do
             local v = t.fields[k]
@@ -5508,6 +5532,13 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
                end
             end
 
+            if t.embeds then
+               copy.embeds = {}
+               for i, tf in ipairs(t.embeds) do
+                  copy.embeds[i] = resolve(tf)
+               end
+            end
+
             if t.elements then
                copy.elements = resolve(t.elements)
             end
@@ -5966,6 +5997,74 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
       return typ
    end
 
+   local function are_disjoint(rec1: Type, rec2: Type): boolean, {string:boolean}
+      local disjoint = true
+      local shared_fields: {string:boolean} = {}
+      for field, t in pairs(rec1.fields) do
+         if rec2.fields[field] and rec2.fields[field] ~= t then
+            shared_fields[field] = true
+            disjoint = false
+         end
+      end
+      for field, t in pairs(rec2.fields) do
+         if rec1.fields[field] and rec1.fields[field] ~= t then
+            shared_fields[field] = true
+            disjoint = false
+         end
+      end
+      return disjoint, shared_fields
+   end
+
+   local function can_embed(t1: Type, t2: Type): boolean, string
+      assert(is_record_type(t1), "Only records can have embeds")
+      if is_record_type(t2) then
+         local compat, fields = are_disjoint(t1, t2)
+         if compat then
+            return compat
+         else
+            local str: {string} = {}
+            for f in pairs(fields) do
+               table.insert(str, f)
+            end
+            return nil, "records share fields: " .. table.concat(str, ", ")
+         end
+      end
+      return false, t2.typename .. " can't be embedded"
+   end
+
+   local resolve_tuple_and_nominal: function(t: Type): Type = nil
+
+   local function resolve_embeds(t: Type): Type
+      if not t.embeds or t.embeds_resolved then
+         return t
+      end
+      t.embeds_resolved = true
+      for i = 1, #t.embeds do
+         local e = resolve_tuple_and_nominal(t.embeds[i])
+         local compat, reason = can_embed(t, e)
+         if not compat then
+            type_error(t, "Invalid embedding: " .. reason)
+         end
+         if e.is_userdata then
+            t.is_userdata = true
+         end
+         if t.elements == nil and e.elements ~= nil then
+            t.elements = e.elements
+            t.typename = "arrayrecord"
+         end
+         if t.elements and e.elements and not same_type(t.elements, e.elements) then
+            type_error(t, "Can not do embedding between arrayrecords with different element types")
+         end
+         t.embeds[i] = e
+         if e.fields then
+            for fname, f in pairs(e.fields) do
+               t.fields[fname] = f
+            end
+         end
+      end
+      return t
+   end
+
    local resolve_nominal: function(t: Type): Type
    do
       local function match_typevals(t: Type, def: Type): Type
@@ -6031,7 +6130,25 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
       end
    end
 
+   local function is_embedded(t1: Type, t2: Type, eq: boolean): boolean
+      t2 = resolve_tuple_and_nominal(t2)
+      t1 = resolve_tuple_and_nominal(t1)
+      local embeds = t1.embeds
+      if embeds and #embeds > 0 then
+         for i = 1, #embeds do
+            if is_a(embeds[i], t2, eq) then
+               return true
+            end
+         end
+      end
+      return false
+   end
+
    local function are_same_nominals(t1: Type, t2: Type): boolean, {Error}
+      if is_embedded(t1, t2, false) then
+         return true
+      end
+
       local same_names: boolean
       if t1.found and t2.found then
          same_names = t1.found.typeid == t2.found.typeid
@@ -6084,7 +6201,6 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
    end
 
    local is_known_table_type: function(t: Type): boolean
-   local resolve_tuple_and_nominal: function(t: Type): Type = nil
 
    -- invariant type comparison
    same_type = function(t1: Type, t2: Type): boolean, {Error}
@@ -6102,6 +6218,11 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
       if t1.typename ~= t2.typename then
          return false, terr(t1, "got %s, expected %s", t1, t2)
       end
+
+      if is_embedded(t1, t2, false) then
+         return true
+      end
+
       if t1.typename == "array" then
          return same_type(t1.elements, t2.elements)
       elseif t1.typename == "tupletable" then
@@ -6354,6 +6475,8 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
             end
          end
          return false, terr(t1, "cannot match against any alternatives of the polymorphic type")
+      elseif is_embedded(t1, t2, for_equality) then
+         return true
       elseif t1.typename == "nominal" and t2.typename == "nominal" then
          local same, err = are_same_nominals(t1, t2)
          if same then
@@ -6959,6 +7082,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
          t = resolve_nominal(t)
       end
       assert(t.typename ~= "nominal")
+      t = resolve_embeds(t)
       return t
    end
 

--- a/tl.tl
+++ b/tl.tl
@@ -6074,6 +6074,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
          if e.fields then
             for fname, f in pairs(e.fields) do
                t.fields[fname] = f
+               table.insert(t.field_order, fname)
             end
          end
          if e.readonlys then


### PR DESCRIPTION
Implement the "embed" and "const / readonly" field functions for OOP simulations to support some Lua project uses. The "embed" function is refactored from @euclidianAce's [implementation](https://github.com/euclidianAce/tl/tree/record-embed) ( mentioned in issue #97 ) with bug fixes.