### PR TITLE
Feature/warn method call for correct type

### DIFF
--- a/spec/call/record_method_spec.lua
+++ b/spec/call/record_method_spec.lua
@@ -80,4 +80,18 @@ describe("record method call", function()
       { y = 9, msg = "invoked method as a regular function: use ':' instead of '.'" },
    }))
 
+   it("reports potentially wrong use of self. in call", util.check_warnings([[
+      local record Foo
+         x: integer
+      end
+      function Foo:copy_x(other: Foo)
+         self.x = other.x
+      end
+      function Foo:copy_all(other: Foo)
+         self.copy_x(other)
+      end
+   ]], {
+      { y = 8, msg = "invoked method as a regular function: consider using ':' instead of '.'" }
+   }))
+
 end)

--- a/spec/call/record_method_spec.lua
+++ b/spec/call/record_method_spec.lua
@@ -111,4 +111,47 @@ describe("record method call", function()
       m.a.add(first)
    ]], {}, {}))
 
+   it("reports correct errors for calls on aliases of method", util.check_type_error([[
+      local record Foo
+         x: integer
+      end
+      function Foo:add(other: integer)
+         self.x = other and (self.x + other) or self.x
+      end
+      local first: Foo = {}
+      local fadd = first.add
+      fadd(12)
+      global gadd = first.add
+      gadd(13)
+      local tab = {
+         hadd = first.add
+      }
+      tab.hadd(14)
+
+   ]],
+   { 
+      { y = 9, msg = "argument 1: got integer, expected Foo" },
+      { y = 11, msg = "argument 1: got integer, expected Foo" },
+      { y = 15, msg = "argument 1: got integer, expected Foo" },
+   }))
+
+   it("reports no warnings for correctly-typed calls on aliases of method", util.check_warnings([[
+      local record Foo
+         x: integer
+      end
+      function Foo:add(other: Foo)
+         self.x = other and (self.x + other.x) or self.x
+      end
+      local first: Foo = {}
+      local fadd = first.add
+      fadd(first)
+      global gadd = first.add
+      gadd(first)
+      local tab = {
+         hadd = first.add
+      }
+      tab.hadd(first)
+
+   ]], {}, {}))
+
 end)

--- a/spec/call/record_method_spec.lua
+++ b/spec/call/record_method_spec.lua
@@ -94,4 +94,21 @@ describe("record method call", function()
       { y = 8, msg = "invoked method as a regular function: consider using ':' instead of '.'" }
    }))
 
+   it("accepts use of dot call for method on record typetype", util.check_warnings([[
+      local record Foo
+         x: integer
+      end
+      function Foo:add(other: Foo)
+         self.x = other and (self.x + other.x) or self.x
+      end
+      local first: Foo = {}
+      Foo.add(first)
+      local q = Foo
+      q.add(first)
+      local m = {
+         a: Foo
+      }
+      m.a.add(first)
+   ]], {}, {}))
+
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -7495,7 +7495,10 @@ tl.type_check = function(ast, opts)
                   local f = is_func and func or func.types[i]
                   if f.is_method and not is_method then
                      if args[1] and is_a(args[1], f.args[1]) then
-                        node_warning("hint", where, "invoked method as a regular function: consider using ':' instead of '.'")
+                        local receiver_is_typetype = where.e1.e1 and where.e1.e1.type and where.e1.e1.type.resolved and where.e1.e1.type.resolved.typename == "typetype"
+                        if not receiver_is_typetype then
+                           node_warning("hint", where, "invoked method as a regular function: consider using ':' instead of '.'")
+                        end
                      else
                         return node_error(where, "invoked method as a regular function: use ':' instead of '.'")
                      end

--- a/tl.lua
+++ b/tl.lua
@@ -1430,6 +1430,17 @@ local function new_type(ps, i, typename)
    })
 end
 
+
+local function shallow_copy_type(t)
+   local copy = {}
+   for k, v in pairs(t) do
+      copy[k] = v
+   end
+   local typ = copy
+   typ.typeid = new_typeid()
+   return typ
+end
+
 local function verify_kind(ps, i, kind, node_kind)
    if ps.tokens[i].kind == kind then
       return i + 1, new_node(ps.tokens, i, node_kind)
@@ -8787,6 +8798,10 @@ tl.type_check = function(ast, opts)
             node_error(node.vars[i], "cannot infer declaration type; an explicit type annotation is necessary")
             ok = false
             infertype = INVALID
+         elseif infertype and infertype.is_method then
+
+            infertype = shallow_copy_type(infertype)
+            infertype.is_method = false
          end
       end
 
@@ -9485,6 +9500,11 @@ tl.type_check = function(ast, opts)
             if node.decltype then
                vtype = node.decltype
                assert_is_a(node.value, children[2], node.decltype, "in table item")
