### PR TITLE
accept nested type arguments

### DIFF
--- a/spec/parser/parser_spec.lua
+++ b/spec/parser/parser_spec.lua
@@ -67,4 +67,33 @@ describe("parser", function()
       assert.same("table_item", result.ast[1].exps[1][1].kind)
       assert.same("implicit", result.ast[1].exps[1][1].key_parsed)
    end)
+
+   it("accepts nested type arguments", function ()
+      local result = tl.process_string([[
+         local record List<T>
+            items: {T}
+         end
+
+         local record Box<T>
+            item: {T}
+         end
+
+         local list_of_boxes: List<Box<string>> = {
+            items = {}
+         }
+
+         local box: Box<string> = { item = "hello" }
+
+         list_of_boxes.items[1] = box
+      ]])
+      assert.same({}, result.syntax_errors)
+      assert.same(5, #result.ast)
+      assert.same("local_type", result.ast[1].kind)
+      assert.same("local_type", result.ast[2].kind)
+      assert.same("local_declaration", result.ast[3].kind)
+      assert.same("local_declaration", result.ast[4].kind)
+      assert.same("assignment", result.ast[5].kind)
+   end)
+
+
 end)

--- a/tl.tl
+++ b/tl.tl
@@ -1534,7 +1534,25 @@ local function parse_trying_list<T>(ps: ParseState, i: integer, list: {T}, parse
    return i, list
 end
 
-local function parse_typearg_type(ps: ParseState, i: integer): integer, Type, integer
+local function parse_anglebracket_list<T>(ps: ParseState, i: integer, parse_item: ParseItem<Type>): integer, {Type}
+   if ps.tokens[i+1].tk == ">" then
+      return fail(ps, i+1, "type argument list cannot be empty")
+   end
+   local typ = new_type(ps, i, "tuple")
+   i = verify_tk(ps, i, "<")
+   i = parse_list(ps, i, typ, { [">"] = true, [">>"] = true, }, "sep", parse_item)
+   if ps.tokens[i].tk == ">" then
+      i = i + 1
+   elseif ps.tokens[i].tk == ">>" then
+      -- tokenizer hack: consume one bracket from '>>', don't increment i
+      ps.tokens[i].tk = ">"
+   else
+      return fail(ps, i, "syntax error, expected '>'")
+   end
+   return i, typ
+end
+
+local function parse_typearg(ps: ParseState, i: integer): integer, Type, integer
    i = verify_kind(ps, i, "identifier")
    return i, a_type {
       y = ps.tokens[i - 2].y,
@@ -1542,22 +1560,6 @@ local function parse_typearg_type(ps: ParseState, i: integer): integer, Type, in
       typename = "typearg",
       typearg = ps.tokens[i-1].tk,
    }
-end
-
-local function parse_typearg_list(ps: ParseState, i: integer): integer, Type
-   if ps.tokens[i+1].tk == ">" then
-      return fail(ps, i+1, "type argument list cannot be empty")
-   end
-   local typ = new_type(ps, i, "tuple")
-   return parse_bracket_list(ps, i, typ, "<", ">", "sep", parse_typearg_type)
-end
-
-local function parse_typeval_list(ps: ParseState, i: integer): integer, Type
-   if ps.tokens[i+1].tk == ">" then
-      return fail(ps, i+1, "type argument list cannot be empty")
-   end
-   local typ = new_type(ps, i, "tuple")
-   return parse_bracket_list(ps, i, typ, "<", ">", "sep", parse_type)
 end
 
 local function parse_return_types(ps: ParseState, i: integer): integer, Type
@@ -1568,7 +1570,7 @@ local function parse_function_type(ps: ParseState, i: integer): integer, Type
    local typ = new_type(ps, i, "function")
    i = i + 1
    if ps.tokens[i].tk == "<" then
-      i, typ.typeargs = parse_typearg_list(ps, i)
+      i, typ.typeargs = parse_anglebracket_list(ps, i, parse_typearg)
    end
    if ps.tokens[i].tk == "(" then
       i, typ.args = parse_argument_type_list(ps, i)
@@ -1621,7 +1623,7 @@ local function parse_base_type(ps: ParseState, i: integer): integer, Type, integ
       end
 
       if ps.tokens[i].tk == "<" then
-         i, typ.typevals = parse_typeval_list(ps, i)
+         i, typ.typevals = parse_anglebracket_list(ps, i, parse_type)
       end
       return i, typ
    elseif tk == "{" then
@@ -1752,7 +1754,7 @@ end
 local function parse_function_args_rets_body(ps: ParseState, i: integer, node: Node): integer, Node
    local istart = i - 1
    if ps.tokens[i].tk == "<" then
-      i, node.typeargs = parse_typearg_list(ps, i)
+      i, node.typeargs = parse_anglebracket_list(ps, i, parse_typearg)
    end
    i, node.args = parse_argument_list(ps, i)
    i, node.rets = parse_return_types(ps, i)
@@ -2551,7 +2553,7 @@ parse_record_body = function(ps: ParseState, i: integer, def: Type, node: Node):
    def.fields = {}
    def.field_order = {}
    if ps.tokens[i].tk == "<" then
-      i, def.typeargs = parse_typearg_list(ps, i)
+      i, def.typeargs = parse_anglebracket_list(ps, i, parse_typearg)
    end
    while not (ps.tokens[i].kind == "$EOF$" or ps.tokens[i].tk == "end") do
       if ps.tokens[i].tk == "userdata" and ps.tokens[i+1].tk ~= ":" then


### PR DESCRIPTION
Fixes C++98-like ambiguity when using nested type variables like `T<U<V>>`, as pointed out by @wqferr, using a C++11-like solution in the parser.
