### PR TITLE
Fix a case userdata record is not resolved properly

### DIFF
--- a/spec/statement/return_spec.lua
+++ b/spec/statement/return_spec.lua
@@ -97,6 +97,29 @@ describe("return", function()
       ]], {
          { msg = "in return value (inferred at foo.tl:2:13): got integer, expected string" }
       }))
+
+      it("when exporting userdata record", function ()
+         util.mock_io(finally, {
+            ["mod.tl"] = [[
+               local record R
+                  userdata
+               end
+               local r: R
+               return r
+            ]],
+            ["foo.tl"] = [[
+               local r = require("mod")
+               return r
+            ]],
+         })
+
+         local tl = require("tl")
+         local result, err = tl.process("foo.tl", assert(tl.init_env()))
+
+         assert.same(nil, err)
+         assert.same({}, result.syntax_errors)
+         assert.same({}, result.type_errors)
+      end)
    end)
 
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -5732,6 +5732,7 @@ tl.type_check = function(ast, opts)
          local copy = {}
          seen[orig_t] = copy
 
+         copy.is_userdata = t.is_userdata
          copy.typename = t.typename
          copy.filename = t.filename
          copy.typeid = t.typeid

--- a/tl.tl
+++ b/tl.tl
@@ -5732,6 +5732,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
          local copy: Type = {}
          seen[orig_t] = copy
 
+         copy.is_userdata = t.is_userdata
          copy.typename = t.typename
          copy.filename = t.filename
          copy.typeid = t.typeid


### PR DESCRIPTION
The problem appeared after the new return inference commit, the minimal issue case is:
```lua
-- file: mod.tl
local record R
   userdata
end
local r: R
return r

-- file: foo.tl
local r = require("mod")
return r
```