### PR TITLE
Fix returning record with type alias issue

### DIFF
--- a/spec/statement/return_spec.lua
+++ b/spec/statement/return_spec.lua
@@ -97,6 +97,39 @@ describe("return", function()
       ]], {
          { msg = "in return value (inferred at foo.tl:2:13): got integer, expected string" }
       }))
+
+      it("when exporting type alias", function ()
+         util.mock_io(finally, {
+            ["mod.tl"] = [[
+               local record R
+                  n: number
+               end
+               local record Mod
+                  type T = R
+               end
+               local inst: Mod
+               return inst
+            ]],
+            ["merged.tl"] = [[
+               local mod = require("mod")
+               return {
+                  mod = mod
+               }
+            ]],
+            ["foo.tl"] = [[
+               local merged = require("merged")
+               local t: merged.mod.T
+               print(t.n)
+            ]],
+         })
+
+         local tl = require("tl")
+         local result, err = tl.process("foo.tl", assert(tl.init_env()))
+
+         assert.same(nil, err)
+         assert.same({}, result.syntax_errors)
+         assert.same({}, result.type_errors)
+      end)
    end)
 
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -6332,6 +6332,10 @@ tl.type_check = function(ast, opts)
                typetype = typetype.def.found
                assert(is_typetype(typetype))
             end
+            if typetype.def.typename == "nominal" then
+               typetype = typetype.def.found
+               assert(is_typetype(typetype))
+            end
             assert(typetype.def.typename ~= "nominal")
             resolved = match_typevals(t, typetype.def)
          else

--- a/tl.tl
+++ b/tl.tl
@@ -6332,6 +6332,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
                typetype = typetype.def.found
                assert(is_typetype(typetype))
             end
+            if typetype.def.typename == "nominal" then
+               typetype = typetype.def.found
+               assert(is_typetype(typetype))
+            end
             assert(typetype.def.typename ~= "nominal")
             resolved = match_typevals(t, typetype.def)
          else


### PR DESCRIPTION
The problem appeared after recent commit. Minimal reproducing codes are:
```lua
-- file: mod.tl
local record R
   n: number
end
local record Mod
   type T = R
end
local inst: Mod
return inst

-- file: merged.tl
local mod = require("mod")
return {
   mod = mod
}

-- file: foo.tl
local merged = require("merged")
local t: merged.mod.T
print(t.n)
```
Tried fixing it, if there is better way of fixing, this PR can be just dropped.