### PR TITLE
Fix a few compiler issues with close attribute

### DIFF
--- a/spec/assignment/to_const_spec.lua
+++ b/spec/assignment/to_const_spec.lua
@@ -16,4 +16,46 @@ describe("assignment to const", function()
    ]], {
       { msg = "expected a local variable definition" }
    }))
+
+   it("close variable fails", util.check_type_error([[
+      local record R
+         metamethod __close: function()
+      end
+      local c <close>: R = setmetatable({}, {
+         __close = function() end
+      })
+      c = nil
+   ]], {
+      { y = 7, x = 7, msg = "cannot assign to <close> variable" },
+   }, "5.4"))
+
+   it("close variable 'is_closable' check should not crash with built-in function", util.check_type_error([[
+      local function f() end
+      local a <close> = f
+      local b <close> = setmetatable
+   ]], {
+      { y = 2, x = 13, msg = "to-be-closed variable a has a non-closable type function()" },
+      { y = 3, x = 13, msg = "to-be-closed variable b has a non-closable type function<A>(A, metatable<A>): A" },
+   }, "5.4"))
+end)
+
+describe("attributes syntax", function()
+   it("with annotation error", util.check_syntax_error([[
+      local c <costn> = 3
+      local a <> = 1
+      print(c, a)
+   ]], {
+      { y = 1, x = 21, msg = "unknown variable annotation: costn" },
+      { y = 2, x = 16, msg = "syntax error, expected identifier" },
+      { y = 2, x = 18, msg = "expected a variable annotation" },
+      { y = 3, x = 7, msg = "syntax error" },
+   }))
+
+   it("error", util.check_syntax_error([[
+      local b < = 2
+      print(b)
+   ]], {
+      { y = 1, x = 17, msg = "syntax error, expected identifier"},
+      { y = 1, x = 19, msg = "expected a variable annotation" },
+   }))
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -2183,11 +2183,11 @@ local function parse_variable_name(ps, i)
          if not is_attribute[annotation.tk] then
             fail(ps, i, "unknown variable annotation: " .. annotation.tk)
          end
+         node.attribute = annotation.tk
       else
          fail(ps, i, "expected a variable annotation")
       end
       i = verify_tk(ps, i, ">")
-      node.attribute = annotation.tk
    end
    return i, node
 end
@@ -5008,6 +5008,7 @@ local function init_globals(lax)
                ["__eq"] = a_type({ typename = "function", args = TUPLE({ ANY, ANY }), rets = TUPLE({ BOOLEAN }) }),
                ["__lt"] = a_type({ typename = "function", args = TUPLE({ ANY, ANY }), rets = TUPLE({ BOOLEAN }) }),
                ["__le"] = a_type({ typename = "function", args = TUPLE({ ANY, ANY }), rets = TUPLE({ BOOLEAN }) }),
+               ["__close"] = a_type({ typename = "function", args = TUPLE({ a }), rets = TUPLE({}) }),
             },
          } end),
       }),
@@ -6929,7 +6930,9 @@ tl.type_check = function(ast, opts)
       if same_type(t, NIL) then
          return true
       end
-      t = resolve_nominal(t)
+      if t.typename ~= "function" then
+         t = resolve_nominal(t)
+      end
       return t.meta_fields and t.meta_fields["__close"] ~= nil
    end
 

--- a/tl.tl
+++ b/tl.tl
@@ -2183,11 +2183,11 @@ local function parse_variable_name(ps: ParseState, i: integer): integer, Node, i
          if not is_attribute[annotation.tk] then
             fail(ps, i, "unknown variable annotation: " .. annotation.tk)
          end
+         node.attribute = annotation.tk as Attribute
       else
          fail(ps, i, "expected a variable annotation")
       end
       i = verify_tk(ps, i, ">")
-      node.attribute = annotation.tk as Attribute
    end
    return i, node
 end
@@ -5008,6 +5008,7 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
                ["__eq"] = a_type { typename = "function", args = TUPLE { ANY, ANY }, rets = TUPLE { BOOLEAN } },
                ["__lt"] = a_type { typename = "function", args = TUPLE { ANY, ANY }, rets = TUPLE { BOOLEAN } },
                ["__le"] = a_type { typename = "function", args = TUPLE { ANY, ANY }, rets = TUPLE { BOOLEAN } },
+               ["__close"] = a_type { typename = "function", args = TUPLE { a }, rets = TUPLE { } },
             },
          } end),
       },
@@ -6929,7 +6930,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
       if same_type(t, NIL) then
          return true
       end
-      t = resolve_nominal(t)
+      if t.typename ~= "function" then
+         t = resolve_nominal(t)
+      end
       return t.meta_fields and t.meta_fields["__close"] ~= nil
    end
 


### PR DESCRIPTION
Fix a few issues when using Teal with close attributes feature. Stop vscode plugin from complaining compiler crashes.