### PR TITLE
fix: in function calls, infer self before return

### DIFF
--- a/spec/subtyping/table_spec.lua
+++ b/spec/subtyping/table_spec.lua
@@ -1,0 +1,19 @@
+local util = require("spec.util")
+
+describe("'table' alias to {any:any}", function()
+   it("is bivariant as a special-case", util.check([[
+      local record R
+         tbl_contains: function(table, any): boolean
+      end
+
+      local record opt
+         record Opt<T>
+            get: function<T>(Opt<T>): T
+         end
+
+         foldopen: Opt<{string}>
+      end
+
+      print(R.tbl_contains(opt.foldopen:get(), 'search'))
+   ]]))
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -7406,6 +7406,15 @@ tl.type_check = function(ast, opts)
             local args_ok
             local args_errs
 
+            local from = 1
+            if argdelta == -1 then
+               from = 2
+               local errs = {}
+               if not arg_check(where, is_a, args[1], f.args[1], nil, errs, "self") then
+                  return nil, errs
+               end
+            end
+
             if rets then
                rets = infer_at(where, rets)
                infer_emptytables(where, nil, rets, f.rets, 0)

--- a/tl.lua
+++ b/tl.lua
@@ -6379,7 +6379,7 @@ tl.type_check = function(ast, opts)
    local function arg_check(where, cmp, a, b, n, errs, ctx)
       local matches, match_errs = cmp(a, b)
       if not matches then
-         add_errs_prefixing(where, match_errs, errs, (ctx or "argument") .. " " .. n .. ": ")
+         add_errs_prefixing(where, match_errs, errs, ctx .. (n and " " .. n or "") .. ": ")
          return false
       end
       return true
@@ -6776,7 +6776,7 @@ tl.type_check = function(ast, opts)
          end
          local all_errs = {}
          for i = 1, #t1.args do
-            arg_check(t1, same_type, t1.args[i], t2.args[i], i - argdelta, all_errs)
+            arg_check(t1, same_type, t1.args[i], t2.args[i], i - argdelta, all_errs, "argument")
          end
          for i = 1, #t1.rets do
             local _, errs = same_type(t1.rets[i], t2.rets[i])
@@ -7222,7 +7222,7 @@ tl.type_check = function(ast, opts)
             table.insert(all_errs, error_in_type(t1, "incompatible number of arguments: got " .. #t1.args .. " %s, expected " .. #t2.args .. " %s", t1.args, t2.args))
          else
             for i = ((t1.is_method or t2.is_method) and 2 or 1), #t1.args do
-               arg_check(nil, is_a, t1.args[i], t2.args[i] or ANY, i, all_errs)
+               arg_check(nil, is_a, t1.args[i], t2.args[i] or ANY, i, all_errs, "argument")
             end
          end
          local diff_by_va = #t2.rets - #t1.rets == 1 and t2.rets.is_va
@@ -7377,7 +7377,7 @@ tl.type_check = function(ast, opts)
       local check_args_rets
       do
 
-         local function check_func_type_list(where, wheres, xs, ys, delta, mode)
+         local function check_func_type_list(where, wheres, xs, ys, from, delta, mode)
             assert(xs.typename == "tuple", xs.typename)
             assert(ys.typename == "tuple", ys.typename)
 
@@ -7385,7 +7385,7 @@ tl.type_check = function(ast, opts)
             local n_xs = #xs
             local n_ys = #ys
 
-            for i = 1, math.max(n_xs, n_ys) do
+            for i = from, math.max(n_xs, n_ys) do
                local pos = i + delta
                local x = xs[i] or (xs.is_va and xs[n_xs]) or NIL
                local y = ys[i] or (ys.is_va and ys[n_ys])
@@ -7410,10 +7410,10 @@ tl.type_check = function(ast, opts)
                rets = infer_at(where, rets)
                infer_emptytables(where, nil, rets, f.rets, 0)
 
-               rets_ok, rets_errs = check_func_type_list(where, nil, f.rets, rets, 0, "return")
+               rets_ok, rets_errs = check_func_type_list(where, nil, f.rets, rets, 1, 0, "return")
             end
 
-            args_ok, args_errs = check_func_type_list(where, where_args, args, f.args, argdelta, "argument")
+            args_ok, args_errs = check_func_type_list(where, where_args, args, f.args, 1, argdelta, "argument")
             if (not args_ok) or (not rets_ok) then
                return nil, args_errs or {}
             end

--- a/tl.tl
+++ b/tl.tl
@@ -6379,7 +6379,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
    local function arg_check(where: Node, cmp: CompareTypes, a: Type, b: Type, n: integer, errs: {Error}, ctx: string): boolean
       local matches, match_errs = cmp(a, b)
       if not matches then
-         add_errs_prefixing(where, match_errs, errs, (ctx or "argument") .. " " .. n .. ": ")
+         add_errs_prefixing(where, match_errs, errs, ctx .. (n and " " .. n or "") .. ": ")
          return false
       end
       return true
@@ -6776,7 +6776,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
          end
          local all_errs = {}
          for i = 1, #t1.args do
-            arg_check(t1 as Node, same_type, t1.args[i], t2.args[i], i - argdelta, all_errs)
+            arg_check(t1 as Node, same_type, t1.args[i], t2.args[i], i - argdelta, all_errs, "argument")
          end
          for i = 1, #t1.rets do
             local _, errs = same_type(t1.rets[i], t2.rets[i])
@@ -7222,7 +7222,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
             table.insert(all_errs, error_in_type(t1, "incompatible number of arguments: got " .. #t1.args .. " %s, expected " .. #t2.args .. " %s", t1.args, t2.args))
          else
             for i = ((t1.is_method or t2.is_method) and 2 or 1), #t1.args do
-               arg_check(nil, is_a, t1.args[i], t2.args[i] or ANY, i, all_errs)
+               arg_check(nil, is_a, t1.args[i], t2.args[i] or ANY, i, all_errs, "argument")
             end
          end
          local diff_by_va = #t2.rets - #t1.rets == 1 and t2.rets.is_va
@@ -7377,7 +7377,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
       local check_args_rets: function(where: Node, where_args: {Node}, f: Type, args: {Type}, rets: {Type}, argdelta: integer): Type, {Error}
       do
          -- check if a tuple `xs` matches tuple `ys`
-         local function check_func_type_list(where: Node, wheres: {Node}, xs: Type, ys: Type, delta: integer, mode: string): boolean, {Error}
+         local function check_func_type_list(where: Node, wheres: {Node}, xs: Type, ys: Type, from: integer, delta: integer, mode: string): boolean, {Error}
             assert(xs.typename == "tuple", xs.typename)
             assert(ys.typename == "tuple", ys.typename)
 
@@ -7385,7 +7385,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
             local n_xs = #xs
             local n_ys = #ys
 
-            for i = 1, math.max(n_xs, n_ys) do
+            for i = from, math.max(n_xs, n_ys) do
                local pos = i + delta
                local x = xs[i] or (xs.is_va and xs[n_xs]) or NIL
                local y = ys[i] or (ys.is_va and ys[n_ys])
@@ -7410,10 +7410,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
                rets = infer_at(where, rets)
                infer_emptytables(where, nil, rets, f.rets, 0)
 
-               rets_ok, rets_errs = check_func_type_list(where, nil, f.rets, rets, 0, "return")
+               rets_ok, rets_errs = check_func_type_list(where, nil, f.rets, rets, 1, 0, "return")
             end
 
-            args_ok, args_errs = check_func_type_list(where, where_args, args, f.args, argdelta, "argument")
+            args_ok, args_errs = check_func_type_list(where, where_args, args, f.args, 1, argdelta, "argument")
             if (not args_ok) or (not rets_ok) then
                return nil, args_errs or {}
             end

--- a/tl.tl
+++ b/tl.tl
@@ -7406,6 +7406,15 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
             local args_ok: boolean
             local args_errs: {Error}
 
+            local from = 1
+            if argdelta == -1 then
+               from = 2
+               local errs = {}
+               if not arg_check(where, is_a, args[1], f.args[1], nil, errs, "self") then
+                  return nil, errs
+               end
+            end
+
             if rets then
                rets = infer_at(where, rets)
                infer_emptytables(where, nil, rets, f.rets, 0)


### PR DESCRIPTION
A tricky aspect of bidirectional flow typing: let's ensure that in a method, the self type flows down before the return type flows up.

Also, the test case demonstrates that the `table` map type has bivariant behavior to ease the transition of Lua code.

Fixes #619.
