### PR TITLE
Fix Lua 5.1 error (load -> loadstring)

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -2162,7 +2162,7 @@ local function parse_argument(ps, i)
       i, decltype = parse_type(ps, i)
 
       if node then
-         i, node.decltype = i, decltype
+         node.decltype = decltype
       end
    end
    return i, node, 0
@@ -9634,7 +9634,16 @@ local function tl_package_loader(module_name)
 
 
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
-      local chunk, err = load(code, "@" .. found_filename, "t")
+
+
+      local err = ""
+      local chunk = function() end
+      if _VERSION == "Lua 5.1" then
+         chunk = loadstring(code)
+         err = "5.1 error"
+      else
+         chunk, err = load(code, "@" .. found_filename, "t")
+      end
       if chunk then
          return function()
             local ret = chunk()

--- a/tl.lua
+++ b/tl.lua
@@ -9635,7 +9635,6 @@ local function tl_package_loader(module_name)
 
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
       local chunk, err = load(code, "@" .. found_filename, "t")
-
       if chunk then
          return function()
             local ret = chunk()

--- a/tl.lua
+++ b/tl.lua
@@ -9634,16 +9634,8 @@ local function tl_package_loader(module_name)
 
 
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
+      local chunk, err = load(code, "@" .. found_filename, "t")
 
-
-      local err = ""
-      local chunk = function() end
-      if _VERSION == "Lua 5.1" then
-         chunk = loadstring(code)
-         err = "5.1 error"
-      else
-         chunk, err = load(code, "@" .. found_filename, "t")
-      end
       if chunk then
          return function()
             local ret = chunk()

--- a/tl.tl
+++ b/tl.tl
@@ -9634,16 +9634,8 @@ local function tl_package_loader(module_name: string): any
       -- TODO: should this be a hard error? this seems analogous to
       -- finding a lua file with a syntax error in it
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
+      local chunk, err = load(code, "@" .. found_filename, "t")
 
-      -- Lua 5.1 doesn't have the load function, so if Lua 5.1 is in use, use loadstring instead.
-      local err = ""
-      local chunk = function() end
-      if _VERSION == "Lua 5.1" then
-      	chunk = loadstring(code)
-      	err = "5.1 error"
-      else
-         chunk, err = load(code, "@" .. found_filename, "t")
-      end
       if chunk then
          return function(): any
             local ret = chunk()

--- a/tl.tl
+++ b/tl.tl
@@ -9635,7 +9635,6 @@ local function tl_package_loader(module_name: string): any
       -- finding a lua file with a syntax error in it
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
       local chunk, err = load(code, "@" .. found_filename, "t")
-
       if chunk then
          return function(): any
             local ret = chunk()

--- a/tl.tl
+++ b/tl.tl
@@ -2162,7 +2162,7 @@ local function parse_argument(ps: ParseState, i: integer): integer, Node, intege
       i, decltype = parse_type(ps, i)
 
       if node then
-         i, node.decltype = i, decltype
+         node.decltype = decltype
       end
    end
    return i, node, 0
@@ -9634,7 +9634,16 @@ local function tl_package_loader(module_name: string): any
       -- TODO: should this be a hard error? this seems analogous to
       -- finding a lua file with a syntax error in it
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
-      local chunk, err = load(code, "@" .. found_filename, "t")
+
+      -- Lua 5.1 doesn't have the load function, so if Lua 5.1 is in use, use loadstring instead.
+      local err = ""
+      local chunk = function() end
+      if _VERSION == "Lua 5.1" then
+      	chunk = loadstring(code)
+      	err = "5.1 error"
+      else
+         chunk, err = load(code, "@" .. found_filename, "t")
+      end
       if chunk then
          return function(): any
             local ret = chunk()


### PR DESCRIPTION
I was attempting to run teal within gopher-lua - https://github.com/yuin/gopher-lua - and was running into a few odd errors. I was running the following scripts:

```go
//main.go
package main

import (
        "github.com/yuin/gopher-lua"
)

var luaString string = `
tl = require("tl")
tl.loader()
addsub = require("addsub")
print (addsub.add(10, 20))
`

func main() {
        L := lua.NewState()
        defer L.Close()
        if err := L.DoString(luaString); err != nil {
                panic(err)
        }

}
```

```teal
--addsub.tl
local addsub = {}

function addsub.add(a: number, b: number): number
   return a + b
end

function addsub.sub(a: number, b: number): number
   return a - b
end

return addsub
```

The code block `i, node.decltype = i, decltype` would cause a bubbling up error (since all the lua types were checked by Go) where `i` would occasionally be set to "decltype" (I have no idea why).  The second edit is just a little check for 5.1, since Lua 5.1 doesn't have load, I added in loadstring if it detects that version. These 2 edits let this script run properly so that I can run teal in Golang, which is pretty neat.

Happy to fix up formatting or anything else - tonight is the first time I've ever used lua, so I'm not sure about conventions here.

Note: on my computer, not all tests pass. Made issue #521 about that. All the tests that pass in master repo also pass in this updated repo.