### PR TITLE
fix close signature

### DIFF
--- a/tl.lua
+++ b/tl.lua
@@ -31,7 +31,7 @@ do
          "no" "full" "line"
       end
 
-      close: function(FILE): boolean, string, number
+      close: function(FILE): boolean, string, integer
       flush: function(FILE)
 
       lines: function(FILE): (function(): (string))

--- a/tl.tl
+++ b/tl.tl
@@ -31,7 +31,7 @@ do
          "no" "full" "line"
       end
 
-      close: function(FILE): boolean, string, number
+      close: function(FILE): boolean, string, integer
       flush: function(FILE)
 
       lines: function(FILE): (function(): (string))


### PR DESCRIPTION
quotes from Lua manual:

    When closing a file handle created with io.popen, file:close returns the same values returned by os.execute.