### PR TITLE
improve error message for redefined functions

### DIFF
--- a/spec/error_reporting/warning_spec.lua
+++ b/spec/error_reporting/warning_spec.lua
@@ -113,6 +113,34 @@ describe("warnings", function()
          { y = 2, msg = "redeclaration of variable 'i' (originally declared at 1:16)" },
          { y = 1, msg = "unused variable i: integer" },
       }))
+
+
+      it("reports redefined local functions", util.check_warnings([[
+         local function a() end
+         a()
+         local function a() end
+         a()
+      ]], {
+         { y = 3, msg = "redeclaration of function 'a' (originally declared at 1:10)" },
+      }))
+
+      it("reports local functions redefined as variables", util.check_warnings([[
+         local function a() end
+         a()
+         local a = 3
+         print(a)
+      ]], {
+         { y = 3, msg = "redeclaration of variable 'a' (originally declared at 1:10)" },
+      }))
+
+      it("reports local variables redefined as functions", util.check_warnings([[
+         local a = 3
+         print(a)
+         local function a() end
+         a()
+      ]], {
+         { y = 3, msg = "redeclaration of function 'a' (originally declared at 1:16)" },
+      }))
    end)
 
    describe("on goto labels", function()

--- a/tl.tl
+++ b/tl.tl
@@ -5841,10 +5841,19 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
 
    local function redeclaration_warning(node: Node, old_var: Variable)
       if node.tk:sub(1, 1) == "_" then return end
+
+      local var_kind = "variable"
+      local var_name = node.tk
+      if node.kind == "local_function" then
+         var_kind = "function"
+         var_name = node.name.tk
+      end
+
+      local short_error = "redeclaration of " .. var_kind .. " '%s'"
       if old_var.declared_at then
-         node_warning("redeclaration", node, "redeclaration of variable '%s' (originally declared at %d:%d)", node.tk, old_var.declared_at.y, old_var.declared_at.x)
+         node_warning("redeclaration", node, short_error .. " (originally declared at %d:%d)", var_name, old_var.declared_at.y, old_var.declared_at.x)
       else
-         node_warning("redeclaration", node, "redeclaration of variable '%s'", node.tk)
+         node_warning("redeclaration", node, short_error, var_name)
       end
    end
 


### PR DESCRIPTION
Consider this code sample:

```
local function foo() end
local function foo() end
```

Before this change:

```
========================================
3 warnings:
invalid.tl:2:1: redeclaration of variable 'local' (originally declared at 1:1)
invalid.tl:1:1: unused function foo: function()
invalid.tl:2:1: unused function foo: function()
```

After this change:

```
========================================
3 warnings:
invalid.tl:2:1: redeclaration of function 'foo' (originally declared at 1:1)
invalid.tl:1:1: unused function foo: function()
invalid.tl:2:1: unused function foo: function()
```