### PR TITLE
Add Helix editor on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ https://github.com/teal-language/teal-types — check it out and make your contr
 
 ## Text editor support
 
-Teal language support is currently available for [Vim](https://github.com/teal-language/vim-teal), [Visual Studio Code](https://github.com/teal-language/vscode-teal) and [lite](https://github.com/rxi/lite-plugins/blob/master/plugins/language_teal.lua) with [linter](https://github.com/drmargarido/linters/blob/master/linter_teal.lua) support.
+Teal language support is currently available for [Vim](https://github.com/teal-language/vim-teal), [Visual Studio Code](https://github.com/teal-language/vscode-teal), [lite](https://github.com/rxi/lite-plugins/blob/master/plugins/language_teal.lua) with [linter](https://github.com/drmargarido/linters/blob/master/linter_teal.lua) support and [Helix](https://docs.helix-editor.com/lang-support.html#:~:text=teal&text=teal-language-server) with LSP support.
 
 ## Community
 


### PR DESCRIPTION
Starting from 25.01, Helix now supports Teal built-in, the editor also integrates LSP by invoking teal-language-server from PATH.

I was in doubt about the URL since the configuration it's not a plugin (only the LSP needs to be installed and available on PATH), so I decided to point to the documentation on language support.

The URL uses the ["Text Fragments"](https://wicg.github.io/scroll-to-text-fragment/) feature (which is supported on major browsers) to highlight (and jump) to the Teal entry.