### PR TITLE
Fix/remove pcall method warning

### DIFF
--- a/spec/stdlib/pcall_spec.lua
+++ b/spec/stdlib/pcall_spec.lua
@@ -72,4 +72,21 @@ describe("pcall", function()
    ]], {
       { msg = "xyz: got boolean, expected number" }
    }))
+
+   it("does not warn when passed a method as the first argument", util.check_warnings([[
+      local record Text
+         text: string
+      end
+      function Text:print(): nil
+         if self.text == nil then
+            error("Text is nil")
+         end
+         print(self.text)
+      end
+      local myText: Text = {}
+      local ok, err = pcall(myText.print, myText)
+      if not ok then
+         print(err)
+      end
+   ]], {}, {}))
 end)

--- a/spec/stdlib/pcall_spec.lua
+++ b/spec/stdlib/pcall_spec.lua
@@ -89,4 +89,23 @@ describe("pcall", function()
          print(err)
       end
    ]], {}, {}))
+
+   it("checks the correct input arguments when passed a method as the first argument", util.check_type_error([[
+      local record Text
+         text: string
+      end
+      function Text:print(): nil
+         if self.text == nil then
+            error("Text is nil")
+         end
+         print(self.text)
+      end
+      local myText: Text = {}
+      local ok, err = pcall(myText.print, 12)
+      if not ok then
+         print(err)
+      end
+   ]], {
+      { msg = "argument 2: got integer, expected Text" }
+   }))
 end)

--- a/spec/stdlib/xpcall_spec.lua
+++ b/spec/stdlib/xpcall_spec.lua
@@ -117,4 +117,21 @@ describe("xpcall", function()
       { msg = "argument 3: got integer, expected string" },
    }))
 
+   it("does not warn when passed a method as the first argument", util.check_warnings([[
+      local record Text
+         text: string
+      end
+
+      local function msgh(err: nil) print(err) end
+
+      function Text:print(): nil
+         if self.text == nil then
+            error("Text is nil")
+         end
+         print(self.text)
+      end
+      local myText: Text = {}
+      xpcall(myText.print, msgh, myText)
+   ]], {}, {}))
+
 end)

--- a/spec/stdlib/xpcall_spec.lua
+++ b/spec/stdlib/xpcall_spec.lua
@@ -134,4 +134,23 @@ describe("xpcall", function()
       xpcall(myText.print, msgh, myText)
    ]], {}, {}))
 
+   it("checks the correct input arguments when passed a method as the first argument", util.check_type_error([[
+      local record Text
+         text: string
+      end
+      
+      local function msgh(err: nil) print(err) end
+
+      function Text:print(): nil
+         if self.text == nil then
+            error("Text is nil")
+         end
+         print(self.text)
+      end
+      local myText: Text = {}
+      xpcall(myText.print, msgh, 12)
+   ]], {
+      { msg = "argument 3: got integer, expected Text" }
+   }))
+
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -8448,7 +8448,11 @@ tl.type_check = function(ast, opts)
          return TUPLE({ BOOLEAN })
       end
 
+
       local ftype = table.remove(b, 1)
+      ftype = shallow_copy_type(ftype)
+
+
       local fe2 = {}
       if node.e1.tk == "xpcall" then
          base_nargs = 2

--- a/tl.lua
+++ b/tl.lua
@@ -8451,7 +8451,7 @@ tl.type_check = function(ast, opts)
 
       local ftype = table.remove(b, 1)
       ftype = shallow_copy_type(ftype)
-
+      ftype.is_method = false
 
       local fe2 = {}
       if node.e1.tk == "xpcall" then

--- a/tl.tl
+++ b/tl.tl
@@ -8448,7 +8448,7 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
          return TUPLE { BOOLEAN }
       end
 
-      -- The function called by pcall/xpcall is invoked as a regular function, so we wish to avoid incorrect error messages / unnecessary warning messages
+      -- The function called by pcall/xpcall is invoked as a regular function, so we wish to avoid incorrect error messages / unnecessary warning messages associated with calling methods as functions
       local ftype = table.remove(b, 1)
       ftype = shallow_copy_type(ftype)
       ftype.is_method = false

--- a/tl.tl
+++ b/tl.tl
@@ -8448,7 +8448,11 @@ tl.type_check = function(ast: Node, opts: TypeCheckOptions): Result, string
          return TUPLE { BOOLEAN }
       end
 
+      -- The function called by pcall/xpcall is invoked as a regular function, so we wish to avoid incorrect error messages / unnecessary warning messages
       local ftype = table.remove(b, 1)
+      ftype = shallow_copy_type(ftype)
+      ftype.is_method = false
+
       local fe2: Node = {}
       if node.e1.tk == "xpcall" then
          base_nargs = 2


### PR DESCRIPTION
### What?
- Adds tests for the incorrect warnings and errors raised in #656 
- Updates `special_pcall_xpcall` so that the function type of the first argument is treated as not a method, even if it is a method

### Why?
Resolves #656 

`pcall` (and `xpcall`) invokes its first argument as a regular function with the provided arguments - it has no way of implicitly passing the `self` parameter from the method owner of its first argument to the method.
Therefore, it should not warn `invoked method as a regular function: use ':' instead of '.'` when its first argument is a method, or raise this as the error message when passed an argument of incorrect type.

### Anything else?
I was slightly worried that setting `is_method` to `false` on this type might cause unintended side-effects, however I have checked through the sequence of function calls from `special_pcall_xpcall` where `ftype` is passed, and it appears that `is_method` is exclusively used for determining whether to show these warnings / errors.