### PR TITLE
Require "global function" in global functions

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -48,7 +48,7 @@ precedence, see below.
 
    label ::= ‘::’ Name ‘::’
 
-   funcname ::= Name {‘.’ Name} [‘:’ Name]
++  funcname ::= Name {‘.’ Name} ‘:’ Name | Name {‘.’ Name} ‘.’ Name
 
    varlist ::= var {‘,’ var}
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -680,7 +680,7 @@ You can declare functions that generate iterators which can be used in
 This is an example [taken the book "Programming in Lua"](https://www.lua.org/pil/7.1.html):
 
 ```
-function allwords(): (function(): string)
+local function allwords(): (function(): string)
    local line = io.read()
    local pos = 1
    return function(): string
@@ -711,7 +711,7 @@ in both function declarations.
 Just like in Lua, some functions in Teal may receive a variable amount of arguments. Variadic functions can be declared by specifying `...` as the last argument of the function:
 
 ```
-function test(...: number)
+local function test(...: number)
    print(...)
 end
 
@@ -721,7 +721,7 @@ test(1, 2, 3)
 In case your function returns a variable amount of values, you may also declare variadic return types by using the `type...` syntax:
 
 ```
-function test(...: number): number...
+local function test(...: number): number...
    return ...
 end
 
@@ -854,9 +854,15 @@ declaration and/or assignment:
 
 ```
 global n: number
+
 global m: {string:boolean} = {}
+
 global hi = function(): string
    return "hi"
+end
+
+global function my_function()
+   print("I am a global function")
 end
 ```
 

--- a/spec/call/generic_function_spec.lua
+++ b/spec/call/generic_function_spec.lua
@@ -381,7 +381,7 @@ describe("generic function", function()
 
    it("does not leak an unresolved generic type", function()
       local _, ast = util.check([[
-         function mypairs<a, b>(map: {a:b}): (a, b)
+         local function mypairs<a, b>(map: {a:b}): (a, b)
          end
 
          local _, resolved   = mypairs({["hello"] = true})
@@ -397,9 +397,9 @@ describe("generic function", function()
    end)
 
    it("does not produce a recursive type", util.lax_check([[
-      function mypairs<a, b>(map: {a:b}): (a, b)
+      local function mypairs<a, b>(map: {a:b}): (a, b)
       end
-      function myipairs<a>(array: {a}): (a)
+      local function myipairs<a>(array: {a}): (a)
       end
 
       local _, xs = mypairs(xss)

--- a/spec/call/record_method_spec.lua
+++ b/spec/call/record_method_spec.lua
@@ -41,7 +41,7 @@ describe("record method call", function()
          end
          return "what"
       end
-      function foo()
+      local function foo()
          r:f(r:f("hello"))
       end
    ]])

--- a/spec/cli/global_env_def_spec.lua
+++ b/spec/cli/global_env_def_spec.lua
@@ -6,11 +6,9 @@ describe("--global-env-def argument", function()
       util.do_in(util.write_tmp_dir(finally, {
          mod = {
             ["add.tl"] = [[
-               function add(n: number, m: number): number
+               global function add(n: number, m: number): number
                    return n + m
                end
-
-               return add
             ]],
          },
          ["test.tl"] = [[
@@ -39,11 +37,9 @@ describe("--global-env-def argument", function()
       util.do_in(util.write_tmp_dir(finally, {
          mod = {
             ["add.tl"] = [[
-               function add(n: number, m: number): number
+               global function add(n: number, m: number): number
                    return n + m
                end
-
-               return add
             ]],
          },
          ["test.tl"] = [[
@@ -60,11 +56,9 @@ describe("--global-env-def argument", function()
       util.do_in(util.write_tmp_dir(finally, {
          mod = {
             ["add.tl"] = [[
-               function add(n: number, m: number): number
+               global function add(n: number, m: number): number
                    return n + m
                end
-
-               return add
             ]],
          },
          ["test.tl"] = [[

--- a/spec/cli/include_dir_spec.lua
+++ b/spec/cli/include_dir_spec.lua
@@ -6,25 +6,28 @@ describe("-I --include-dir argument", function()
       util.do_in(util.write_tmp_dir(finally, {
          mod = {
             ["add.tl"] = [[
-               function add(n: number, m: number): number
+               local function add(n: number, m: number): number
                    return n + m
                end
 
                return add
             ]],
             ["subtract.tl"] = [[
-               function subtract(n: number, m: number): number
+               global function subtract(n: number, m: number): number
                    return n - m
                end
-
-               return subtract
             ]],
          },
          ["test.tl"] = [[
-            require("add")
+            local add = require("add")
             local x: number = add(1, 2)
 
             assert(x == 3)
+
+            require("subtract")
+            local y: number = subtract(100, 90)
+
+            assert(y == 10)
          ]],
       }), function()
          local pd = io.popen(util.tl_cmd("check", "-I", "mod", "test.tl"), "r")

--- a/spec/compat/lua_versions_spec.lua
+++ b/spec/compat/lua_versions_spec.lua
@@ -4,14 +4,14 @@ local util = require("spec.util")
 describe("Lua version compatibility", function()
    if _VERSION == "Lua 5.1" or _VERSION == "Lua 5.2" then
       it("generates compat code for // operator", util.gen([[
-         function hello(n: number): number
+         local function hello(n: number): number
             return 9
          end
 
          local x = 124 // 3
          local x = hello(12) // hello(hello(12) // 12)
       ]], [[
-         function hello(n)
+         local function hello(n)
             return 9
          end
 

--- a/spec/declaration/local_function_spec.lua
+++ b/spec/declaration/local_function_spec.lua
@@ -167,7 +167,7 @@ describe("local function", function()
 
          local normal: number
 
-         function new(normal: string): Name
+         local function new(normal: string): Name
             return {
                normal = normal:upper()
             }

--- a/spec/declaration/record_method_spec.lua
+++ b/spec/declaration/record_method_spec.lua
@@ -293,12 +293,12 @@ describe("record method", function()
    end)
 
    it("does not fail when declaring methods on untyped self (regression test for #427)", util.check_type_error([[
-      function foo()
-        local self = { }
-        function self:bar(): string
-          return "bar"
-        end
-        return self
+      local function foo()
+         local self = { }
+         function self:bar(): string
+            return "bar"
+         end
+         return self
       end
    ]], {
       { msg = "in return value: excess return values" }

--- a/spec/declaration/record_spec.lua
+++ b/spec/declaration/record_spec.lua
@@ -92,7 +92,7 @@ for i, name in ipairs({"records", "arrayrecords"}) do
             foo: R
          end
 
-         function id(r: R): R
+         local function id(r: R): R
             return r
          end
       ]]))
@@ -115,7 +115,7 @@ for i, name in ipairs({"records", "arrayrecords"}) do
             graphics: love_graphics
          end
 
-         function main()
+         global function main()
             love.graphics.print("Hello world", 100, 100)
          end
       ]]))
@@ -152,7 +152,7 @@ for i, name in ipairs({"records", "arrayrecords"}) do
             u: function(): string
          end
 
-         function f(r: R): R
+         local function f(r: R): R
             return r
          end
       ]], {
@@ -166,7 +166,7 @@ for i, name in ipairs({"records", "arrayrecords"}) do
             u: function(): UnknownType
          end
 
-         function f(r: R): R
+         local function f(r: R): R
             return r
          end
       ]], {
@@ -579,7 +579,7 @@ for i, name in ipairs({"records", "arrayrecords"}) do
             foo: R
          end
 
-         function id(r: R): R
+         local function id(r: R): R
             return r
          end
       ]]))
@@ -601,7 +601,7 @@ for i, name in ipairs({"records", "arrayrecords"}) do
             foo: R
          end
 
-         function id(r: R): R
+         local function id(r: R): R
             return r
          end
       ]], {

--- a/spec/operator/eq_spec.lua
+++ b/spec/operator/eq_spec.lua
@@ -198,7 +198,7 @@ describe("flow analysis with ==", function()
          local type UnionAorB = A | B
          local b: B = {}
 
-         function head(n: UnionAorB): UnionAorB
+         local function head(n: UnionAorB): UnionAorB
            if n == b then
              return n.h
            end
@@ -279,7 +279,7 @@ describe("flow analysis with ==", function()
       }))
 
       it("resolves == on the test", util.check [[
-         function process(ts: {number | string})
+         local function process(ts: {number | string})
             local t: number | string
             t = ts[1]
             local i = 1

--- a/spec/operator/index_spec.lua
+++ b/spec/operator/index_spec.lua
@@ -176,7 +176,7 @@ describe("[]", function()
          local wrong_var: WrongType = {}
          local index_var: IndexType = {}
 
-         function f<T, U>(a: T, b: U)
+         local function f<T, U>(a: T, b: U)
          end
 
          local map = {}

--- a/spec/operator/is_spec.lua
+++ b/spec/operator/is_spec.lua
@@ -141,7 +141,7 @@ describe("flow analysis with is", function()
          end
          local type UnionAorB = A | B
 
-         function head(n: UnionAorB): UnionAorB
+         local function head(n: UnionAorB): UnionAorB
            if n is B then
              return n.h
            else
@@ -393,7 +393,7 @@ describe("flow analysis with is", function()
       }))
 
       it("resolves is on the test", util.check [[
-         function process(ts: {number | string})
+         local function process(ts: {number | string})
             local t: number | string
             t = ts[1]
             local i = 1
@@ -419,7 +419,7 @@ describe("flow analysis with is", function()
       }))
 
       it("can resolve on else block even if it can't on if block (#210)", util.check [[
-         function foo(v: any)
+         local function foo(v: any)
             if not v is string then
                print("foo")
             else
@@ -516,7 +516,7 @@ describe("flow analysis with is", function()
       end)
 
       it("generates type checks for primitive types", util.gen([[
-         function process(ts: {number | string | boolean})
+         local function process(ts: {number | string | boolean})
             local t: number | string | boolean
             t = ts[1]
             if t is number then
@@ -526,7 +526,7 @@ describe("flow analysis with is", function()
             end
          end
       ]], [[
-         function process(ts)
+         local function process(ts)
             local t
             t = ts[1]
             if type(t) == "number" do
@@ -541,7 +541,7 @@ describe("flow analysis with is", function()
          local type U = record
             userdata
          end
-         function process(ts: {number | {string} | boolean | U})
+         global function process(ts: {number | {string} | boolean | U})
             local t: number | {string} | boolean | U
             t = ts[1]
             if t is number then

--- a/spec/statement/forin_spec.lua
+++ b/spec/statement/forin_spec.lua
@@ -59,7 +59,7 @@ describe("forin", function()
 
          local r: Rec = {}
 
-         function foo(init: Rec)
+         local function foo(init: Rec)
             for k, v in pairs(init) do
                r[k] = v
             end
@@ -95,7 +95,7 @@ describe("forin", function()
          metamethod __call: function(): integer
       end
 
-      function foo(incr: integer): R
+      local function foo(incr: integer): R
          local x = 0
          return setmetatable({incr=incr} as R, {
             __call = function(self: R): integer
@@ -116,7 +116,7 @@ describe("forin", function()
          metamethod __call: function(): integer
       end
 
-      function foo(): R
+      local function foo(): R
          return setmetatable({} as R, {
             __call = function(wrong_self: integer): integer
                return nil
@@ -136,7 +136,7 @@ describe("forin", function()
          metamethod __call: function(integer): integer
       end
 
-      function foo(): R
+      local function foo(): R
          return nil
       end
 
@@ -211,7 +211,7 @@ describe("forin", function()
       ]])
 
       it("accepts nested unresolved values", util.lax_check([[
-         function fun(xss)
+         local function fun(xss)
            for _, xs in pairs(xss) do
              for _, x in pairs(xs) do
                for _, u in ipairs({}) do

--- a/spec/statement/return_spec.lua
+++ b/spec/statement/return_spec.lua
@@ -55,7 +55,7 @@ describe("return", function()
          end
          local type unionAorB = A | B
 
-         function head(n: unionAorB): unionAorB
+         local function head(n: unionAorB): unionAorB
            if n is B then
              return n.h  --  10
            else

--- a/spec/stdlib/require_spec.lua
+++ b/spec/stdlib/require_spec.lua
@@ -81,7 +81,7 @@ describe("require", function()
          ["foo.tl"] = [[
             local point = require "point"
 
-            function bla(p: point.Point)
+            global function bla(p: point.Point)
                print(p.x, p.y)
             end
          ]],
@@ -176,7 +176,7 @@ describe("require", function()
             local bar = require "bar"
             local bla1 = require "bla"
 
-            function use_point(p: pnt.Point)
+            global function use_point(p: pnt.Point)
                print(p.x, p.y)
                print(bla1.func().xx)
             end
@@ -231,7 +231,7 @@ describe("require", function()
             local pnt = require "point"
             local bar = require "bar"
 
-            function use_point(p: pnt.Point)
+            global function use_point(p: pnt.Point)
                print(p.x, p.y)
             end
 
@@ -419,7 +419,7 @@ describe("require", function()
          ["main.tl"] = [[
             local someds = require("someds")
 
-            function main()
+            global function main()
                local b:someds.Callback = function(event: someds.Event)
                end
                someds.subscribe(b)
@@ -448,7 +448,7 @@ describe("require", function()
          ["main.tl"] = [[
             local som = require("someds")
 
-            function main()
+            global function main()
                local b:som.Callback = function(event: som.Event)
                end
                som.subscribe(b)
@@ -504,7 +504,7 @@ describe("require", function()
          ["main.tl"] = [[
             local someds = require("someds")
 
-            function main()
+            global function main()
                local b:someds.Callback = function(event: someds.Event<string>)
                end
                someds.subscribe(b)
@@ -661,7 +661,7 @@ describe("require", function()
                 lu.assertIsTrue(100 == 200)
             end
 
-            function main(args: any)
+            global function main(args: any)
                 local runner = lu.LuaUnit.new()
                 runner:setOutputType("tap")
                 local code = runner:runSuite(args)

--- a/tl.lua
+++ b/tl.lua
@@ -1241,6 +1241,7 @@ local Node = {ExpectedContext = {}, }
 
 
 
+
 local function is_array_type(t)
    return t.typename == "array" or t.typename == "arrayrecord"
 end
@@ -2229,7 +2230,12 @@ local function parse_local_function(ps, i)
    return parse_function_args_rets_body(ps, i, node)
 end
 
-local function parse_global_function(ps, i)
+local FunctionType = {}
+
+
+
+
+local function parse_function(ps, i, ft)
    local orig_i = i
    i = verify_tk(ps, i, "function")
    local fn = new_node(ps.tokens, i, "global_function")
@@ -2266,6 +2272,12 @@ local function parse_global_function(ps, i)
 
    if not fn.name then
       return orig_i + 1
+   end
+
+   if fn.kind == "record_function" and ft == "global" then
+      fail(ps, orig_i, "record functions cannot be annotated as 'global'")
+   elseif fn.kind == "global_function" and ft == "record" then
+      fn.implicit_global_function = true
    end
 
    return i, fn
@@ -2838,7 +2850,7 @@ end
 local function parse_global(ps, i)
    local ntk = ps.tokens[i + 1].tk
    if ntk == "function" then
-      return parse_global_function(ps, i + 1)
+      return parse_function(ps, i + 1, "global")
    elseif ntk == "type" and ps.tokens[i + 2].kind == "identifier" then
       return parse_type_declaration(ps, i, "global_type")
    elseif ntk == "record" and ps.tokens[i + 2].kind == "identifier" then
@@ -2858,6 +2870,10 @@ local function parse_type_statement(ps, i)
    return parse_call_or_assignment(ps, i)
 end
 
+local function parse_record_function(ps, i)
+   return parse_function(ps, i, "record")
+end
+
 local parse_statement_fns = {
    ["::"] = parse_label,
    ["do"] = parse_do,
@@ -2871,7 +2887,7 @@ local parse_statement_fns = {
    ["global"] = parse_global,
    ["repeat"] = parse_repeat,
    ["return"] = parse_return,
-   ["function"] = parse_global_function,
+   ["function"] = parse_record_function,
 }
 
 parse_statements = function(ps, i, toplevel)
@@ -8668,6 +8684,9 @@ node.exps[3] and node.exps[3].type, }
       ["global_function"] = {
          before = function(node)
             begin_scope(node)
+            if (not lax) and node.implicit_global_function then
+               node_error(node, "functions need an explicit 'local' or 'global' annotation")
+            end
          end,
          before_statements = function(node)
             add_internal_function_variables(node)

--- a/tl.tl
+++ b/tl.tl
@@ -1190,6 +1190,7 @@ local record Node
    args: Node
    rets: Type
    body: Node
+   implicit_global_function: boolean
 
    name: Node
 
@@ -2229,7 +2230,12 @@ local function parse_local_function(ps: ParseState, i: integer): integer, Node
    return parse_function_args_rets_body(ps, i, node)
 end
 
-local function parse_global_function(ps: ParseState, i: integer): integer, Node
+local enum FunctionType
+   "global"
+   "record"
+end
+
+local function parse_function(ps: ParseState, i: integer, ft: FunctionType): integer, Node
    local orig_i = i
    i = verify_tk(ps, i, "function")
    local fn = new_node(ps.tokens, i, "global_function")
@@ -2266,6 +2272,12 @@ local function parse_global_function(ps: ParseState, i: integer): integer, Node
 
    if not fn.name then
       return orig_i + 1
+   end
+
+   if fn.kind == "record_function" and ft == "global" then
+      fail(ps, orig_i, "record functions cannot be annotated as 'global'")
+   elseif fn.kind == "global_function" and ft == "record" then
+      fn.implicit_global_function = true
    end
 
    return i, fn
@@ -2838,7 +2850,7 @@ end
 local function parse_global(ps: ParseState, i: integer): integer, Node
    local ntk = ps.tokens[i + 1].tk
    if ntk == "function" then
-      return parse_global_function(ps, i + 1)
+      return parse_function(ps, i + 1, "global")
    elseif ntk == "type" and ps.tokens[i+2].kind == "identifier" then
       return parse_type_declaration(ps, i, "global_type")
    elseif ntk == "record" and ps.tokens[i+2].kind == "identifier" then
@@ -2858,6 +2870,10 @@ local function parse_type_statement(ps: ParseState, i: integer): integer, Node
    return parse_call_or_assignment(ps, i)
 end
 
+local function parse_record_function(ps: ParseState, i: integer): integer, Node
+   return parse_function(ps, i, "record")
+end
+
 local parse_statement_fns: {string : function(ParseState, integer):(integer, Node)} = {
    ["::"] = parse_label,
    ["do"] = parse_do,
@@ -2871,7 +2887,7 @@ local parse_statement_fns: {string : function(ParseState, integer):(integer, Nod
    ["global"] = parse_global,
    ["repeat"] = parse_repeat,
    ["return"] = parse_return,
-   ["function"] = parse_global_function,
+   ["function"] = parse_record_function,
 }
 
 parse_statements = function(ps: ParseState, i: integer, toplevel: boolean): integer, Node
@@ -8668,6 +8684,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
       ["global_function"] = {
          before = function(node: Node)
             begin_scope(node)
+            if (not lax) and node.implicit_global_function then
+               node_error(node, "functions need an explicit 'local' or 'global' annotation")
+            end
          end,
          before_statements = function(node: Node)
             add_internal_function_variables(node)


### PR DESCRIPTION
This PR changes the language so that bare `function name() ... end` doesn't work anymore: you need to say either `local function name() ... end` or `global function name() ... end`.

Record functions still work the same way:
* `function record:field() end` and `function record.field() end` still work.

Function values still work the same way:
* `x = function() end` still works.

Bare `function name() ... end` still works if the file extension is `.lua` instead of `.tl` (triggering the compiler's "lax mode").

Initial feedback regarding this change was positive back in February when I brought it up in the Matrix/Gitter chat in the wake of #500, but I'd still like to get feedback before merging this significant change!

Closes #500.