### PR TITLE
fix utf8.codes signature

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -5571,7 +5571,7 @@ local function init_globals(lax)
             ["charpattern"] = STRING,
             ["codepoint"] = a_type({ typename = "function", args = TUPLE({ STRING, OPT(NUMBER), OPT(NUMBER) }), rets = VARARG({ INTEGER }) }),
             ["codes"] = a_type({ typename = "function", args = TUPLE({ STRING }), rets = TUPLE({
-               a_type({ typename = "function", args = TUPLE({}), rets = TUPLE({ NUMBER, NUMBER }) }),
+               a_type({ typename = "function", args = TUPLE({ STRING, OPT(NUMBER) }), rets = TUPLE({ NUMBER, NUMBER }) }),
             }), }),
             ["len"] = a_type({ typename = "function", args = TUPLE({ STRING, NUMBER, NUMBER }), rets = TUPLE({ INTEGER }) }),
             ["offset"] = a_type({ typename = "function", args = TUPLE({ STRING, NUMBER, NUMBER }), rets = TUPLE({ INTEGER }) }),

--- a/tl.tl
+++ b/tl.tl
@@ -5571,7 +5571,7 @@ local function init_globals(lax: boolean): {string:Variable}, {string:Type}
             ["charpattern"] = STRING,
             ["codepoint"] = a_type { typename = "function", args = TUPLE { STRING, OPT(NUMBER), OPT(NUMBER) }, rets = VARARG { INTEGER } },
             ["codes"] = a_type { typename = "function", args = TUPLE { STRING }, rets = TUPLE {
-               a_type { typename = "function", args = TUPLE {}, rets = TUPLE { NUMBER, NUMBER } },
+               a_type { typename = "function", args = TUPLE { STRING, OPT(NUMBER) }, rets = TUPLE { NUMBER, NUMBER } },
             }, },
             ["len"] = a_type { typename = "function", args = TUPLE { STRING, NUMBER, NUMBER }, rets = TUPLE { INTEGER } },
             ["offset"] = a_type { typename = "function", args = TUPLE { STRING, NUMBER, NUMBER }, rets = TUPLE { INTEGER } },


### PR DESCRIPTION
the iterator returned by `utf8.codes` needs some arguments (when called outside a `for` loop)

```
$ cat codes.lua
local s = "foo"
local iter = utf8.codes(s)
print(iter(s))
print(iter(s, 1))
$ ./tl run codes.lua
1	102
2	111
$ ./tl check codes.lua
========================================
2 errors:
codes.lua:3:11: wrong number of arguments (given 1, expects 0)
codes.lua:4:11: wrong number of arguments (given 2, expects 0)
```