### PR TITLE
Fix a case union with typearg in return value is not resolved properly

### DIFF
--- a/spec/call/generic_function_spec.lua
+++ b/spec/call/generic_function_spec.lua
@@ -523,5 +523,17 @@ describe("generic function", function()
       local _foo: integer = Container:resolve()
       local _bar: string = Container:resolve()
    ]])
+
+   it("should resolve union with typearg in return value", util.check [[
+      local record A
+         f: function()
+      end
+
+      local create_by_name: function<T>(name: string): T | nil
+      local a: A | nil = create_by_name("A")
+      if not a is nil then
+         a.f()
+      end
+   ]])
 end)
 

--- a/tl.lua
+++ b/tl.lua
@@ -7244,7 +7244,9 @@ tl.type_check = function(ast, opts)
 
             infer_emptytables(where, where_args, args, f.args, argdelta)
 
-            mark_invalid_typeargs(f)
+            if not rets then
+               mark_invalid_typeargs(f)
+            end
 
             return resolve_typevars_at(where, f.rets)
          end

--- a/tl.tl
+++ b/tl.tl
@@ -7244,7 +7244,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
 
             infer_emptytables(where, where_args, args, f.args, argdelta)
 
-            mark_invalid_typeargs(f)
+            if not rets then
+               mark_invalid_typeargs(f)
+            end
 
             return resolve_typevars_at(where, f.rets)
          end


### PR DESCRIPTION
Recent Teal commits are breaking an small case in my project. Took some time debugging around to find that when `check_args_rets` passes most of the args and returns checking, the `mark_invalid_typeargs` function will still mark typearg in union to be unresolvable.