### PR TITLE
canonicalize pathnames to improve behavior of env.loaded

### DIFF
--- a/spec/cli/build_script_spec.lua
+++ b/spec/cli/build_script_spec.lua
@@ -282,7 +282,7 @@ Wrote: build/build.lua
          cmd_output =
 [[========================================
 1 syntax error:
-./build.tl:8:17: syntax error
+build.tl:8:17: syntax error
 ]]
       })
    end)

--- a/spec/error_reporting/syntax_error_spec.lua
+++ b/spec/error_reporting/syntax_error_spec.lua
@@ -208,8 +208,8 @@ describe("syntax errors", function()
       }
 
       for file, expected in pairs(expected) do
-         assert.same(#expected, #(assert(result.env.loaded["./" .. file]).syntax_errors))
-         for i, err in ipairs(result.env.loaded["./" .. file].syntax_errors) do
+         assert.same(#expected, #(assert(result.env.loaded[file]).syntax_errors))
+         for i, err in ipairs(result.env.loaded[file].syntax_errors) do
             assert.match(expected[i].filename, err.filename, 1, true)
             assert.same(expected[i].y, err.y)
          end

--- a/spec/error_reporting/typecheck_error_spec.lua
+++ b/spec/error_reporting/typecheck_error_spec.lua
@@ -14,7 +14,7 @@ describe("typecheck errors", function()
       util.check_type_error([[
          local bar = require "bar"
       ]], {
-         { filename = "./bar.tl" }
+         { filename = "bar.tl" }
       })()
    end)
 
@@ -31,7 +31,7 @@ describe("typecheck errors", function()
       util.lax_check([[
          local bar = require "bar"
       ]], {
-         { msg = "b", filename = "./bar.lua" }
+         { msg = "b", filename = "bar.lua" }
       })()
    end)
 
@@ -106,7 +106,7 @@ describe("typecheck errors", function()
 
          aaa.myfunc(b)
       ]], {
-         { msg = "argument 1: Thing (defined in ./bbb.tl:4) is not a Thing (defined in ./aaa.tl:1)" }
+         { msg = "argument 1: Thing (defined in bbb.tl:4) is not a Thing (defined in aaa.tl:1)" }
       })()
    end)
 
@@ -149,7 +149,7 @@ describe("typecheck errors", function()
 
          aaa.myfunc(b)
       ]], {
-         { msg = "argument 1: Thing (defined in ./bbb.tl:1) is not a Thing (defined in ./aaa.tl:1)" }
+         { msg = "argument 1: Thing (defined in bbb.tl:1) is not a Thing (defined in aaa.tl:1)" }
       })()
    end)
 

--- a/spec/loader/loader_spec.lua
+++ b/spec/loader/loader_spec.lua
@@ -27,7 +27,7 @@ describe("tl.loader", function()
          end)
          util.assert_popen_close(0, pd:close())
          util.assert_line_by_line([[
-            @.]] .. util.os_sep .. [[file1.tl
+            @file1.tl
          ]], output)
       end)
    end)

--- a/spec/parser/parser_error_spec.lua
+++ b/spec/parser/parser_error_spec.lua
@@ -31,6 +31,6 @@ describe("parser errors", function()
          local bar = require "bar"
       ]]
       local result = tl.process_string(code, true, nil, "foo.tl")
-      assert.is_not_nil(string.match(result.env.loaded["./bar.tl"].syntax_errors[1].filename, "bar.tl$"), "errors should contain .filename property")
+      assert.is_not_nil(string.match(result.env.loaded["bar.tl"].syntax_errors[1].filename, "bar.tl$"), "errors should contain .filename property")
    end)
 end)

