### PR TITLE
make `v is T and v or e` imply not-T for expression e

### DIFF
--- a/spec/lang/inference/or_spec.lua
+++ b/spec/lang/inference/or_spec.lua
@@ -1,0 +1,15 @@
+
+local util = require("spec.util")
+
+describe("inference in 'or' expressions", function()
+   it("`v is T and v or _` for a truthy T infers that _ is of type not-T (#878)", util.check([[
+      local record R end
+
+      local function convert(_: string): R end
+
+      local u: string | R
+      local _r: R = u is R
+         and u
+         or convert(u)
+   ]]))
+end)

--- a/tl.lua
+++ b/tl.lua
@@ -12532,6 +12532,18 @@ self:expand_type(node, values, elements) })
                self:apply_facts(node, node.e1.known)
             elseif node.op.op == "or" then
                self:apply_facts(node, facts_not(node, node.e1.known))
+
+
+               if node.e1.kind == "op" and node.e1.op.op == "and" and
+                  node.e1.e1.kind == "op" and node.e1.e1.op.op == "is" and
+                  node.e1.e2.kind == "variable" and
+                  node.e1.e2.tk == node.e1.e1.e1.tk and
+                  node.e1.e1.e2.casttype.typename ~= "boolean" and
+                  node.e1.e1.e2.casttype.typename ~= "nil" then
+
+                  self:apply_facts(node, facts_not(node, IsFact({ var = node.e1.e1.e1.tk, typ = node.e1.e1.e2.casttype, w = node })))
+               end
+
             elseif node.op.op == "@funcall" then
                if e1type.typename == "generic" then
                   e1type = self:apply_generic(node, e1type)

--- a/tl.tl
+++ b/tl.tl
@@ -12532,6 +12532,18 @@ do
                self:apply_facts(node, node.e1.known)
             elseif node.op.op == "or" then
                self:apply_facts(node, facts_not(node, node.e1.known))
+
+               -- special-case `v is T and v or _` when T is a truthy type
+               if node.e1.kind == "op" and node.e1.op.op == "and"
+                  and node.e1.e1.kind == "op" and node.e1.e1.op.op == "is"
+                  and node.e1.e2.kind == "variable"
+                  and node.e1.e2.tk == node.e1.e1.e1.tk
+                  and node.e1.e1.e2.casttype.typename ~= "boolean"
+                  and node.e1.e1.e2.casttype.typename ~= "nil"
+               then
+                  self:apply_facts(node, facts_not(node, IsFact { var = node.e1.e1.e1.tk, typ = node.e1.e1.e2.casttype, w = node }))
+               end
+
             elseif node.op.op == "@funcall" then
                if e1type is GenericType then
                   e1type = self:apply_generic(node, e1type)


### PR DESCRIPTION
Only for "truthy types" (i.e. all except boolean and nil).

Closes #878.