### PR TITLE
fix file:close signature

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -5227,7 +5227,7 @@ local function init_globals(lax)
             typename = "record",
             is_userdata = true,
             fields = {
-               ["close"] = a_type({ typename = "function", args = TUPLE({ NOMINAL_FILE }), rets = TUPLE({ BOOLEAN, STRING }) }),
+               ["close"] = a_type({ typename = "function", args = TUPLE({ NOMINAL_FILE }), rets = TUPLE({ BOOLEAN, STRING, INTEGER }) }),
                ["flush"] = a_type({ typename = "function", args = TUPLE({ NOMINAL_FILE }), rets = TUPLE({}) }),
                ["lines"] = a_type({ typename = "function", args = VARARG({ NOMINAL_FILE, a_type({ typename = "union", types = { STRING, NUMBER } }) }), rets = TUPLE({
                   a_type({ typename = "function", args = TUPLE({}), rets = VARARG({ STRING }) }),

--- a/tl.tl
+++ b/tl.tl
@@ -5227,7 +5227,7 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
             typename = "record",
             is_userdata = true,
             fields = {
-               ["close"] = a_type { typename = "function", args = TUPLE { NOMINAL_FILE }, rets = TUPLE { BOOLEAN, STRING} },
+               ["close"] = a_type { typename = "function", args = TUPLE { NOMINAL_FILE }, rets = TUPLE { BOOLEAN, STRING, INTEGER } },
                ["flush"] = a_type { typename = "function", args = TUPLE { NOMINAL_FILE }, rets = TUPLE {} },
                ["lines"] = a_type { typename = "function", args = VARARG { NOMINAL_FILE, a_type { typename = "union", types = { STRING, NUMBER } } }, rets = TUPLE {
                   a_type { typename = "function", args = TUPLE {}, rets = VARARG { STRING } },


### PR DESCRIPTION
since Lua 5.2, when closing a file handle created with `io.popen`, `file:close` returns the same values returned by `os.execute`.