### PR TITLE
Let Lua sort the `package.loaded` table

### DIFF
--- a/spec/lang/loader/loader_spec.lua
+++ b/spec/lang/loader/loader_spec.lua
@@ -30,5 +30,36 @@ describe("tl.loader", function()
             @.]] .. util.os_sep .. [[file1.tl
          ]], output)
       end)
+      it("works properly with the package.loaded table", function()
+         local dir_name = util.write_tmp_dir(finally, {
+            ["module.lua"] = [[
+               package.loaded['module'] = { worked = 'it works' }
+
+               return nil
+            ]],
+            ["module.d.tl"] = [[
+               local record module
+                  worked: string
+               end
+
+               return module
+            ]],
+            ["main.tl"] = [[
+               local m = require 'module'
+               print(type(m))
+               print(m.worked)
+            ]]
+         })
+         local pd, output
+         util.do_in(dir_name, function()
+            pd = io.popen(util.tl_cmd("run", "main.tl"), "r")
+            output = pd:read("*a")
+         end)
+         util.assert_popen_close(0, pd:close())
+         util.assert_line_by_line([[
+            table
+            it works
+         ]], output)
+      end)
    end)
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -14165,7 +14165,6 @@ local function tl_package_loader(module_name)
                loader_data = found_filename
             end
             local ret = chunk(modname, loader_data)
-            package.loaded[module_name] = ret
             return ret
          end, found_filename
       else

--- a/tl.tl
+++ b/tl.tl
@@ -14165,7 +14165,6 @@ local function tl_package_loader(module_name: string): any, any
                loader_data = found_filename
             end
             local ret = chunk(modname, loader_data)
-            package.loaded[module_name] = ret
             return ret
          end, found_filename
       else


### PR DESCRIPTION
This now makes `tl` work with Lua modules that only populate the `package.loaded` table. The loader doesn't have to do anything with that table:

> Once a loader is found, `require` calls the loader with two arguments: `modname` and an extra value, a loader data, also returned by the searcher. The loader data can be any value useful to the module; for the default searchers, it indicates where the loader was found. (For instance, if the loader came from a file, this extra value is the file path.) If the loader returns any non-nil value, `require` assigns the returned value to `package.loaded[modname]`. If the loader does not return a non-nil value and has not assigned any value to `package.loaded[modname]`, then `require` assigns `true` to this entry. In any case, `require` returns the final value of `package.loaded[modname]`. Besides that value, `require` also returns as a second result the loader data returned by the searcher, which indicates how `require` found the module.