### PR TITLE
should not used # on map with number key type

### DIFF
--- a/spec/assignment/to_map_spec.lua
+++ b/spec/assignment/to_map_spec.lua
@@ -46,12 +46,10 @@ describe("assignment to maps", function()
    ]])
 
    it("does not accept an array-like key in a map", util.check_type_error([[
-      local function f(x: {string:any}): number
-         return #x
+      local function f(x: {string:any})
       end
 
-      local x = f({"string value", pi=math.pi})
-      print(x)
+      f({"string value", pi=math.pi})
    ]], {
       { msg = "argument 1: in map key: got integer, expected string" }
    }))

--- a/spec/operator/len_spec.lua
+++ b/spec/operator/len_spec.lua
@@ -7,4 +7,17 @@ describe("#", function()
    it("returns an integer when used on tuple", util.check[[
       local x: integer = #({1, "hi"})
    ]])
+
+   it("the map size is always zero", util.check_type_error([[
+       local x: {string:string} = {a="a", b="b", c="c"}
+       print(#x)
+   ]], {
+      { y=2, msg = "use # operator on this map will always get 0" }
+   }))
+   it("the map size may be wrong", util.check_warnings([[
+       local x: {integer:string} = {[1]="a", [2]="b", [4]="c"}
+       print(#x)
+   ]], {
+      { y=2, msg = "use # operator on map with number key type may get unexpected result" }
+   }))
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -9179,6 +9179,13 @@ node.exps[3] and node.exps[3].type, }
                      return node_error(node, "cannot use operator '" .. node.op.op:gsub("%%", "%%%%") .. "' on type %s", resolve_tuple(orig_a))
                   end
                end
+               if a.typename == "map" then
+                  if a.keys.typename == "number" or a.keys.typename == "integer" then
+                     node_warning("hint", node, "use # operator on map with number key type may get unexpected result")
+                  else
+                     return node_error(node, "use # operator on this map will always get 0")
+                  end
+               end
 
                if node.type.typename ~= "boolean" and not is_unknown(node.type) then
                   node.known = FACT_TRUTHY

--- a/tl.tl
+++ b/tl.tl
@@ -9179,6 +9179,13 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
                      return node_error(node, "cannot use operator '" .. node.op.op:gsub("%%", "%%%%") .. "' on type %s", resolve_tuple(orig_a))
                   end
                end
+               if a.typename == "map" then
+                  if a.keys.typename == "number" or a.keys.typename == "integer" then
+                      node_warning("hint", node, "use # operator on map with number key type may get unexpected result")
+                  else
+                      return node_error(node, "use # operator on this map will always get 0")
+                  end
+               end
 
                if node.type.typename ~= "boolean" and not is_unknown(node.type) then
                   node.known = FACT_TRUTHY


### PR DESCRIPTION
```lua
x = {[1]="a", [2]="b", [5]="c"}
print(#x)
```
will get `2`

```lua
x ={a="a", b="b", c="c"}
print(#x)
```
will always get `0`

This is probably a bug in your code, it not equal to `map_key_number(var)`

-----

If the key inserted to the map is in order (like 1, 2, 3), the result it correct, so `#` on map of number key will throw a warning instead of error.