### PR TITLE
fix error output for bad tlconfig.lua file

### DIFF
--- a/tl
+++ b/tl
@@ -903,6 +903,7 @@ local function get_config(cmd)
    if conf then
       local ok, user_config = pcall(conf)
       if not ok then
+         err = user_config
          die("Error loading tlconfig.lua:\n" .. err)
       end
 


### PR DESCRIPTION
Placing an error, eg `error("oops")` in a tlconfig.lua file currently results in:

```
/opt/homebrew/opt/lua/bin/lua5.4: /opt/homebrew/lib/luarocks/rocks-5.4/tl/0.13.2-1/bin/tl:906: attempt to concatenate a nil value (local 'err')
stack traceback:
	/opt/homebrew/lib/luarocks/rocks-5.4/tl/0.13.2-1/bin/tl:906: in local 'get_config'
	/opt/homebrew/lib/luarocks/rocks-5.4/tl/0.13.2-1/bin/tl:1322: in main chunk
	[C]: in ?
```

With this fix, you get:

```
Error loading tlconfig.lua:
tlconfig.lua:1: oops
```