### PR TITLE
auto-generate math.maxinteger and math.mininteger

### DIFF
--- a/spec/cli/gen_spec.lua
+++ b/spec/cli/gen_spec.lua
@@ -212,8 +212,16 @@ describe("tl gen", function()
       local t = {1, 2, 3, 4}
       print(table.unpack(t))
       local n = 42
+      local maxi = math.maxinteger
+      local mini = math.mininteger
       if n is integer then
          print("hello")
+      end
+      if maxi is integer then
+         print("maxi")
+      end
+      if mini is integer then
+         print("mini")
       end
    ]]
 
@@ -222,28 +230,52 @@ describe("tl gen", function()
       local t = { 1, 2, 3, 4 }
       print(table.unpack(t))
       local n = 42
+      local maxi = math.maxinteger
+      local mini = math.mininteger
       if math.type(n) == "integer" then
          print("hello")
+      end
+      if math.type(maxi) == "integer" then
+         print("maxi")
+      end
+      if math.type(mini) == "integer" then
+         print("mini")
       end
    ]]
 
    local output_code_with_optional_compat = [[
-      local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local math = _tl_compat and _tl_compat.math or math; local table = _tl_compat and _tl_compat.table or table; local _tl_table_unpack = unpack or table.unpack
+      local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local math = _tl_compat and _tl_compat.math or math; local _tl_math_maxinteger = math.maxinteger or math.pow(2, 53); local _tl_math_mininteger = math.mininteger or -math.pow(2, 53) - 1; local table = _tl_compat and _tl_compat.table or table; local _tl_table_unpack = unpack or table.unpack
       local t = { 1, 2, 3, 4 }
       print(_tl_table_unpack(t))
       local n = 42
+      local maxi = _tl_math_maxinteger
+      local mini = _tl_math_mininteger
       if math.type(n) == "integer" then
          print("hello")
+      end
+      if math.type(maxi) == "integer" then
+         print("maxi")
+      end
+      if math.type(mini) == "integer" then
+         print("mini")
       end
    ]]
 
    local output_code_with_required_compat = [[
-      local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = true, require('compat53.module'); if p then _tl_compat = m end end; local math = _tl_compat and _tl_compat.math or math; local table = _tl_compat and _tl_compat.table or table; local _tl_table_unpack = unpack or table.unpack
+      local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = true, require('compat53.module'); if p then _tl_compat = m end end; local math = _tl_compat and _tl_compat.math or math; local _tl_math_maxinteger = math.maxinteger or math.pow(2, 53); local _tl_math_mininteger = math.mininteger or -math.pow(2, 53) - 1; local table = _tl_compat and _tl_compat.table or table; local _tl_table_unpack = unpack or table.unpack
       local t = { 1, 2, 3, 4 }
       print(_tl_table_unpack(t))
       local n = 42
+      local maxi = _tl_math_maxinteger
+      local mini = _tl_math_mininteger
       if math.type(n) == "integer" then
          print("hello")
+      end
+      if math.type(maxi) == "integer" then
+         print("maxi")
+      end
+      if math.type(mini) == "integer" then
+         print("mini")
       end
    ]]
 

--- a/tl.lua
+++ b/tl.lua
@@ -4568,6 +4568,10 @@ local function add_compat_entries(program, used_set, gen_compat)
          load_code(name, "local bit32 = bit32; if not bit32 then local p, m = " .. req("bit32") .. "; if p then bit32 = m end")
       elseif name == "mt" then
          load_code(name, "local _tl_mt = function(m, s, a, b) return (getmetatable(s == 1 and a or b)[m](a, b) end")
+      elseif name == "math.maxinteger" then
+         load_code(name, "local _tl_math_maxinteger = math.maxinteger or math.pow(2,53)")
+      elseif name == "math.mininteger" then
+         load_code(name, "local _tl_math_mininteger = math.mininteger or -math.pow(2,53) - 1")
       else
          if not compat_loaded then
             load_code("compat", "local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = " .. req("compat53.module") .. "; if p then _tl_compat = m end")
@@ -4987,7 +4991,7 @@ rets = TUPLE({ a_type({ typename = "function", args = TUPLE({}), rets = TUPLE({ 
                   a_type({ typename = "function", args = VARARG({ ANY }), rets = TUPLE({ ANY }) }),
                },
             }),
-            ["maxinteger"] = INTEGER,
+            ["maxinteger"] = a_type({ typename = "integer", needs_compat = true }),
             ["min"] = a_type({
                typename = "poly",
                types = {
@@ -4997,7 +5001,7 @@ rets = TUPLE({ a_type({ typename = "function", args = TUPLE({}), rets = TUPLE({ 
                   a_type({ typename = "function", args = VARARG({ ANY }), rets = TUPLE({ ANY }) }),
                },
             }),
-            ["mininteger"] = INTEGER,
+            ["mininteger"] = a_type({ typename = "integer", needs_compat = true }),
             ["modf"] = a_type({ typename = "function", args = TUPLE({ NUMBER }), rets = TUPLE({ INTEGER, NUMBER }) }),
             ["pi"] = NUMBER,
             ["pow"] = a_type({ typename = "function", args = TUPLE({ NUMBER, NUMBER }), rets = TUPLE({ NUMBER }) }),

--- a/tl.tl
+++ b/tl.tl
@@ -4568,6 +4568,10 @@ local function add_compat_entries(program: Node, used_set: {string: boolean}, ge
          load_code(name, "local bit32 = bit32; if not bit32 then local p, m = " .. req("bit32") .. "; if p then bit32 = m end")
       elseif name == "mt" then
          load_code(name, "local _tl_mt = function(m, s, a, b) return (getmetatable(s == 1 and a or b)[m](a, b) end")
+      elseif name == "math.maxinteger" then
+         load_code(name, "local _tl_math_maxinteger = math.maxinteger or math.pow(2,53)")
+      elseif name == "math.mininteger" then
+         load_code(name, "local _tl_math_mininteger = math.mininteger or -math.pow(2,53) - 1")
       else
          if not compat_loaded then
             load_code("compat", "local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = " .. req("compat53.module") .. "; if p then _tl_compat = m end")
@@ -4987,7 +4991,7 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
                   a_type { typename = "function", args = VARARG { ANY }, rets = TUPLE { ANY } },
                }
             },
-            ["maxinteger"] = INTEGER,
+            ["maxinteger"] = a_type { typename = "integer", needs_compat = true },
             ["min"] = a_type {
                typename = "poly",
                types = {
@@ -4997,7 +5001,7 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
                   a_type { typename = "function", args = VARARG { ANY }, rets = TUPLE { ANY } },
                }
             },
-            ["mininteger"] = INTEGER,
+            ["mininteger"] = a_type { typename = "integer", needs_compat = true },
             ["modf"] = a_type { typename = "function", args = TUPLE { NUMBER }, rets = TUPLE { INTEGER, NUMBER } },
             ["pi"] = NUMBER,
             ["pow"] = a_type { typename = "function", args = TUPLE { NUMBER, NUMBER }, rets = TUPLE { NUMBER } },


### PR DESCRIPTION
As discussed in #488 

Without this change, `math.maxinteger` and `math.mininteger` would be accepted by Teal, but the generated Lua on PUC-Lua < 5.3 or LuaJIT without the compat module would not find it, resulting on a run-time error when attempting to use it.

The change makes Teal produce those two values, so they exist when compat is optional or required (they will not be provided by Teal when compat is `off`).