### PR TITLE
Allow predeclaration of local functions

### DIFF
--- a/spec/declaration/global_function_spec.lua
+++ b/spec/declaration/global_function_spec.lua
@@ -58,6 +58,13 @@ describe("global function", function()
       { y = 1, msg = "functions need an explicit 'local' or 'global' annotation" },
    }))
 
+   it("a function can be pre-declared", util.check [[
+      local f: function()
+      function f()
+         print("I am a bare function")
+      end
+   ]])
+
    local modes = {
       {
          fn = "function",

--- a/tl.tl
+++ b/tl.tl
@@ -1191,6 +1191,7 @@ local record Node
    rets: Type
    body: Node
    implicit_global_function: boolean
+   is_predeclared_local_function: boolean
 
    name: Node
 
@@ -8885,8 +8886,17 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
       ["global_function"] = {
          before = function(node: Node)
             begin_scope(node)
-            if (not lax) and node.implicit_global_function then
-               node_error(node, "functions need an explicit 'local' or 'global' annotation")
+            if node.implicit_global_function then
+               local typ = find_var_type(node.name.tk)
+               if typ then
+                  if typ.typename == "function" then
+                     node.is_predeclared_local_function = true
+                  elseif not lax then
+                     node_error(node, "cannot declare function: type of " .. node.name.tk .. " is %s", typ)
+                  end
+               elseif not lax then
+                  node_error(node, "functions need an explicit 'local' or 'global' annotation")
+               end
             end
          end,
          before_statements = function(node: Node)
@@ -8895,6 +8905,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
          end,
          after = function(node: Node, children: {Type}): Type
             end_function_scope(node)
+            if node.is_predeclared_local_function then
+               return node.type
+            end
             add_global(node, node.name.tk, a_type {
                y = node.y,
                x = node.x,


### PR DESCRIPTION
Consider this code sample:

```
local foo : function()
function foo() end
foo()
```

Before this change it would fail with:

```
========================================
1 error:
invalid.tl:2:1: functions need an explicit 'local' or 'global' annotation
```

This change makes it valid again (it was the case before 0.14).

Rationale: in Lua `function foo() end` is sugar for `foo = function() end`, and I suppose it should remain the same in Teal.

This kind of code is useful to write mutually recursive functions such as this:

```
local collatz_odd : function(integer): integer

local function collatz_even(n: integer): integer
    print(n)
    n = n // 2
    if n % 2 == 1 then
        return collatz_odd(n)
    end
    return collatz_even(n)
end

function collatz_odd(n: integer): integer
    print(n)
    if n == 1 then
        return 1
    end
    return collatz_even(3 * n + 1)
end

collatz_odd(7)
```