### PR TITLE
Add new warning when nil is assigned to a non-nilable type

### DIFF
--- a/spec/declaration/record_function_spec.lua
+++ b/spec/declaration/record_function_spec.lua
@@ -101,7 +101,7 @@ describe("record function", function()
            func: function(R)
          end
 
-         function R:func(): boolean
+         function R:func(): boolean | nil
            return self._current and self._current:func()
          end
       ]], {}, {

--- a/tl.lua
+++ b/tl.lua
@@ -6903,7 +6903,7 @@ tl.type_check = function(ast, opts)
    end
 
 
-   is_a = function(t1, t2, for_equality)
+   is_a = function(t1, t2, for_equality, ignore_nil)
       assert(type(t1) == "table")
       assert(type(t2) == "table")
 
@@ -6939,7 +6939,7 @@ tl.type_check = function(ast, opts)
       end
 
 
-      if t1.typename == "nil" then
+      if not ignore_nil and t1.typename == "nil" then
          return true
       end
 
@@ -7252,6 +7252,9 @@ tl.type_check = function(ast, opts)
 
 
       if t1.typename == "nil" then
+         if not is_a(t1, t2, nil, true) then
+            node_warning("hint", node, "assigning nil to a non-nilable type %s", t2.typename)
+         end
          return true
       elseif t2.typename == "unresolved_emptytable_value" then
          if is_number_type(t2.emptytable_type.keys) then

--- a/tl.tl
+++ b/tl.tl
@@ -6279,7 +6279,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
       return var
    end
 
-   local type CompareTypes = function(Type, Type, boolean): boolean, {Error}
+   local type CompareTypes = function(Type, Type, boolean, boolean): boolean, {Error}
 
    local function compare_and_infer_typevars(t1: Type, t2: Type, comp: CompareTypes): boolean, {Error}
       -- if both are typevars and they are the same variable, nothing to do here
@@ -6315,7 +6315,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
    end
 
    local same_type: function(t1: Type, t2: Type): boolean, {Error}
-   local is_a: function(Type, Type, boolean): boolean, {Error}
+   local is_a: function(Type, Type, boolean, boolean): boolean, {Error}
 
    local type TypeGetter = function(string): Type
 
@@ -6903,7 +6903,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
    end
 
    -- subtyping comparison
-   is_a = function(t1: Type, t2: Type, for_equality: boolean): boolean, {Error}
+   is_a = function(t1: Type, t2: Type, for_equality: boolean, ignore_nil: boolean): boolean, {Error}
       assert(type(t1) == "table")
       assert(type(t2) == "table")
 
@@ -6939,7 +6939,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
       end
 
       -- ∀ t, nil <: t
-      if t1.typename == "nil" then -- TODO nilable
+      if not ignore_nil and t1.typename == "nil" then -- TODO nilable
          return true
       end
 
@@ -7252,6 +7252,9 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
 
       -- some flow-based inference
       if t1.typename == "nil" then
+         if not is_a(t1, t2, nil, true) then
+            node_warning("hint", node, "assigning nil to a non-nilable type %s", t2.typename)
+         end
          return true
       elseif t2.typename == "unresolved_emptytable_value" then
          if is_number_type(t2.emptytable_type.keys) then -- ideally integer only


### PR DESCRIPTION
This pull request add a new warning when you assign `nil` to a type that is not-nilable. For example the following code

```
local x: number = 10
x = nil
```

will now return an warning that looks like

```
========================================
1 warning:
test.tl:18:1: assigning nil to a non-nilable type number
```

hinting that the correct way to write this code is (assuming that you want assigning nil to be valid)
```
local x: number | nil = 10
x = nil
```

This change causes the tl compiler to throw a lot of warning when building. If required I could modify the tl compiler to explicitly mark types as nilable where required.

This change also required a test update to the record function spec tests, as one of the tests would assign nil to a boolean value and then expect zero warning to be generated.