--- a/spec/stdlib/require_spec.lua
+++ b/spec/stdlib/require_spec.lua
@@ -313,7 +313,7 @@ describe("require", function()
 
       assert.same({}, result.syntax_errors)
       assert.same(1, #result.type_errors)
-      assert.match("Point (defined in foo.tl:3) is not a Point (defined in ./point.tl:1)", result.type_errors[1].msg, 1, true)
+      assert.match("Point (defined in foo.tl:3) is not a Point (defined in point.tl:1)", result.type_errors[1].msg, 1, true)
    end)
 
    it("catches errors in exported functions", function ()
@@ -336,8 +336,8 @@ describe("require", function()
       local result, err = tl.process("foo.tl")
 
       assert.same(0, #result.syntax_errors)
-      assert.same(1, #result.env.loaded["./box.tl"].type_errors)
-      assert.match("cannot use operator ..", result.env.loaded["./box.tl"].type_errors[1].msg)
+      assert.same(1, #result.env.loaded["box.tl"].type_errors)
+      assert.match("cannot use operator ..", result.env.loaded["box.tl"].type_errors[1].msg)
    end)
 
    it("exports global types", function ()

--- a/tl.tl
+++ b/tl.tl
@@ -131,6 +131,8 @@ local record tl
 
    package_loader_env: Env
    load_envs: { {any:any} : Env }
+
+   canonicalize_path: function(string, string): string
 end
 
 tl.version = function(): string
@@ -229,6 +231,51 @@ if os.getenv("TL_DEBUG") then
          end
       end
    end, "cr", 100)
+end
+
+--------------------------------------------------------------------------------
+-- File system utility
+--------------------------------------------------------------------------------
+
+function tl.canonicalize_path(filename: string, sep: string): string
+   if not filename then
+      return nil
+   end
+
+   sep = sep or package.config:sub(1, 1)
+   if sep ~= "/" then
+      filename = filename:gsub(sep, "/")
+   end
+
+   filename = filename:gsub("/*$", ""):gsub("/+", "/")
+   local pieces: {string} = {}
+   local drive = ""
+   if sep == "\\" and filename:match("^.:") then
+      drive, filename = filename:match("^(.:)(.*)$")
+   end
+   local root = ""
+   if filename:sub(1, 1) == "/" then
+      root = "/"
+   end
+   for piece in filename:gmatch("[^/]+") do
+      if piece == ".." then
+         local prev = pieces[#pieces]
+         if not prev or prev == ".." then
+            table.insert(pieces, "..")
+         elseif prev ~= "" then
+            table.remove(pieces)
+         end
+      elseif piece ~= "." then
+         table.insert(pieces, piece)
+      end
+   end
+   filename = (drive .. root .. table.concat(pieces, "/")):gsub("/*$", "")
+
+   if sep ~= "/" then
+      filename = filename:gsub("/", sep)
+   end
+
+   return filename
 end
 
 --------------------------------------------------------------------------------
@@ -2938,6 +2985,8 @@ local function clear_redundant_errors(errors: {Error})
 end
 
 function tl.parse_program(tokens: {Token}, errs: {Error}, filename: string): integer, Node, {string}
+   filename = tl.canonicalize_path(filename)
+
    errs = errs or {}
    local ps: ParseState = {
       tokens = tokens,
@@ -4499,19 +4548,18 @@ function tl.search_module(module_name: string, search_dtl: boolean): string, FIL
    local path = os.getenv("TL_PATH") or package.path
    if search_dtl then
       found, fd, tried = search_for(module_name, ".d.tl", path, tried)
-      if found then
-         return found, fd
-      end
    end
-   found, fd, tried = search_for(module_name, ".tl", path, tried)
+   if not found then
+      found, fd, tried = search_for(module_name, ".tl", path, tried)
+   end
+   if not found then
+      found, fd, tried = search_for(module_name, ".lua", path, tried)
+   end
    if found then
-      return found, fd
+      return tl.canonicalize_path(found), fd
+   else
+      return nil, nil, tried
    end
-   found, fd, tried = search_for(module_name, ".lua", path, tried)
-   if found then
-      return found, fd
-   end
-   return nil, nil, tried
 end
 
 local record Variable
@@ -9579,6 +9627,8 @@ end
 --------------------------------------------------------------------------------
 
 tl.process = function(filename: string, env: Env): Result, string
+   filename = tl.canonicalize_path(filename)
+
    if env and env.loaded and env.loaded[filename] then
       return env.loaded[filename]
    end
@@ -9609,6 +9659,7 @@ tl.process = function(filename: string, env: Env): Result, string
 end
 
 function tl.process_string(input: string, is_lua: boolean, env: Env, filename: string): Result
+   filename = tl.canonicalize_path(filename)
 
    env = env or tl.init_env(is_lua)
    if env.loaded and env.loaded[filename] then


### PR DESCRIPTION
This does not go as far as converting pathnames to absolute as that would require going beyond pure-Lua, but it does improve the situation. In particular, it should allow type-checking the global_env_def file from the current folder without a confusion between "file.d.tl" and "./file.d.tl".

Fixes #518 (unless relative and absolute paths are mixed, but it's an incremental improvement)
