### PR TITLE
Update playground.yml to use newer node.js version

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
As it goes wrong in the part that uploads the lua compiler to the playground I don't have a much better way to check if it works than making a PR and hope for the best.

I do however believe that updating the node.js version is the way forward compared to finding a version of netlify-cli that works on version 12 as 12 is ancient at this point.