+            end
+            if vtype.is_method then
+
+               vtype = shallow_copy_type(vtype)
+               vtype.is_method = false
             end
             node.type = a_type({
                y = node.y,

--- a/tl.lua
+++ b/tl.lua
@@ -7493,8 +7493,12 @@ tl.type_check = function(ast, opts)
             for i = 1, n do
                if (not tried) or not tried[i] then
                   local f = is_func and func or func.types[i]
-                  if f.is_method and not is_method and not (args[1] and is_a(args[1], f.args[1])) then
-                     return node_error(where, "invoked method as a regular function: use ':' instead of '.'")
+                  if f.is_method and not is_method then
+                     if args[1] and is_a(args[1], f.args[1]) then
+                        node_warning("hint", where, "invoked method as a regular function: consider using ':' instead of '.'")
+                     else
+                        return node_error(where, "invoked method as a regular function: use ':' instead of '.'")
+                     end
                   end
                   local expected = #f.args
 

--- a/tl.tl
+++ b/tl.tl
@@ -1430,6 +1430,17 @@ local function new_type(ps: ParseState, i: integer, typename: TypeName): Type
    }
 end
 
+-- Makes a shallow copy of the given type with a new typeid
+local function shallow_copy_type(t: Type): Type
+   local copy: {any:any} = {}
+   for k, v in pairs(t as {any:any}) do
+      copy[k] = v
+   end
+   local typ: Type = copy as Type
+   typ.typeid = new_typeid()
+   return typ
+end
+
 local function verify_kind(ps: ParseState, i: integer, kind: TokenKind, node_kind: NodeKind): integer, Node
    if ps.tokens[i].kind == kind then
       return i + 1, new_node(ps.tokens, i, node_kind)
@@ -8787,6 +8798,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
             node_error(node.vars[i], "cannot infer declaration type; an explicit type annotation is necessary")
             ok = false
             infertype = INVALID
+         elseif infertype and infertype.is_method then
+            -- If we assign a method to a variable, e.g local myfunc = myobj.dothing, the variable should not be treated as a method
+            infertype = shallow_copy_type(infertype)
+            infertype.is_method = false
          end
       end
 
@@ -9485,6 +9500,11 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
             if node.decltype then
                vtype = node.decltype
                assert_is_a(node.value, children[2], node.decltype, "in table item")
+            end
+            if vtype.is_method then
+               -- If we assign a method to a table item, e.g local a = { myfunc = myobj.dothing }, the table item should not be treated as a method
+               vtype = shallow_copy_type(vtype)
+               vtype.is_method = false
             end
             node.type = a_type {
                y = node.y,

--- a/tl.tl
+++ b/tl.tl
@@ -7495,7 +7495,10 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
                   local f = is_func and func or func.types[i]
                   if f.is_method and not is_method then
                      if args[1] and is_a(args[1], f.args[1]) then
-                        node_warning("hint", where, "invoked method as a regular function: consider using ':' instead of '.'")
+                        local receiver_is_typetype = where.e1.e1 and where.e1.e1.type and where.e1.e1.type.resolved and where.e1.e1.type.resolved.typename == "typetype"
+                        if not receiver_is_typetype then
+                           node_warning("hint", where, "invoked method as a regular function: consider using ':' instead of '.'")
+                        end
                      else
                         return node_error(where, "invoked method as a regular function: use ':' instead of '.'")
                      end

--- a/tl.tl
+++ b/tl.tl
@@ -7493,8 +7493,12 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
             for i = 1, n do
                if (not tried) or not tried[i] then
                   local f = is_func and func or func.types[i]
-                  if f.is_method and not is_method and not (args[1] and is_a(args[1], f.args[1])) then
-                     return node_error(where, "invoked method as a regular function: use ':' instead of '.'")
+                  if f.is_method and not is_method then
+                     if args[1] and is_a(args[1], f.args[1]) then
+                        node_warning("hint", where, "invoked method as a regular function: consider using ':' instead of '.'")
+                     else
+                        return node_error(where, "invoked method as a regular function: use ':' instead of '.'")
+                     end
                   end
                   local expected = #f.args
 


### PR DESCRIPTION
## What?
Adds a warning message to non-method calls on methods where the argument type is compatible with the receiver type.

## Why?
Currently, an error is thrown for code like this:
```
record MyRecord
end
function MyRecord:read(argument: string)
end
local myRecord: MyRecord = {}
myRecord.read("hello")
```
telling the programmer to call `:read` rather than `.read`.
This is useful, as it captures a common programmer error.

However, if the method argument type is the same as the receiver type, for example:
```
record MyRecord
end
function MyRecord:read(other: MyRecord)
end
local myRecord: MyRecord = {}
local otherRecord: MyRecord = {}
myRecord.read(otherRecord)
```
then no error is thrown, as the type of `otherRecord` is compatible with the receiver type.

But, in this case, it is very possible that the programmer still intended to write `myRecord:read(otherRecord)`, and just made a typing mistake.
Therefore, this PR adds a warning to any non-method call of a method where the argument type is compatible with the receiver type, so that this common mistake is identified when checking / building with teal.

## Anything else?
Could someone let me know how versioning works on this project?
I noticed that there is a constant `local VERSION = "0.15.1+dev"` at the top of `tl.tl` - should I be bumping this version with my PR, and if so, what to?