### PR TITLE
Fix redeclaring `i`

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -2162,7 +2162,7 @@ local function parse_argument(ps, i)
       i, decltype = parse_type(ps, i)
 
       if node then
-         i, node.decltype = i, decltype
+         node.decltype = decltype
       end
    end
    return i, node, 0
@@ -9634,7 +9634,16 @@ local function tl_package_loader(module_name)
 
 
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
-      local chunk, err = load(code, "@" .. found_filename, "t")
+
+
+      local err = ""
+      local chunk = function() end
+      if _VERSION == "Lua 5.1" then
+         chunk = loadstring(code)
+         err = "5.1 error"
+      else
+         chunk, err = load(code, "@" .. found_filename, "t")
+      end
       if chunk then
          return function()
             local ret = chunk()

--- a/tl.lua
+++ b/tl.lua
@@ -9635,7 +9635,6 @@ local function tl_package_loader(module_name)
 
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
       local chunk, err = load(code, "@" .. found_filename, "t")
-
       if chunk then
          return function()
             local ret = chunk()

--- a/tl.lua
+++ b/tl.lua
@@ -9634,16 +9634,8 @@ local function tl_package_loader(module_name)
 
 
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
+      local chunk, err = load(code, "@" .. found_filename, "t")
 
-
-      local err = ""
-      local chunk = function() end
-      if _VERSION == "Lua 5.1" then
-         chunk = loadstring(code)
-         err = "5.1 error"
-      else
-         chunk, err = load(code, "@" .. found_filename, "t")
-      end
       if chunk then
          return function()
             local ret = chunk()

--- a/tl.tl
+++ b/tl.tl
@@ -9634,16 +9634,8 @@ local function tl_package_loader(module_name: string): any
       -- TODO: should this be a hard error? this seems analogous to
       -- finding a lua file with a syntax error in it
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
+      local chunk, err = load(code, "@" .. found_filename, "t")
 
-      -- Lua 5.1 doesn't have the load function, so if Lua 5.1 is in use, use loadstring instead.
-      local err = ""
-      local chunk = function() end
-      if _VERSION == "Lua 5.1" then
-      	chunk = loadstring(code)
-      	err = "5.1 error"
-      else
-         chunk, err = load(code, "@" .. found_filename, "t")
-      end
       if chunk then
          return function(): any
             local ret = chunk()

--- a/tl.tl
+++ b/tl.tl
@@ -9635,7 +9635,6 @@ local function tl_package_loader(module_name: string): any
       -- finding a lua file with a syntax error in it
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
       local chunk, err = load(code, "@" .. found_filename, "t")
-
       if chunk then
          return function(): any
             local ret = chunk()

--- a/tl.tl
+++ b/tl.tl
@@ -2162,7 +2162,7 @@ local function parse_argument(ps: ParseState, i: integer): integer, Node, intege
       i, decltype = parse_type(ps, i)
 
       if node then
-         i, node.decltype = i, decltype
+         node.decltype = decltype
       end
    end
    return i, node, 0
@@ -9634,7 +9634,16 @@ local function tl_package_loader(module_name: string): any
       -- TODO: should this be a hard error? this seems analogous to
       -- finding a lua file with a syntax error in it
       local code = assert(tl.pretty_print_ast(program, tl.package_loader_env.gen_target, true))
-      local chunk, err = load(code, "@" .. found_filename, "t")
+
+      -- Lua 5.1 doesn't have the load function, so if Lua 5.1 is in use, use loadstring instead.
+      local err = ""
+      local chunk = function() end
+      if _VERSION == "Lua 5.1" then
+      	chunk = loadstring(code)
+      	err = "5.1 error"
+      else
+         chunk, err = load(code, "@" .. found_filename, "t")
+      end
       if chunk then
          return function(): any
             local ret = chunk()


### PR DESCRIPTION
When running teal in gopher-lua (https://github.com/yuin/gopher-lua), types get checked by the system, and the single line `i, node.decltype = i, decltype` caused a complete failure to run teal. When replaced with the equivalent `node.decltype = decltype`, the system runs just fine.

These should be functionally equivalent. Nothing else is changed and it does not appear to change any tests.