### PR TITLE
add a non-regression test for return arity edge case

### DIFF
--- a/spec/lang/statement/return_spec.lua
+++ b/spec/lang/statement/return_spec.lua
@@ -37,6 +37,14 @@ describe("return", function()
             return bar()
          end
       ]], {}))
+
+      it("with zero (regression test for #741)", util.check([[
+         local function bar() end
+
+         local function foo()
+            return bar()
+         end
+      ]]))
    end)
 
    describe("type checking", function()


### PR DESCRIPTION
Fixes #741 (fixed in Teal 0.24.0)