### PR TITLE
rockspec: Use HTTPS transport for fetching sources

### DIFF
--- a/tl-dev-1.rockspec
+++ b/tl-dev-1.rockspec
@@ -2,7 +2,7 @@ rockspec_format = "3.0"
 package = "tl"
 version = "dev-1"
 source = {
-   url = "git://github.com/teal-language/tl"
+   url = "git+https://github.com/teal-language/tl"
 }
 description = {
    summary = "Teal, a typed dialect of Lua",


### PR DESCRIPTION
GitHub are dropping support for the unencrypted git:// protocol: https://github.blog/2021-09-01-improving-git-protocol-security-github/

When installing tl through luarocks, this would cause issues such as:

```
$ luarocks --dev install tl

Cloning into 'tl'...

fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.

Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

To fix the issue, we set the source to an HTTPS URL, instead of a git:// URL.

Related: https://github.com/teal-language/teal-types/pull/29