### PR TITLE
Fix a case to check array of enums

### DIFF
--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -129,6 +129,22 @@ for i, name in ipairs({"records", "arrayrecords"}) do
          { msg = "attempt to redeclare field 'print' (only functions can be overloaded)" }
       }))
 
+      it("enum check in overloaded function", util.check_type_error([[
+         local enum E
+            "a"
+            "b"
+            "c"
+         end
+         local type R = record ]]..pick(i, "", "{number}")..[[
+            f: function(enums: {E})
+            f: function(tuple: {string, number})
+         end
+         local r: R
+         r.f({"a", "b", "x"})
+      ]], {
+         { y = 11, msg = "argument 1: string \"x\" is not a member of E" }
+      }))
+
       it("can report an error on unknown types in polymorphic definitions", util.check_type_error([[
          -- this reports an error
          local type R = record ]]..pick(i, "", "{R}")..[[

--- a/tl.lua
+++ b/tl.lua
@@ -6408,6 +6408,16 @@ tl.type_check = function(ast, opts)
       elseif t2.typename == "array" then
          if is_array_type(t1) then
             if is_a(t1.elements, t2.elements) then
+               local t1e = resolve_tuple_and_nominal(t1.elements)
+               local t2e = resolve_tuple_and_nominal(t2.elements)
+               if t2e.typename == "enum" and t1e.typename == "string" and #t1.types > 1 then
+                  for i = 2, #t1.types do
+                     local t = t1.types[i]
+                     if not is_a(t, t2e) then
+                        return false, terr(t, "%s is not a member of %s", t, t2e)
+                     end
+                  end
+               end
                return true
             end
          elseif t1.typename == "tupletable" then

--- a/tl.tl
+++ b/tl.tl
@@ -6408,6 +6408,16 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result
       elseif t2.typename == "array" then
          if is_array_type(t1) then
             if is_a(t1.elements, t2.elements) then
+               local t1e = resolve_tuple_and_nominal(t1.elements)
+               local t2e = resolve_tuple_and_nominal(t2.elements)
+               if t2e.typename == "enum" and t1e.typename == "string" and #t1.types > 1 then
+                  for i = 2, #t1.types do
+                     local t = t1.types[i]
+                     if not is_a(t, t2e) then
+                        return false, terr(t, "%s is not a member of %s", t, t2e)
+                     end
+                  end
+               end
                return true
             end
          elseif t1.typename == "tupletable" then


### PR DESCRIPTION
An array of enums used as argument in a overloaded function is not well checked. A minimal example could be
```lua
local enum E
   "a"
end
local record R
   f: function()
   f: function({E})
end
local r: R
r.f({"a", "ERROR"}) -- is not reporting type errors
```