### PR TITLE
playground: Use NodeJS 14.x as required by deps

### DIFF
--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
     steps:
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
Some dependencies now require usage of NodeJS 14.x