### PR TITLE
make math.huge an integer instead of a number

### DIFF
--- a/spec/stdlib/math_spec.lua
+++ b/spec/stdlib/math_spec.lua
@@ -16,4 +16,10 @@ describe("math", function()
       ]])
    end)
 
+   describe("huge", function()
+      it("is an integer", util.check [[
+         local x: integer = math.huge
+      ]])
+   end)
+
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -4974,7 +4974,7 @@ rets = TUPLE({ a_type({ typename = "function", args = TUPLE({}), rets = TUPLE({ 
                },
             }),
             ["frexp"] = a_type({ typename = "function", args = TUPLE({ NUMBER }), rets = TUPLE({ NUMBER, NUMBER }) }),
-            ["huge"] = NUMBER,
+            ["huge"] = INTEGER,
             ["ldexp"] = a_type({ typename = "function", args = TUPLE({ NUMBER, NUMBER }), rets = TUPLE({ NUMBER }) }),
             ["log"] = a_type({ typename = "function", args = TUPLE({ NUMBER, NUMBER }), rets = TUPLE({ NUMBER }) }),
             ["log10"] = a_type({ typename = "function", args = TUPLE({ NUMBER }), rets = TUPLE({ NUMBER }) }),

--- a/tl.tl
+++ b/tl.tl
@@ -4974,7 +4974,7 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
                }
             },
             ["frexp"] = a_type { typename = "function", args = TUPLE { NUMBER }, rets = TUPLE { NUMBER, NUMBER } },
-            ["huge"] = NUMBER,
+            ["huge"] = INTEGER,
             ["ldexp"] = a_type { typename = "function", args = TUPLE { NUMBER, NUMBER }, rets = TUPLE { NUMBER } },
             ["log"] = a_type { typename = "function", args = TUPLE { NUMBER, NUMBER }, rets = TUPLE { NUMBER } },
             ["log10"] = a_type { typename = "function", args = TUPLE { NUMBER }, rets = TUPLE { NUMBER } },


### PR DESCRIPTION
Otherwise initializing an integer variable to math.huge throws an error:

```
local x: integer = math.huge -- expected integer, got number
```
