### PR TITLE
Generate cleaner codes for nil check

### DIFF
--- a/spec/operator/is_spec.lua
+++ b/spec/operator/is_spec.lua
@@ -356,6 +356,27 @@ describe("flow analysis with is", function()
          { y = 10, msg = "got boolean | thread, expected boolean" },
       }))
 
+      it("gen cleaner checking codes for nil", util.gen([[
+         local record R
+            f: function()
+         end
+         local function get(): R | nil
+         end
+         local r = get()
+         if not r is nil then
+            r.f()
+         end
+      ]], [[
+
+
+
+local function get()
+end
+local r = get()
+if not (r == nil) then
+   r.f()
+end]]))
+
    end)
 
    describe("on while", function()

--- a/tl.lua
+++ b/tl.lua
@@ -3960,6 +3960,9 @@ function tl.pretty_print_ast(ast, gen_target, mode)
                   table.insert(out, "math.type(")
                   add_child(out, children[1], "", indent)
                   table.insert(out, ") == \"integer\"")
+               elseif node.e2.casttype.typename == "nil" then
+                  add_child(out, children[1], "", indent)
+                  table.insert(out, " == nil")
                else
                   table.insert(out, "type(")
                   add_child(out, children[1], "", indent)

--- a/tl.tl
+++ b/tl.tl
@@ -3960,6 +3960,9 @@ function tl.pretty_print_ast(ast: Node, gen_target: TargetMode, mode: boolean | 
                   table.insert(out, "math.type(")
                   add_child(out, children[1], "", indent)
                   table.insert(out, ") == \"integer\"")
+               elseif node.e2.casttype.typename == "nil" then
+                  add_child(out, children[1], "", indent)
+                  table.insert(out, " == nil")
                else
                   table.insert(out, "type(")
                   add_child(out, children[1], "", indent)


### PR DESCRIPTION
Have been using an idiom to notice user to do a nil check before using some API results.
```lua
local record R
   f: function()
end
local function get(): R | nil
end
local r = get()
if not r is nil then
   r.f()
end
```
And currently `r is nil` is being generated to `(type(r) == "nil")`, could make it to be just `(r == nil)`.