### PR TITLE
Fixes for `...` in macroexp

### DIFF
--- a/spec/lang/code_gen/macroexp_spec.lua
+++ b/spec/lang/code_gen/macroexp_spec.lua
@@ -194,5 +194,19 @@ describe("macroexp code generation", function()
          print("the 'x' fields are equal")
       end
    ]]))
+
+   it("works with ...", util.gen([[
+      local macroexp macroprint(a: string, ...: string): string
+         return print(a, ...)
+      end
+
+      macroprint('varargs', 'dis', 'appear')
+   ]], [[
+
+
+
+
+      print('varargs', 'dis', 'appear')
+   ]]))
 end)
 

--- a/spec/lang/declaration/macroexp_spec.lua
+++ b/spec/lang/declaration/macroexp_spec.lua
@@ -35,4 +35,18 @@ describe("macroexp declaration", function()
    ]], {
       { y = 7, x = 29, msg = "cannot use argument 's' multiple times in macroexp" }
    }))
+
+   it("checks multiple use of arguments", util.check_type_error([[
+      global function f(a: string, b:string)
+         print(a, b)
+      end
+
+      local record R1
+         metamethod __call: function(self: R1, ...: string): boolean = macroexp(self: R1, ...: string): boolean
+            return print(...) or print(...)
+         end
+      end
+   ]], {
+      { y = 7, x = 40, msg = "cannot use argument '...' multiple times in macroexp" }
+   }))
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -9829,8 +9829,19 @@ a.types[i], b.types[i]), }
    end
 
    local function expand_macroexp(orignode, args, macroexp)
-      local on_arg_id = function(_node, i)
-         return { Node, args[i] }
+      local on_arg_id = function(node, i)
+         if node.kind == '...' then
+
+            local nd = {
+               kind = "expression_list",
+            }
+            for n = i, #args do
+               nd[n - i + 1] = args[n]
+            end
+            return { Node, nd }
+         else
+            return { Node, args[i] }
+         end
       end
 
       local on_node = function(_, node, children, ret)

--- a/tl.lua
+++ b/tl.lua
@@ -9811,6 +9811,16 @@ a.types[i], b.types[i]), }
                   return on_arg_id(node, i)
                end,
             },
+            ["..."] = {
+               after = function(_, node, _children)
+                  local i = argnames[node.tk]
+                  if not i then
+                     return nil
+                  end
+
+                  return on_arg_id(node, i)
+               end,
+            },
          },
          after = on_node,
       }

--- a/tl.tl
+++ b/tl.tl
@@ -9829,8 +9829,19 @@ do
    end
 
    local function expand_macroexp(orignode: Node, args: {Node}, macroexp: Node)
-      local on_arg_id = function(_node: Node, i: integer): {Node, Node}
-         return { Node, args[i] }
+      local on_arg_id = function(node: Node, i: integer): {Node, Node}
+         if node.kind == '...' then
+            -- we have to handle varargs specifically
+            local nd = {
+               kind = "expression_list",
+            }
+            for n = i, #args do
+               nd[n - i + 1] = args[n]
+            end
+            return { Node, nd }
+         else
+            return { Node, args[i] }
+         end
       end
 
       local on_node = function(_: nil, node: Node, children: {{Node, Node}}, ret: {Node, Node}): {Node, Node}

--- a/tl.tl
+++ b/tl.tl
@@ -9832,7 +9832,7 @@ do
       local on_arg_id = function(node: Node, i: integer): {Node, Node}
          if node.kind == '...' then
             -- we have to handle varargs specifically
-            local nd = {
+            local nd: Node = {
                kind = "expression_list",
             }
             for n = i, #args do

--- a/tl.tl
+++ b/tl.tl
@@ -9810,6 +9810,16 @@ do
 
                   return on_arg_id(node, i)
                end
+            },
+            ["..."] = {
+               after = function(_: nil, node: Node, _children: {T}): T
+                  local i = argnames[node.tk]
+                  if not i then
+                     return nil
+                  end
+
+                  return on_arg_id(node, i)
+               end
             }
          },
          after = on_node as VisitorAfter<nil, Node, T>,


### PR DESCRIPTION
Fixes #939 

This does a couple of things. First, it adds '...' to the elements that get iterated over, so it warns when there is multiple use of varargs. It then codegens `...` as the leftover arguments.