### PR TITLE
Add parsing for various string functions

### DIFF
--- a/spec/lang/stdlib/assert_spec.lua
+++ b/spec/lang/stdlib/assert_spec.lua
@@ -1,21 +1,23 @@
 local util = require("spec.util")
 
 describe("assert", function()
-   it("propagates its known facts", util.check_type_error([[
+   it("propagates its known facts even with locals", util.check_type_error([[
       local function f(): string | boolean
          return true
       end
 
+      local myassert = assert
+
       local x: string | boolean
       local y: string | boolean
-      assert(x is string)
+      myassert(x is string)
       print(x .. "!")
       print(y .. "!")
       x = f()
       print(x .. "!")
    ]], {
-      { y = 9, msg = "cannot use operator '..' for types string | boolean and string" },
       { y = 11, msg = "cannot use operator '..' for types string | boolean and string" },
+      { y = 13, msg = "cannot use operator '..' for types string | boolean and string" },
    }))
 
    it("ignores additional arguments", util.check([[

--- a/spec/lang/stdlib/pcall_spec.lua
+++ b/spec/lang/stdlib/pcall_spec.lua
@@ -27,7 +27,9 @@ describe("pcall", function()
       local function f(s: string): number
          return 123
       end
-      local a, b, d = pcall(pcall, f, "num")
+      -- checking that it doesn't get confused
+      local xpcall = pcall
+      local a, b, d = pcall(xpcall, f, "num")
 
       assert(a == true)
       assert(b == true)

--- a/spec/lang/stdlib/rawget_spec.lua
+++ b/spec/lang/stdlib/rawget_spec.lua
@@ -8,4 +8,16 @@ describe("rawget", function()
       local str = "hello"
       local a = {str:sub(2, 10)}
    ]]))
+
+   it("errors on invalid indices", util.check_type_error([[
+      local dat = { test = "1", that = 2 }
+      local one: string = rawget(dat, "test")
+      local f1 = rawget(dat, "t")
+      local two: integer = rawget(dat, "that")
+   ]], {
+      {
+         msg = "invalid key 't'",
+         y = 3,
+      }
+   }))
 end)

--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -20,6 +20,22 @@ describe("string", function()
          local s1: string = string.match("hello world", "world")
          local s2: string = string.match("hello world", "world", 2)
       ]]))
+      it("can match with position captures", util.check([[
+         local i1, s1: integer, string = string.match("hello world", "()w(o)rld")
+      ]]))
+   end)
+
+   describe("find", function()
+      it("can take an optional init position", util.check([[
+         local a, b: integer, integer = string.find("hello world", "world")
+         local a2, b2: integer, integer = string.find("hello world", "world", 2)
+      ]]))
+      it("accepts plain patterns", util.check([[
+         local a, b: integer, integer = string.find("hello world", "wor[ld", 1, true)
+      ]]))
+      it("can find with position captures", util.check([[
+         local a, b, i1, s1: integer, integer, integer, string = string.find("hello world", "()[()w](o)rld")
+      ]]))
    end)
 
    describe("gsub", function()
@@ -45,6 +61,15 @@ describe("string", function()
             ["world"] = "mundo",
          }
          local holamundo, count: string, integer = s:gsub("%w+", map)
+      ]]))
+
+      it("accepts a map with integers, returns a string and integer", util.check([[
+         local s = "hello world"
+         local map: {integer:string} = {
+            [1] = "hola",
+            [2] = "mundo",
+         }
+         local holamundo, count: string, integer = s:gsub("()", map)
       ]]))
 
       it("accepts a map and integer, returns a string and integer", util.check([[
@@ -90,6 +115,14 @@ describe("string", function()
              s:gsub("[-%d]+", f)
              return t
          end
+      ]]))
+
+      it("captures integer positions, returns a string", util.check([[
+         local s = "hello world"
+         local function f(a: integer, b: string): string
+            return '[' .. a .. ']' .. b
+         end
+         local ret: string = s:gsub("()(%w+)", f)
       ]]))
    end)
 

--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -38,6 +38,15 @@ describe("string", function()
       ]]))
    end)
 
+   describe("format", function()
+      it("works with various specifiers", util.check([[
+         local s1: string = string.format("%02A %a  %E %e %f %G %g %% %%", 1.1, 1.2, 1.3, 1.4, 1.4, 1.4, 1.4)
+         local s2: string = string.format("%5c  %3d %i %o %u %X %x %% %%", 11, 12, 13, 14, 14, 14, 14)
+         local s3: string = string.format('%s %s %s', 123, 123.5, "test")
+         local s4: string = string.format('%p %p %p %p', {}, "test", 5, io.input())
+      ]]))
+   end)
+
    describe("gsub", function()
       it("accepts a string, returns a string", util.check([[
          local s = "hello"

--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -36,15 +36,34 @@ describe("string", function()
       it("can find with position captures", util.check([[
          local a, b, i1, s1: integer, integer, integer, string = string.find("hello world", "()[()w](o)rld")
       ]]))
+      it("works with locals", util.check([[
+         local myfinder = ("test").find
+         local a, b, i1, s1: integer, integer, integer, string = myfinder("hello world", "()[()w](o)rld")
+      ]]))
    end)
 
    describe("format", function()
       it("works with various specifiers", util.check([[
-         local s1: string = string.format("%02A %a  %E %e %f %G %g %% %%", 1.1, 1.2, 1.3, 1.4, 1.4, 1.4, 1.4)
-         local s2: string = string.format("%5c  %3d %i %o %u %X %x %% %%", 11, 12, 13, 14, 14, 14, 14)
-         local s3: string = string.format('%s %s %s', 123, 123.5, "test")
-         local s4: string = string.format('%p %p %p %p', {}, "test", 5, io.input())
+         local sfmt = string.format
+         local s1: string = sfmt("%02A %a  %E %e %f %G %g %% %%", 1.1, 1.2, 1.3, 1.4, 1.4, 1.4, 1.4)
+         local s2: string = sfmt("%5c  %3d %i %o %u %X %x %% %%", 11, 12, 13, 14, 14, 14, 14)
+         local s3: string = sfmt('%s %s %s', 123, 123.5, "test")
+         local s4: string = sfmt('%p %p %p %p', {}, "test", 5, io.input())
       ]]))
+      it("fails with bad specifiers", util.check_type_error([[
+         local sfmt = string.format
+         local s1: string = sfmt("%e", "test")
+         local s2: string = sfmt("%5c", 10.5)
+      ]], {
+         {
+            msg = "argument 2: got string \"test\", expected number",
+            y = 2,
+         },
+         {
+            msg = "argument 2: got number, expected integer",
+            y = 3,
+         }
+      }))
    end)
 
    describe("gsub", function()
@@ -61,6 +80,7 @@ describe("string", function()
       it("accepts a string and integer, returns a string and integer", util.check([[
          local s = "hello world"
          local helloword, count: string, integer = s:gsub("%w+", "word", 6)
+         local helloword, count: string, integer = s:gsub("()", "%1", 6)
       ]]))
 
       it("accepts a map, returns a string and integer", util.check([[
@@ -133,6 +153,17 @@ describe("string", function()
          end
          local ret: string = s:gsub("()(%w+)", f)
       ]]))
+
+      it("fails with unclosed patterns", util.check_type_error([[
+         local a = ("test"):gsub("(", "")
+         local b = ("test"):gsub("%", "")
+         local c = ("test"):gsub(")(", "")
+      ]], {
+         {
+            msg = "malformed pattern: expected class",
+            y = 2,
+         },
+      }))
    end)
 
 
@@ -141,6 +172,29 @@ describe("string", function()
          local packed: string = string.pack("<!7XdLfz", 12345, 5.2, "testing")
          local a, b, c, next: integer, number, string, integer = string.unpack("<!7XdLfz", packed)
       ]]))
+      it("errors with invalid types or arguments", util.check_type_error([[
+         local packed: string = string.pack("<!7L", 4.5)
+         local packed2: string = string.pack("<!7Xdf", "testing")
+         local packed3: string = string.pack("<!7z", 5)
+         local packed4: string = string.pack("", "test")
+      ]], {
+         {
+            msg = "argument 2: got number, expected integer",
+            y = 1,
+         },
+         {
+            msg = "argument 2: got string \"testing\", expected number",
+            y = 2,
+         },
+         {
+            msg = "argument 2: got integer, expected string",
+            y = 3,
+         },
+         {
+            msg = "wrong number of arguments",
+            y = 4,
+         },
+      }))
       it("works with constant strings", util.check([[
          -- <const> is required so that it gets recognised as a constant for string.pack and unpack
          local pstr <const> = "<!7XdLfz"

--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -158,10 +158,23 @@ describe("string", function()
          local a = ("test"):gsub("(", "")
          local b = ("test"):gsub("%", "")
          local c = ("test"):gsub(")(", "")
+         local d = ("test"):gsub("%f[", "")
       ]], {
+         {
+            msg = "malformed pattern: 1 capture not closed",
+            y = 1,
+         },
          {
             msg = "malformed pattern: expected class",
             y = 2,
+         },
+         {
+            msg = "malformed pattern: unexpected ')'",
+            y = 3,
+         },
+         {
+            msg = "malformed pattern: missing ']'",
+            y = 4,
          },
       }))
    end)

--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -135,4 +135,17 @@ describe("string", function()
       ]]))
    end)
 
+
+   describe("pack", function()
+      it("works with types", util.check([[
+         local packed: string = string.pack("<!7XdLfz", 12345, 5.2, "testing")
+         local a, b, c, next: integer, number, string, integer = string.unpack("<!7XdLfz", packed)
+      ]]))
+      it("works with constant strings", util.check([[
+         -- <const> is required so that it gets recognised as a constant for string.pack and unpack
+         local pstr <const> = "<!7XdLfz"
+         local packed: string = string.pack(pstr, 12345, 5.2, "testing")
+         local a, b, c, next: integer, number, string, integer = pstr:unpack(packed)
+      ]]))
+   end)
 end)

--- a/spec/lang/stdlib/xpcall_spec.lua
+++ b/spec/lang/stdlib/xpcall_spec.lua
@@ -97,8 +97,11 @@ describe("xpcall", function()
          return {"hello", "world"}, true
       end
 
+      -- checking that it doesn't get confused
+      local pcall = xpcall
+
       local function msgh(err: string) print(err) end
-      local pok, strs, yep = xpcall(f, msgh, "hello", 123)
+      local pok, strs, yep = pcall(f, msgh, "hello", 123)
       print(strs[1]:upper())
       local xyz: number = yep
    ]], {

--- a/tl.lua
+++ b/tl.lua
@@ -11450,26 +11450,27 @@ a.types[i], b.types[i]), }
       while pos <= #pat do
          local c = pat:sub(pos, pos)
          local to_add
+         local goto_next
          if c:match("[<> =x]") then
 
             if skip_next then
                return nil, "expected argument for 'X'"
             end
             pos = pos + 1
-            goto next
+            goto_next = true
          elseif c == "X" then
             if skip_next then
                return nil, "expected argument for 'X'"
             end
             skip_next = true
             pos = pos + 1
-            goto next
+            goto_next = true
          elseif c == "!" then
             if skip_next then
                return nil, "expected argument for 'X'"
             end
             pos = pack_string_skipnum(pos + 1, pat)
-            goto next
+            goto_next = true
          elseif c:match("[Ii]") then
             pos = pack_string_skipnum(pos + 1, pat)
             to_add = a_type(node, "integer", {})
@@ -11490,12 +11491,13 @@ a.types[i], b.types[i]), }
          else
             return nil, "invalid format option: '" .. c .. "'"
          end
-         if skip_next then
-            skip_next = false
-         else
-            table.insert(results, to_add)
+         if not goto_next then
+            if skip_next then
+               skip_next = false
+            else
+               table.insert(results, to_add)
+            end
          end
-         ::next::
       end
       if skip_next then
          return nil, "expected argument for 'X'"

--- a/tl.lua
+++ b/tl.lua
@@ -11247,8 +11247,9 @@ a.types[i], b.types[i]), }
       end
    end
 
-   local function special_pcall_xpcall(self, node, _a, b, argdelta)
-      local base_nargs = (node.e1.tk == "xpcall") and 2 or 1
+   local function special_pcall_xpcall(self, node, a, b, argdelta)
+      local isx = a.special_function_handler == "xpcall"
+      local base_nargs = isx and 2 or 1
       local bool = a_type(node, "boolean", {})
       if #node.e2 < base_nargs then
          self.errs:add(node, "wrong number of arguments (given " .. #node.e2 .. ", expects at least " .. base_nargs .. ")")
@@ -11263,7 +11264,7 @@ a.types[i], b.types[i]), }
       ftype = ensure_not_method(ftype)
 
       local fe2 = node_at(node.e2, {})
-      if node.e1.tk == "xpcall" then
+      if isx then
          base_nargs = 2
          local arg2 = node.e2[2]
          local msgh = table.remove(b.tuple, 1)

--- a/tl.lua
+++ b/tl.lua
@@ -7389,13 +7389,13 @@ tl.new_env = function(opts)
 
 
       local string_t = (stdlib_globals["string"].t).def
-      string_t.fields["find"].special_function_handler = "string_find"
-      string_t.fields["format"].special_function_handler = "string_format"
-      string_t.fields["gmatch"].special_function_handler = "string_gmatch"
-      string_t.fields["gsub"].special_function_handler = "string_gsub"
-      string_t.fields["match"].special_function_handler = "string_match"
-      string_t.fields["pack"].special_function_handler = "string_pack"
-      string_t.fields["unpack"].special_function_handler = "string_unpack"
+      string_t.fields["find"].special_function_handler = "string.find"
+      string_t.fields["format"].special_function_handler = "string.format"
+      string_t.fields["gmatch"].special_function_handler = "string.gmatch"
+      string_t.fields["gsub"].special_function_handler = "string.gsub"
+      string_t.fields["match"].special_function_handler = "string.match"
+      string_t.fields["pack"].special_function_handler = "string.pack"
+      string_t.fields["unpack"].special_function_handler = "string.unpack"
 
       stdlib_globals["assert"].t.special_function_handler = "assert"
       stdlib_globals["ipairs"].t.special_function_handler = "ipairs"
@@ -11647,7 +11647,7 @@ a.types[i], b.types[i]), }
          self:apply_facts(node, node.e2[1].known)
          return r
       end,
-      ["string_pack"] = function(self, node, a, b, argdelta)
+      ["string.pack"] = function(self, node, a, b, argdelta)
          if #b.tuple < 1 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 1)")
          end
@@ -11679,7 +11679,7 @@ a.types[i], b.types[i]), }
          end
       end,
 
-      ["string_unpack"] = function(self, node, a, b, argdelta)
+      ["string.unpack"] = function(self, node, a, b, argdelta)
          if #b.tuple < 2 or #b.tuple > 3 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects 2 or 3)")
          end
@@ -11710,7 +11710,7 @@ a.types[i], b.types[i]), }
          return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
       end,
 
-      ["string_format"] = function(self, node, a, b, argdelta)
+      ["string.format"] = function(self, node, a, b, argdelta)
          if #b.tuple < 1 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 1)")
          end
@@ -11743,7 +11743,7 @@ a.types[i], b.types[i]), }
          end
       end,
 
-      ["string_match"] = function(self, node, a, b, argdelta)
+      ["string.match"] = function(self, node, a, b, argdelta)
          if #b.tuple < 2 or #b.tuple > 3 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects 2 or 3)")
          end
@@ -11770,7 +11770,7 @@ a.types[i], b.types[i]), }
          return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
       end,
 
-      ["string_find"] = function(self, node, a, b, argdelta)
+      ["string.find"] = function(self, node, a, b, argdelta)
          if #b.tuple < 2 or #b.tuple > 4 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 2 and at most 4)")
          end
@@ -11806,7 +11806,7 @@ a.types[i], b.types[i]), }
          return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
       end,
 
-      ["string_gmatch"] = function(self, node, a, b, argdelta)
+      ["string.gmatch"] = function(self, node, a, b, argdelta)
          if #b.tuple < 2 or #b.tuple > 3 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects 2 or 3)")
          end
@@ -11840,7 +11840,7 @@ a.types[i], b.types[i]), }
          return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
       end,
 
-      ["string_gsub"] = function(self, node, a, b, argdelta)
+      ["string.gsub"] = function(self, node, a, b, argdelta)
 
 
 

--- a/tl.lua
+++ b/tl.lua
@@ -11301,7 +11301,12 @@ a.types[i], b.types[i]), }
             if pat:sub(i + 2, i + 2) ~= "[" then
                return nil, nil, "malformed pattern: missing '[' after %f"
             end
-            return pattern_findclassend(pat, i + 2, strict), false
+            local e, _, err = pattern_findclassend(pat, i + 2, strict)
+            if not e then
+               return nil, nil, err
+            else
+               return e, false
+            end
          elseif peek == "b" then
             if pat:sub(i + 3, i + 3) == "" then
                return nil, nil, "malformed pattern: need balanced characters"
@@ -11421,6 +11426,9 @@ a.types[i], b.types[i]), }
             i = i + 1
          elseif c == ")" then
             unclosed = unclosed - 1
+            if unclosed < 0 then
+               return nil, "malformed pattern: unexpected ')'"
+            end
             i = i + 1
          elseif strict and c:match("[]^$()*+%-?]") then
             return nil, "malformed pattern: character was unexpected: '" .. c .. "'"
@@ -11436,7 +11444,7 @@ a.types[i], b.types[i]), }
          results[1] = a_type(node, "string", {})
       end
       if unclosed ~= 0 then
-         return results, unclosed .. " captures not closed"
+         return nil, "malformed pattern: " .. unclosed .. " capture" .. (unclosed == 1 and "" or "s") .. " not closed"
       end
       return results
    end

--- a/tl.lua
+++ b/tl.lua
@@ -311,24 +311,24 @@ do
 
       char: function(integer...): string
       dump: function(function(any...): (any), ? boolean): string
-      find: function(string, string, ? integer, ? boolean): integer, integer, string...
-      format: function(string, any...): string
-      gmatch: function(string, string, ? integer): (function(): string...)
+      find: function(string, string, ? integer, ? boolean): integer, integer, string... --[[special_function]]
+      format: function(string, any...): string --[[special_function]]
+      gmatch: function(string, string, ? integer): (function(): string...) --[[special_function]]
 
-      gsub: function(string, string, string, ? integer): string, integer
-      gsub: function(string, string, {string:string|integer|number}, ? integer): string, integer
-      gsub: function(string, string, {integer:string|integer|number}, ? integer): string, integer
-      gsub: function(string, string, function((string|integer)...): ((string|integer|number)...), ? integer): string, integer
+      gsub: function(string, string, string, ? integer): string, integer --[[special_function]]
+      gsub: function(string, string, {string:string|integer|number}, ? integer): string, integer --[[special_function]]
+      gsub: function(string, string, {integer:string|integer|number}, ? integer): string, integer --[[special_function]]
+      gsub: function(string, string, function((string|integer)...): ((string|integer|number)...), ? integer): string, integer --[[special_function]]
 
       len: function(string): integer
       lower: function(string): string
-      match: function(string, string, ? integer): string...
-      pack: function(string, any...): string
+      match: function(string, string, ? integer): string... --[[special_function]]
+      pack: function(string, any...): string --[[special_function]]
       packsize: function(string): integer
       rep: function(string, integer, ? string): string
       reverse: function(string): string
       sub: function(string, integer, ? integer): string
-      unpack: function(string, string, ? integer): any...
+      unpack: function(string, string, ? integer): any... --[[special_function]]
       upper: function(string): string
    end
 
@@ -397,7 +397,7 @@ do
       type XpcallMsghFunction = function(...: any): ()
 
       arg: {string}
-      assert: function<A, B>(A, ? B, ...: any): A
+      assert: function<A, B>(A, ? B, ...: any): A --[[special_function]]
 
       collectgarbage: function(? CollectGarbageCommand): number
       collectgarbage: function(CollectGarbageSetValue, integer): number
@@ -408,7 +408,7 @@ do
 
       error: function(? any, ? integer)
       getmetatable: function<T>(T): metatable<T>
-      ipairs: function<A>({A}): (function():(integer, A))
+      ipairs: function<A>({A}): (function():(integer, A)) --[[special_function]]
 
       load: function((string | LoadFunction), ? string, ? LoadMode, ? table): (function, string)
       load: function((string | LoadFunction), ? string, ? string, ? table): (function, string)
@@ -418,12 +418,12 @@ do
       next: function<K, V>({K:V}, ? K): (K, V)
       next: function<A>({A}, ? integer): (integer, A)
 
-      pairs: function<K, V>({K:V}): (function():(K, V))
-      pcall: function(function(any...):(any...), any...): boolean, any...
+      pairs: function<K, V>({K:V}): (function():(K, V)) --[[special_function]]
+      pcall: function(function(any...):(any...), any...): boolean, any... --[[special_function]]
       print: function(any...)
       rawequal: function(any, any): boolean
 
-      rawget: function<K, V>({K:V}, K): V
+      rawget: function<K, V>({K:V}, K): V --[[special_function]]
       rawget: function({any:any}, any): any
       rawget: function(any, any): any
 
@@ -433,7 +433,7 @@ do
       rawset: function({any:any}, any, any): {any:any}
       rawset: function(any, any, any): any
 
-      require: function(string): any
+      require: function(string): any --[[special_function]]
 
       select: function<T>(integer, T...): T...
       select: function(integer, any...): any...
@@ -447,7 +447,7 @@ do
       tostring: function(any): string
       type: function(any): string
       warn: function(string, string...)
-      xpcall: function(function(any...):(any...), XpcallMsghFunction, any...): boolean, any...
+      xpcall: function(function(any...):(any...), XpcallMsghFunction, any...): boolean, any... --[[special_function]]
       _VERSION: string
    end
 
@@ -1667,6 +1667,24 @@ local table_types = {
    ["none"] = false,
    ["*"] = false,
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -7370,6 +7388,24 @@ tl.new_env = function(opts)
       table_t.fields["unpack"].needs_compat = true
 
 
+      local string_t = (stdlib_globals["string"].t).def
+      string_t.fields["find"].special_function_handler = "string_find"
+      string_t.fields["format"].special_function_handler = "string_format"
+      string_t.fields["gmatch"].special_function_handler = "string_gmatch"
+      string_t.fields["gsub"].special_function_handler = "string_gsub"
+      string_t.fields["match"].special_function_handler = "string_match"
+      string_t.fields["pack"].special_function_handler = "string_pack"
+      string_t.fields["unpack"].special_function_handler = "string_unpack"
+
+      stdlib_globals["assert"].t.special_function_handler = "assert"
+      stdlib_globals["ipairs"].t.special_function_handler = "ipairs"
+      stdlib_globals["pairs"].t.special_function_handler = "pairs"
+      stdlib_globals["pcall"].t.special_function_handler = "pcall"
+      stdlib_globals["xpcall"].t.special_function_handler = "xpcall"
+      stdlib_globals["rawget"].t.special_function_handler = "rawget"
+      stdlib_globals["require"].t.special_function_handler = "require"
+
+
 
 
       stdlib_globals["..."] = { t = a_vararg(w, { a_type(w, "string", {}) }) }
@@ -7865,6 +7901,7 @@ do
             end
             copy.typeargs = ct
             copy.t, same = resolve(t.t, same)
+            copy.special_function_handler = t.special_function_handler
          elseif t.typename == "array" then
             assert(copy.typename == "array")
 
@@ -7909,6 +7946,7 @@ do
             copy.is_record_function = t.is_record_function
             copy.args, same = resolve(t.args, same)
             copy.rets, same = resolve(t.rets, same)
+            copy.special_function_handler = t.special_function_handler
          elseif t.fields then
             assert(copy.typename == "record" or copy.typename == "interface")
             copy.declname = t.declname
@@ -7964,6 +8002,7 @@ do
             for i, tf in ipairs(t.types) do
                copy.types[i], same = resolve(tf, same)
             end
+            copy.special_function_handler = t.special_function_handler
          elseif t.typename == "tupletable" then
             assert(copy.typename == "tupletable")
             copy.inferred_at = t.inferred_at
@@ -11593,14 +11632,12 @@ a.types[i], b.types[i]), }
 
       ["pcall"] = special_pcall_xpcall,
       ["xpcall"] = special_pcall_xpcall,
-
       ["assert"] = function(self, node, a, b, argdelta)
          node.known = FACT_TRUTHY
          local r = self:type_check_function_call(node, a, b, argdelta)
          self:apply_facts(node, node.e2[1].known)
          return r
       end,
-
       ["string_pack"] = function(self, node, a, b, argdelta)
          if #b.tuple < 1 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 1)")
@@ -11877,31 +11914,19 @@ a.types[i], b.types[i]), }
 
    function TypeChecker:type_check_funcall(node, a, b, argdelta)
       argdelta = argdelta or 0
-      if node.e1.kind == "variable" then
-         local special = special_functions[node.e1.tk]
-         if special then
-            return special(self, node, a, b, argdelta)
-         else
-            return (self:type_check_function_call(node, a, b, argdelta))
-         end
-      elseif node.e1.op and node.e1.op.op == "." and node.e1.e1.kind == "variable" and node.e1.e1.tk == "string" then
-         local special = special_functions["string_" .. node.e1.e2.tk]
-         if special then
-            return special(self, node, a, b, argdelta)
-         else
-            return (self:type_check_function_call(node, a, b, argdelta))
-         end
-      elseif node.e1.op and node.e1.op.op == ":" then
-         table.insert(b.tuple, 1, node.e1.receiver)
-         if b.tuple[1].typename == "string" then
 
-            local special = special_functions["string_" .. node.e1.e2.tk]
-            if special then
-               return special(self, node, a, b, -1)
-            end
+      local special_tyck = special_functions[a.special_function_handler]
+
+      if node.e1.op and node.e1.op.op == ":" then
+         table.insert(b.tuple, 1, node.e1.receiver)
+         if special_tyck then
+            return special_tyck(self, node, a, b, -1)
          end
          return (self:type_check_function_call(node, a, b, -1))
       else
+         if special_tyck then
+            return special_tyck(self, node, a, b, argdelta)
+         end
          return (self:type_check_function_call(node, a, b, argdelta))
       end
    end

--- a/tl.lua
+++ b/tl.lua
@@ -316,8 +316,9 @@ do
       gmatch: function(string, string, ? integer): (function(): string...)
 
       gsub: function(string, string, string, ? integer): string, integer
-      gsub: function(string, string, {string:string}, ? integer): string, integer
-      gsub: function(string, string, function(string...): ((string | integer | number)...), ? integer): string, integer
+      gsub: function(string, string, {string:string|integer|number}, ? integer): string, integer
+      gsub: function(string, string, {integer:string|integer|number}, ? integer): string, integer
+      gsub: function(string, string, function((string|integer)...): ((string|integer|number)...), ? integer): string, integer
 
       len: function(string): integer
       lower: function(string): string

--- a/tl.lua
+++ b/tl.lua
@@ -10343,7 +10343,7 @@ a.types[i], b.types[i]), }
          end
       end
 
-      local keyg = key:gsub('%%', '%%%%')
+      local keyg = key:gsub("%%", "%%%%")
 
       if t.fields then
          assert(t.fields, "record has no fields!?")
@@ -10642,7 +10642,7 @@ a.types[i], b.types[i]), }
             local field_names = sorted_keys(rb.enumset)
             for _, k in ipairs(field_names) do
                if not ra.fields[k] then
-                  errm, erra = "enum value '" .. k:gsub('%%', '%%%%') .. "' is not a field in %s", ra
+                  errm, erra = "enum value '" .. k:gsub("%%", "%%%%") .. "' is not a field in %s", ra
                   break
                end
             end

--- a/tl.tl
+++ b/tl.tl
@@ -9941,9 +9941,9 @@ do
          "type_dot" -- a dot-call where the receiver is a type, e.g. `MyRecord.my_func()`
       end
 
-      local check_call: function(self: TypeChecker, w: Where, wargs: {Where}, f: FunctionType, args: TupleType, expected_rets: TupleType, cm: CallMode, argdelta: integer): boolean, {Error}
+      local check_call: function(self: TypeChecker, w: Where, wargs: {Where}, f: FunctionType, args: TupleType, expected_rets: TupleType, cm: CallMode, argdelta: integer, or_args: TupleType, or_rets: TupleType): boolean, {Error}
       do
-         local check_args_rets: function(TypeChecker, w: Where, wargs: {Where}, f: FunctionType, args: TupleType, expected_rets: TupleType, argdelta: integer): boolean, {Error}
+         local check_args_rets: function(TypeChecker, w: Where, wargs: {Where}, f: FunctionType, args: TupleType, expected_rets: TupleType, argdelta: integer, or_args: TupleType, or_rets: TupleType): boolean, {Error}
          do
             -- check if a tuple `xs` matches tuple `ys`
             local function check_func_type_list(self: TypeChecker, w: Where, wheres: {Where}, xs: TupleType, ys: TupleType, from: integer, delta: integer, v: VarianceMode, mode: ArgCheckMode): boolean, {Error}
@@ -9967,15 +9967,18 @@ do
                return true
             end
 
-            check_args_rets = function(self: TypeChecker, w: Where, wargs: {Where}, f: FunctionType, args: TupleType, expected_rets: TupleType, argdelta: integer): boolean, {Error}
+            check_args_rets = function(self: TypeChecker, w: Where, wargs: {Where}, f: FunctionType, args: TupleType, expected_rets: TupleType, argdelta: integer, or_args: TupleType, or_rets: TupleType): boolean, {Error}
                local rets_ok = true
                local args_ok, args_errs: boolean, {Error} = true, nil
+
+               local fargs = or_args or f.args
+               local frets = or_rets or f.rets
 
                local from = 1
                if argdelta == -1 then
                   from = 2
                   local errs = {}
-                  local first = f.args.tuple[1]
+                  local first = fargs.tuple[1]
                   if (not first is SelfType) and not self:arg_check(w, errs, first, args.tuple[1], "contravariant", "self") then
                      return nil, errs
                   end
@@ -9983,17 +9986,17 @@ do
 
                if expected_rets then
                   expected_rets = self:infer_at(w, expected_rets)
-                  infer_emptytables(self, w, nil, expected_rets, f.rets, 0)
+                  infer_emptytables(self, w, nil, expected_rets, frets, 0)
 
-                  rets_ok = check_func_type_list(self, w, nil, f.rets, expected_rets, 1, 0, "covariant", "return")
+                  rets_ok = check_func_type_list(self, w, nil, frets, expected_rets, 1, 0, "covariant", "return")
                end
 
-               args_ok, args_errs = check_func_type_list(self, w, wargs, f.args, args, from, argdelta, "contravariant", "argument")
+               args_ok, args_errs = check_func_type_list(self, w, wargs, fargs, args, from, argdelta, "contravariant", "argument")
                if (not args_ok) or (not rets_ok) then
                   return nil, args_errs or {}
                end
 
-               infer_emptytables(self, w, wargs, args, f.args, argdelta)
+               infer_emptytables(self, w, wargs, args, fargs, argdelta)
 
                return true
             end
@@ -10013,7 +10016,7 @@ do
             return false
          end
 
-         check_call = function(self: TypeChecker, w: Where, wargs: {Where}, f: FunctionType, args: TupleType, expected_rets: TupleType, cm: CallMode, argdelta: integer): boolean, {Error}
+         check_call = function(self: TypeChecker, w: Where, wargs: {Where}, f: FunctionType, args: TupleType, expected_rets: TupleType, cm: CallMode, argdelta: integer, or_args: TupleType, or_rets: TupleType): boolean, {Error}
             local arg1 = args.tuple[1]
             if cm == "method" and arg1 then
                local selftype = arg1
@@ -10023,7 +10026,7 @@ do
                self:add_var(nil, "@self", a_typedecl(w, selftype))
             end
 
-            local fargs = f.args.tuple
+            local fargs = (or_args or f.args).tuple
             if f.is_method and is_method_mismatch(self, w, arg1, fargs[1], cm) then
                return false
             end
@@ -10032,11 +10035,11 @@ do
             local wanted = #fargs
             local min_arity = self.feat_arity and f.min_arity or 0
 
-            if given < min_arity or (given > wanted and not f.args.is_va) then
+            if given < min_arity or (given > wanted and not (or_args or f.args).is_va) then
                return nil, { Err_at(w, "wrong number of arguments (given " .. given .. ", expects " .. show_arity(f) .. ")") }
             end
 
-            return check_args_rets(self, w, wargs, f, args, expected_rets, argdelta)
+            return check_args_rets(self, w, wargs, f, args, expected_rets, argdelta, or_args, or_rets)
          end
       end
 
@@ -10055,7 +10058,7 @@ do
          end
       end
 
-      local check_poly_call: function(self: TypeChecker, w: Where, wargs: {Where}, p: PolyType, args: TupleType, expected_rets: TupleType, cm: CallMode, argdelta: integer): FunctionType, TupleType, {Error}
+      local check_poly_call: function(self: TypeChecker, w: Where, wargs: {Where}, p: PolyType, args: TupleType, expected_rets: TupleType, cm: CallMode, argdelta: integer, or_args: TupleType, or_rets: TupleType): FunctionType, TupleType, {Error}
       do
          local function fail_poly_call_arity(self: TypeChecker, w: Where, p: PolyType, given: integer): {Error}
             local expects: {string} = {}
@@ -10071,7 +10074,7 @@ do
             return { Err_at(w, "wrong number of arguments (given " .. given .. ", expects " .. table.concat(expects, " or ") .. ")") }
          end
 
-         check_poly_call = function(self: TypeChecker, w: Where, wargs: {Where}, p: PolyType, args: TupleType, expected_rets: TupleType, cm: CallMode, argdelta: integer): FunctionType, TupleType, {Error}
+         check_poly_call = function(self: TypeChecker, w: Where, wargs: {Where}, p: PolyType, args: TupleType, expected_rets: TupleType, cm: CallMode, argdelta: integer, or_args: TupleType, or_rets: TupleType): FunctionType, TupleType, {Error}
             local given = #args.tuple
 
             local tried: {integer:boolean} = {}
@@ -10082,7 +10085,7 @@ do
                for i, f in self:iterate_poly(p) do
                   assert(f is FunctionType, f.typename)
                   assert(f.args)
-                  first_rets = first_rets or f.rets
+                  first_rets = first_rets or or_rets or f.rets
 
                   local wanted = #f.args.tuple
                   local min_arity = self.feat_arity and f.min_arity or 0
@@ -10095,12 +10098,12 @@ do
                      -- then finally try vararg functions
                      or (pass == 3 and (f.args.is_va and given > wanted)) )
                   then
-                     local ok, errs = check_call(self, w, wargs, f, args, expected_rets, cm, argdelta)
+                     local ok, errs = check_call(self, w, wargs, f, args, expected_rets, cm, argdelta, or_args, or_rets)
                      if ok then
-                        return f, f.rets
+                        return f, or_rets or f.rets
                      elseif expected_rets then
                         -- revert inferred returns
-                        infer_emptytables(self, w, wargs, f.rets, f.rets, argdelta)
+                        infer_emptytables(self, w, wargs, or_rets or f.rets, or_rets or f.rets, argdelta)
                      end
 
                      self:rollback_scope_transaction()
@@ -10135,7 +10138,7 @@ do
          return "plain"
       end
 
-      function TypeChecker:type_check_function_call(node: Node, func: Type, args: TupleType, argdelta: integer, e1?: Node, e2?: {Node}): InvalidOrTupleType, FunctionType
+      function TypeChecker:type_check_function_call(node: Node, func: Type, args: TupleType, argdelta: integer, or_args ?: TupleType, or_rets ?: TupleType, e1?: Node, e2?: {Node}): InvalidOrTupleType, FunctionType
          e1 = e1 or node.e1
          e2 = e2 or node.e2
 
@@ -10171,11 +10174,11 @@ do
          local f, ret: FunctionType, InvalidOrTupleType
 
          if func is PolyType then
-            f, ret, errs = check_poly_call(self, node, e2, func, args, expected_rets, cm, argdelta)
+            f, ret, errs = check_poly_call(self, node, e2, func, args, expected_rets, cm, argdelta, or_args, or_rets)
          elseif func is FunctionType then
             local _: boolean
-            _, errs = check_call(self, node, e2, func, args, expected_rets, cm, argdelta)
-            f, ret = func, func.rets
+            _, errs = check_call(self, node, e2, func, args, expected_rets, cm, argdelta, or_args, or_rets)
+            f, ret = func, or_rets or func.rets
          else
             ret = self.errs:invalid_at(node, "not a function: %s", func)
          end
@@ -10252,7 +10255,7 @@ do
          end
 
          local mtdelta = metamethod is FunctionType and metamethod.is_method and -1 or 0
-         local ret_call <const> = self:type_check_function_call(node, metamethod, args, mtdelta, node, e2)
+         local ret_call <const> = self:type_check_function_call(node, metamethod, args, mtdelta, nil, nil, node, e2)
          local ret_unary <const> = resolve_tuple(ret_call)
          local ret <const> = self:to_structural(ret_unary)
          return ret, meta_on_operator
@@ -12178,7 +12181,7 @@ do
 
             if exp1type is PolyType then
                local _r, f: Type, Type
-               _r, f = self:type_check_function_call(exp1, exp1type, args, 0, exp1, {node.exps[2], node.exps[3]})
+               _r, f = self:type_check_function_call(exp1, exp1type, args, 0, nil, nil, exp1, {node.exps[2], node.exps[3]})
                if f then
                   exp1type = f
                else

--- a/tl.tl
+++ b/tl.tl
@@ -1676,13 +1676,13 @@ local enum SpecialFunctionName
    "xpcall"
    "rawget"
    "require"
-   "string_find"
-   "string_format"
-   "string_gmatch"
-   "string_gsub"
-   "string_match"
-   "string_pack"
-   "string_unpack"
+   "string.find"
+   "string.format"
+   "string.gmatch"
+   "string.gsub"
+   "string.match"
+   "string.pack"
+   "string.unpack"
 end
 
 local interface Type
@@ -7389,13 +7389,13 @@ tl.new_env = function(opts?: EnvOptions): Env, string
 
       -- special cased functions
       local string_t = (stdlib_globals["string"].t as TypeDeclType).def as RecordType
-      string_t.fields["find"].special_function_handler = "string_find"
-      string_t.fields["format"].special_function_handler = "string_format"
-      string_t.fields["gmatch"].special_function_handler = "string_gmatch"
-      string_t.fields["gsub"].special_function_handler = "string_gsub"
-      string_t.fields["match"].special_function_handler = "string_match"
-      string_t.fields["pack"].special_function_handler = "string_pack"
-      string_t.fields["unpack"].special_function_handler = "string_unpack"
+      string_t.fields["find"].special_function_handler = "string.find"
+      string_t.fields["format"].special_function_handler = "string.format"
+      string_t.fields["gmatch"].special_function_handler = "string.gmatch"
+      string_t.fields["gsub"].special_function_handler = "string.gsub"
+      string_t.fields["match"].special_function_handler = "string.match"
+      string_t.fields["pack"].special_function_handler = "string.pack"
+      string_t.fields["unpack"].special_function_handler = "string.unpack"
 
       stdlib_globals["assert"].t.special_function_handler = "assert"
       stdlib_globals["ipairs"].t.special_function_handler = "ipairs"
@@ -11647,7 +11647,7 @@ do
          self:apply_facts(node, node.e2[1].known)
          return r
       end,
-      ["string_pack"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+      ["string.pack"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if #b.tuple < 1 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 1)")
          end
@@ -11679,7 +11679,7 @@ do
          end
       end,
 
-      ["string_unpack"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+      ["string.unpack"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if #b.tuple < 2 or #b.tuple > 3 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects 2 or 3)")
          end
@@ -11710,7 +11710,7 @@ do
          return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
       end,
 
-      ["string_format"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+      ["string.format"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if #b.tuple < 1 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 1)")
          end
@@ -11743,7 +11743,7 @@ do
          end
       end,
 
-      ["string_match"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+      ["string.match"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if #b.tuple < 2 or #b.tuple > 3 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects 2 or 3)")
          end
@@ -11770,7 +11770,7 @@ do
          return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
       end,
 
-      ["string_find"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+      ["string.find"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if #b.tuple < 2 or #b.tuple > 4 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 2 and at most 4)")
          end
@@ -11806,7 +11806,7 @@ do
          return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
       end,
 
-      ["string_gmatch"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+      ["string.gmatch"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if #b.tuple < 2 or #b.tuple > 3 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects 2 or 3)")
          end
@@ -11840,7 +11840,7 @@ do
          return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
       end,
 
-      ["string_gsub"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+      ["string.gsub"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          -- if the second argument is a literal, we can parse it and change the matchers
          -- gsub: function(string, string, <matcher>, ? integer): string, integer
 

--- a/tl.tl
+++ b/tl.tl
@@ -11247,8 +11247,9 @@ do
       end
    end
 
-   local function special_pcall_xpcall(self: TypeChecker, node: Node, _a: Type, b: TupleType, argdelta?: integer): Type
-      local base_nargs = (node.e1.tk == "xpcall") and 2 or 1
+   local function special_pcall_xpcall(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): Type
+      local isx = a.special_function_handler == "xpcall"
+      local base_nargs = isx and 2 or 1
       local bool = a_type(node, "boolean", {})
       if #node.e2 < base_nargs then
          self.errs:add(node, "wrong number of arguments (given " .. #node.e2 .. ", expects at least " .. base_nargs .. ")")
@@ -11263,7 +11264,7 @@ do
       ftype = ensure_not_method(ftype)
 
       local fe2: Node = node_at(node.e2, {})
-      if node.e1.tk == "xpcall" then
+      if isx then
          base_nargs = 2
          local arg2 = node.e2[2]
          local msgh = table.remove(b.tuple, 1)

--- a/tl.tl
+++ b/tl.tl
@@ -11437,6 +11437,71 @@ do
       return results
    end
 
+   local function pack_string_skipnum(pos: integer, pat: string): integer
+      -- TODO: remove cast once bootstrap is updated
+      return pat:match("[0-9]*()", pos) as integer
+   end
+
+   local function parse_pack_string(node: Node, pat: string): {Type}, string
+      local pos = 1
+      local results: {Type} = {}
+      local skip_next = false
+      while pos <= #pat do
+         local c = pat:sub(pos, pos)
+         local to_add: Type
+         if c:match"[<> =x]" then
+            -- nothing to do with argument
+            if skip_next then
+               return nil, "expected argument for 'X'"
+            end
+            pos = pos + 1
+            goto next
+         elseif c == "X" then
+            if skip_next then
+               return nil, "expected argument for 'X'"
+            end
+            skip_next = true
+            pos = pos + 1
+            goto next
+         elseif c == "!" then
+            if skip_next then
+               return nil, "expected argument for 'X'"
+            end
+            pos = pack_string_skipnum(pos + 1, pat)
+            goto next
+         elseif c:match"[Ii]" then
+            pos = pack_string_skipnum(pos + 1, pat)
+            to_add = a_type(node, "integer", {})
+         elseif c:match"[bBhHlLjJT]" then
+            pos = pos + 1
+            to_add = a_type(node, "integer", {})
+         elseif c:match"[fdn]" then
+            pos = pos + 1
+            to_add = a_type(node, "number", {})
+         elseif c == "z" or c == "s" or c == "c" then
+            if c == "z" then
+               pos = pos + 1
+            else
+               pos = pack_string_skipnum(pos + 1, pat)
+            end
+            -- string.pack accepts numbers here, but unpacks them as strings so we just skip it
+            to_add = a_type(node, "string", {})
+         else
+            return nil, "invalid format option: '" .. c .. "'"
+         end
+         if skip_next then
+            skip_next = false
+         else
+            table.insert(results, to_add)
+         end
+         ::next::
+      end
+      if skip_next then
+         return nil, "expected argument for 'X'"
+      end
+      return results
+   end
+
    local special_functions: {string : function(TypeChecker, Node, Type, TupleType, ? integer):InvalidOrTupleType } = {
       ["pairs"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if not b.tuple[1] then
@@ -11531,6 +11596,69 @@ do
          local r = self:type_check_function_call(node, a, b, argdelta)
          self:apply_facts(node, node.e2[1].known)
          return r
+      end,
+
+      ["string_pack"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+         if #b.tuple < 1 then
+            return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 1)")
+         end
+
+         local packstr = b.tuple[1]
+
+         if packstr is StringType and packstr.literal and a is FunctionType then
+            local st = packstr.literal
+            local items, e = parse_pack_string(node, st)
+
+            if e then
+               if items then
+                  -- just a warning
+                  self.errs:add_warning("hint", packstr, e)
+               else
+                  return self.errs:invalid_at(packstr, e)
+               end
+            end
+
+            table.insert(items, 1, a_type(node, "string", {}))
+
+            if #items ~= #b.tuple then
+               return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects " .. #items .. ")")
+            end
+
+            return (self:type_check_function_call(node, a, b, argdelta, a_tuple(node, items), nil))
+         else
+            return (self:type_check_function_call(node, a, b, argdelta))
+         end
+      end,
+
+      ["string_unpack"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+         if #b.tuple < 2 or #b.tuple > 3 then
+            return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects 2 or 3)")
+         end
+
+         local packstr = b.tuple[1]
+
+         local rets: TupleType
+
+         if packstr is StringType and packstr.literal then
+            local st = packstr.literal
+            local items, e = parse_pack_string(node, st)
+
+            if e then
+               if items then
+                  -- just a warning
+                  self.errs:add_warning("hint", packstr, e)
+               else
+                  return self.errs:invalid_at(packstr, e)
+               end
+            end
+
+            table.insert(items, a_type(node, "integer", {}))
+
+            -- set the returns to match the response
+            rets = a_tuple(node, items)
+         end
+
+         return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
       end,
 
       ["string_format"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType

--- a/tl.tl
+++ b/tl.tl
@@ -11301,7 +11301,12 @@ do
             if pat:sub(i + 2, i + 2) ~= "[" then
                return nil, nil, "malformed pattern: missing '[' after %f"
             end
-            return pattern_findclassend(pat, i + 2, strict), false
+            local e, _, err = pattern_findclassend(pat, i + 2, strict)
+            if not e then
+               return nil, nil, err
+            else
+               return e, false
+            end
          elseif peek == "b" then
             if pat:sub(i + 3, i + 3) == "" then
                return nil, nil, "malformed pattern: need balanced characters"
@@ -11421,6 +11426,9 @@ do
             i = i + 1
          elseif c == ")" then
             unclosed = unclosed - 1
+            if unclosed < 0 then
+               return nil, "malformed pattern: unexpected ')'"
+            end
             i = i + 1
          elseif strict and c:match"[]^$()*+%-?]" then -- operations that haven't been handled
             return nil, "malformed pattern: character was unexpected: '" .. c .. "'"
@@ -11436,7 +11444,7 @@ do
          results[1] = a_type(node, "string", {})
       end
       if unclosed ~= 0 then
-         return results, unclosed .. " captures not closed"
+         return nil, "malformed pattern: " .. unclosed .. " capture" .. (unclosed == 1 and "" or "s") .. " not closed"
       end
       return results
    end

--- a/tl.tl
+++ b/tl.tl
@@ -14585,7 +14585,7 @@ end
 
 local function lang_heuristic(filename?: string, input?: string): ParseLang
    if filename then
-      local pattern = "(.*)%.([a-z]+)$"
+      local pattern <const> = "(.*)%.([a-z]+)$"
       local _, extension = filename:match(pattern)
       extension = extension and extension:lower()
 

--- a/tl.tl
+++ b/tl.tl
@@ -10343,7 +10343,7 @@ do
          end
       end
 
-      local keyg = key:gsub('%%', '%%%%')
+      local keyg = key:gsub("%%", "%%%%")
 
       if t is RecordLikeType then
          assert(t.fields, "record has no fields!?")
@@ -10642,7 +10642,7 @@ do
             local field_names: {string} = sorted_keys(rb.enumset)
             for _, k in ipairs(field_names) do
                if not ra.fields[k] then
-                  errm, erra = "enum value '" .. k:gsub('%%', '%%%%') .. "' is not a field in %s", ra
+                  errm, erra = "enum value '" .. k:gsub("%%", "%%%%") .. "' is not a field in %s", ra
                   break
                end
             end

--- a/tl.tl
+++ b/tl.tl
@@ -311,24 +311,24 @@ do
 
       char: function(integer...): string
       dump: function(function(any...): (any), ? boolean): string
-      find: function(string, string, ? integer, ? boolean): integer, integer, string...
-      format: function(string, any...): string
-      gmatch: function(string, string, ? integer): (function(): string...)
+      find: function(string, string, ? integer, ? boolean): integer, integer, string... --[[special_function]]
+      format: function(string, any...): string --[[special_function]]
+      gmatch: function(string, string, ? integer): (function(): string...) --[[special_function]]
 
-      gsub: function(string, string, string, ? integer): string, integer
-      gsub: function(string, string, {string:string|integer|number}, ? integer): string, integer
-      gsub: function(string, string, {integer:string|integer|number}, ? integer): string, integer
-      gsub: function(string, string, function((string|integer)...): ((string|integer|number)...), ? integer): string, integer
+      gsub: function(string, string, string, ? integer): string, integer --[[special_function]]
+      gsub: function(string, string, {string:string|integer|number}, ? integer): string, integer --[[special_function]]
+      gsub: function(string, string, {integer:string|integer|number}, ? integer): string, integer --[[special_function]]
+      gsub: function(string, string, function((string|integer)...): ((string|integer|number)...), ? integer): string, integer --[[special_function]]
 
       len: function(string): integer
       lower: function(string): string
-      match: function(string, string, ? integer): string...
-      pack: function(string, any...): string
+      match: function(string, string, ? integer): string... --[[special_function]]
+      pack: function(string, any...): string --[[special_function]]
       packsize: function(string): integer
       rep: function(string, integer, ? string): string
       reverse: function(string): string
       sub: function(string, integer, ? integer): string
-      unpack: function(string, string, ? integer): any...
+      unpack: function(string, string, ? integer): any... --[[special_function]]
       upper: function(string): string
    end
 
@@ -397,7 +397,7 @@ do
       type XpcallMsghFunction = function(...: any): ()
 
       arg: {string}
-      assert: function<A, B>(A, ? B, ...: any): A
+      assert: function<A, B>(A, ? B, ...: any): A --[[special_function]]
 
       collectgarbage: function(? CollectGarbageCommand): number
       collectgarbage: function(CollectGarbageSetValue, integer): number
@@ -408,7 +408,7 @@ do
 
       error: function(? any, ? integer)
       getmetatable: function<T>(T): metatable<T>
-      ipairs: function<A>({A}): (function():(integer, A))
+      ipairs: function<A>({A}): (function():(integer, A)) --[[special_function]]
 
       load: function((string | LoadFunction), ? string, ? LoadMode, ? table): (function, string)
       load: function((string | LoadFunction), ? string, ? string, ? table): (function, string)
@@ -418,12 +418,12 @@ do
       next: function<K, V>({K:V}, ? K): (K, V)
       next: function<A>({A}, ? integer): (integer, A)
 
-      pairs: function<K, V>({K:V}): (function():(K, V))
-      pcall: function(function(any...):(any...), any...): boolean, any...
+      pairs: function<K, V>({K:V}): (function():(K, V)) --[[special_function]]
+      pcall: function(function(any...):(any...), any...): boolean, any... --[[special_function]]
       print: function(any...)
       rawequal: function(any, any): boolean
 
-      rawget: function<K, V>({K:V}, K): V
+      rawget: function<K, V>({K:V}, K): V --[[special_function]]
       rawget: function({any:any}, any): any
       rawget: function(any, any): any
 
@@ -433,7 +433,7 @@ do
       rawset: function({any:any}, any, any): {any:any}
       rawset: function(any, any, any): any
 
-      require: function(string): any
+      require: function(string): any --[[special_function]]
 
       select: function<T>(integer, T...): T...
       select: function(integer, any...): any...
@@ -447,7 +447,7 @@ do
       tostring: function(any): string
       type: function(any): string
       warn: function(string, string...)
-      xpcall: function(function(any...):(any...), XpcallMsghFunction, any...): boolean, any...
+      xpcall: function(function(any...):(any...), XpcallMsghFunction, any...): boolean, any... --[[special_function]]
       _VERSION: string
    end
 
@@ -1668,6 +1668,23 @@ local table_types <total>: {TypeName:boolean} = {
    ["*"] = false,
 }
 
+local enum SpecialFunctionName
+   "assert"
+   "ipairs"
+   "pairs"
+   "pcall"
+   "xpcall"
+   "rawget"
+   "require"
+   "string_find"
+   "string_format"
+   "string_gmatch"
+   "string_gsub"
+   "string_match"
+   "string_pack"
+   "string_unpack"
+end
+
 local interface Type
    is Where
    where self.typename
@@ -1676,6 +1693,7 @@ local interface Type
    typeid: integer       -- unique identifier
    inferred_at: Where    -- for error messages
    needs_compat: boolean -- for Lua compatibilty
+   special_function_handler: SpecialFunctionName -- special handling for format strings etc
 end
 
 local record GenericType
@@ -7369,6 +7387,24 @@ tl.new_env = function(opts?: EnvOptions): Env, string
       table_t.fields["pack"].needs_compat = true
       table_t.fields["unpack"].needs_compat = true
 
+      -- special cased functions
+      local string_t = (stdlib_globals["string"].t as TypeDeclType).def as RecordType
+      string_t.fields["find"].special_function_handler = "string_find"
+      string_t.fields["format"].special_function_handler = "string_format"
+      string_t.fields["gmatch"].special_function_handler = "string_gmatch"
+      string_t.fields["gsub"].special_function_handler = "string_gsub"
+      string_t.fields["match"].special_function_handler = "string_match"
+      string_t.fields["pack"].special_function_handler = "string_pack"
+      string_t.fields["unpack"].special_function_handler = "string_unpack"
+
+      stdlib_globals["assert"].t.special_function_handler = "assert"
+      stdlib_globals["ipairs"].t.special_function_handler = "ipairs"
+      stdlib_globals["pairs"].t.special_function_handler = "pairs"
+      stdlib_globals["pcall"].t.special_function_handler = "pcall"
+      stdlib_globals["xpcall"].t.special_function_handler = "xpcall"
+      stdlib_globals["rawget"].t.special_function_handler = "rawget"
+      stdlib_globals["require"].t.special_function_handler = "require"
+
       -- only global scope and vararg functions accept `...`:
       -- `@is_va` is an internal sentinel value which is
       -- `any` if `...` is accepted in this scope or `nil` if it isn't.
@@ -7865,6 +7901,7 @@ do
             end
             copy.typeargs = ct
             copy.t, same = resolve(t.t, same)
+            copy.special_function_handler = t.special_function_handler
          elseif t is ArrayType then
             assert(copy is ArrayType)
 
@@ -7909,6 +7946,7 @@ do
             copy.is_record_function = t.is_record_function
             copy.args, same = resolve(t.args, same) as (TupleType, boolean)
             copy.rets, same = resolve(t.rets, same) as (TupleType, boolean)
+            copy.special_function_handler = t.special_function_handler
          elseif t is RecordLikeType then
             assert(copy is RecordType or copy is InterfaceType)
             copy.declname = t.declname
@@ -7964,6 +8002,7 @@ do
             for i, tf in ipairs(t.types) do
                copy.types[i], same = resolve(tf, same)
             end
+            copy.special_function_handler = t.special_function_handler
          elseif t is TupleTableType then
             assert(copy is TupleTableType)
             copy.inferred_at = t.inferred_at
@@ -11505,7 +11544,7 @@ do
       return results
    end
 
-   local special_functions: {string : function(TypeChecker, Node, Type, TupleType, ? integer):InvalidOrTupleType } = {
+   local special_functions <total>: {SpecialFunctionName : function(TypeChecker, Node, Type, TupleType, ? integer):InvalidOrTupleType } = {
       ["pairs"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if not b.tuple[1] then
             return self.errs:invalid_at(node, "pairs requires an argument")
@@ -11593,14 +11632,12 @@ do
 
       ["pcall"] = special_pcall_xpcall,
       ["xpcall"] = special_pcall_xpcall,
-
       ["assert"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          node.known = FACT_TRUTHY
          local r = self:type_check_function_call(node, a, b, argdelta)
          self:apply_facts(node, node.e2[1].known)
          return r
       end,
-
       ["string_pack"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if #b.tuple < 1 then
             return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 1)")
@@ -11877,31 +11914,19 @@ do
 
    function TypeChecker:type_check_funcall(node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
       argdelta = argdelta or 0
-      if node.e1.kind == "variable" then
-         local special = special_functions[node.e1.tk]
-         if special then
-            return special(self, node, a, b, argdelta)
-         else
-            return (self:type_check_function_call(node, a, b, argdelta))
-         end
-      elseif node.e1.op and node.e1.op.op == "." and node.e1.e1.kind == "variable" and node.e1.e1.tk == "string" then
-         local special = special_functions["string_" .. node.e1.e2.tk]
-         if special then
-            return special(self, node, a, b, argdelta)
-         else
-            return (self:type_check_function_call(node, a, b, argdelta))
-         end
-      elseif node.e1.op and node.e1.op.op == ":" then
+
+      local special_tyck = special_functions[a.special_function_handler]
+
+      if node.e1.op and node.e1.op.op == ":" then
          table.insert(b.tuple, 1, node.e1.receiver)
-         if b.tuple[1].typename == "string" then
-            -- test for a special function
-            local special = special_functions["string_" .. node.e1.e2.tk]
-            if special then
-               return special(self, node, a, b, -1)
-            end
+         if special_tyck then
+            return special_tyck(self, node, a, b, -1)
          end
          return (self:type_check_function_call(node, a, b, -1))
       else
+         if special_tyck then
+            return special_tyck(self, node, a, b, argdelta)
+         end
          return (self:type_check_function_call(node, a, b, argdelta))
       end
    end

--- a/tl.tl
+++ b/tl.tl
@@ -5777,7 +5777,8 @@ function tl.generate(ast: tl.Node, gen_target: GenTarget, opts?: GenerateOptions
                out.h = out.h + 1
             end
 
-            replaced = replaced:gsub("()\\z(%s*)", function(index_in_disguise: string, ws: string): string
+            replaced = replaced:gsub("()\\z(%s*)", function(index_in_disguise: string|integer, ws: string): string
+               -- TODO: remove cast once bootstrap is updated
                local index <const> = index_in_disguise as integer - 1
                if replaced:sub(index, index) == "\\" then
                   return "\\z" .. ws
@@ -5788,7 +5789,8 @@ function tl.generate(ast: tl.Node, gen_target: GenTarget, opts?: GenerateOptions
                return ""
             end)
 
-            replaced = replaced:gsub("()\\x(..)", function(index_in_disguise: string, digits: string): string
+            replaced = replaced:gsub("()\\x(..)", function(index_in_disguise: string|integer, digits: string): string
+               -- TODO: remove cast once bootstrap is updated
                local index <const> = index_in_disguise as integer - 1
                if replaced:sub(index, index) == "\\" then
                   return "\\x" .. digits
@@ -5797,7 +5799,8 @@ function tl.generate(ast: tl.Node, gen_target: GenTarget, opts?: GenerateOptions
                return byte and string.format("\\%03d", byte) or "\\x" .. digits
             end)
 
-            replaced = replaced:gsub("()\\u{(.-)}", function(index_in_disguise: string, hex_digits: string): string
+            replaced = replaced:gsub("()\\u{(.-)}", function(index_in_disguise: string|integer, hex_digits: string): string
+               -- TODO: remove cast once bootstrap is updated
                local index <const> = index_in_disguise as integer - 1
                if replaced:sub(index, index) == "\\" then
                   return "\\u{" .. hex_digits .. "}"
@@ -11248,6 +11251,155 @@ do
       return rets
    end
 
+   local function pattern_findclassend(pat: string, i: integer, strict: boolean): integer, boolean, string
+      local c = pat:sub(i, i)
+      if c == "%" then
+         local peek = pat:sub(i + 1, i + 1)
+         if peek == "f" then
+            -- frontier
+            if pat:sub(i + 2, i + 2) ~= "[" then
+               return nil, nil, "malformed pattern: missing '[' after %f"
+            end
+            return pattern_findclassend(pat, i + 2, strict), false
+         elseif peek == "b" then
+            if pat:sub(i + 3, i + 3) == "" then
+               return nil, nil, "malformed pattern: need balanced characters"
+            end
+            return i + 3, false
+         elseif peek == "" then
+            return nil, nil, "malformed pattern: expected class"
+         elseif peek:match"[1-9]" then
+            return i + 1, false
+         elseif strict and not peek:match"[][^$()%%.*+%-?AaCcDdGgLlPpSsUuWwXxZz]" then
+            return nil, nil, "malformed pattern: invalid class '" .. peek .. "'"
+         else
+            return i + 1, true
+         end
+      elseif c == "[" then
+         if pat:sub(i + 1, i + 1) == "^" then
+            i = i + 2 -- skip the inverter
+         else
+            i = i + 1
+         end
+
+         local isfirst = true
+         repeat
+            local c_ = pat:sub(i, i)
+            if c_ == "" then
+               return nil, nil, "malformed pattern: missing ']'"
+            elseif c_ == "%" then
+               if strict and not pat:sub(i + 1, i + 1):match"[][^$()%%.*+%-?AaCcDdGgLlPpSsUuWwXxZz]" then
+                  return nil, nil, "malformed pattern: invalid escape"
+               end
+               i = i + 2
+            elseif c_ == "-" and strict and not isfirst then
+               return nil, nil, "malformed pattern: unexpected '-'"
+            else
+               local c2 = pat:sub(i + 1, i + 1)
+               local c3 = pat:sub(i + 2, i + 2)
+               if c2 == "-" then
+                  if strict and c3 == "]" then
+                     return nil, nil, "malformed pattern: unexpected ']'"
+                  elseif strict and c3 == "-" then
+                     return nil, nil, "malformed pattern: unexpected '-'"
+                  elseif strict and c3 == "%" then
+                     return nil, nil, "malformed pattern: unexpected '%'"
+                  end
+                  -- don't skip the last one if it is a % or ]
+                  i = i + 2
+               else
+                  i = i + 1
+               end
+            end
+            isfirst = false
+         until pat:sub(i, i) == "]"
+
+         return i, true
+      else
+         return i, true
+      end
+   end
+
+   local pattern_isop: {string:boolean} = {
+      ["?"] = true,
+      ["+"] = true,
+      ["-"] = true,
+      ["*"] = true,
+   }
+
+   local function parse_pattern_string(node: Node, pat: string, inclempty: boolean): {Type}, string
+      --[[
+         Pattern syntax:
+
+         pat <- start? mid* end?
+         start <- "^"
+         end <- "$"
+         mid <- "(" mid* ")"
+              | "[" "^"? set "]" rpt?
+              | "%" "b" . .
+              | "%" "f" "[" "^"? set "]"
+              | "%" [1-9]
+              | "%" [][^$()%.*+-?AaCcDdGgLlPpSsUuWwXxZz] rpt?
+              | [^][^$()%*+-?] rpt?
+         set <- setitem1? setitem*
+         setitem1 <- "]"
+                   | "]" "-" [^]%]
+         setitem <- "%" [][^$()%.*+-?AaCcDdGgLlPpSsUuWwXxZz]
+                  | [^]%] "-" [^]%]
+                  | [^]%-]
+         rpt <- [-*+?]
+      --]]
+      local strict = false
+
+      local results: {Type} = {}
+
+      local i = pat:sub(1, 1) == "^" and 2 or 1
+      local unclosed = 0
+
+      while i <= #pat do
+         local c = pat:sub(i, i)
+
+         if i == #pat and c == "$" then
+            break
+         end
+
+         local classend, canhavemul, err = pattern_findclassend(pat, i, strict)
+         if not classend then
+            return nil, err
+         end
+
+         local peek = pat:sub(classend + 1, classend + 1)
+
+         if c == "(" and peek == ")" then
+            -- position match
+            table.insert(results, a_type(node, "integer", {}))
+            i = i + 2
+         elseif c == "(" then
+            table.insert(results, a_type(node, "string", {}))
+            unclosed = unclosed + 1
+            i = i + 1
+         elseif c == ")" then
+            unclosed = unclosed - 1
+            i = i + 1
+         elseif strict and c:match"[]^$()*+%-?]" then -- operations that haven't been handled
+            return nil, "malformed pattern: character was unexpected: '" .. c .. "'"
+         elseif pattern_isop[peek] and canhavemul then
+            i = classend + 2
+         else
+            -- simple match
+            i = classend + 1
+         end
+      end
+
+      if inclempty and not results[1] then
+         results[1] = a_type(node, "string", {})
+      end
+      if unclosed ~= 0 then
+         return results, unclosed .. " captures not closed"
+      end
+      return results
+   end
+
    local special_functions: {string : function(TypeChecker, Node, Type, TupleType, ? integer):InvalidOrTupleType } = {
       ["pairs"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if not b.tuple[1] then
@@ -11343,6 +11495,183 @@ do
          self:apply_facts(node, node.e2[1].known)
          return r
       end,
+
+      ["string_match"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+         if #b.tuple < 2 or #b.tuple > 3 then
+            return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects 2 or 3)")
+         end
+
+         local rets: TupleType
+         local pat = b.tuple[2]
+
+         if pat is StringType and pat.literal then
+            local st = pat.literal
+            local items, e = parse_pattern_string(node, st, true)
+
+            if e then
+               if items then
+                  -- just a warning
+                  self.errs:add_warning("hint", pat, e)
+               else
+                  return self.errs:invalid_at(pat, e)
+               end
+            end
+
+            -- set the returns to match the response
+            rets = a_tuple(node, items)
+         end
+         return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
+      end,
+
+      ["string_find"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+         if #b.tuple < 2 or #b.tuple > 4 then
+            return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 2 and at most 4)")
+         end
+
+         local plainarg = node.e2[4 + (argdelta or 0)]
+         local pat = b.tuple[2]
+
+         local rets: TupleType
+
+         if pat is StringType and pat.literal
+            and ((not plainarg) or (plainarg.kind == "boolean" and plainarg.tk == "false")) then
+            -- we have a nice constant string that we can modify
+            local st = pat.literal
+
+            local items, e = parse_pattern_string(node, st, false)
+
+            if e then
+               if items then
+                  -- just a warning
+                  self.errs:add_warning("hint", pat, e)
+               else
+                  return self.errs:invalid_at(pat, e)
+               end
+            end
+
+            table.insert(items, 1, a_type(pat, "integer", {}))
+            table.insert(items, 1, a_type(pat, "integer", {}))
+
+            -- set the returns to match the response
+            rets = a_tuple(node, items)
+         end
+
+         return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
+      end,
+
+      ["string_gmatch"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+         if #b.tuple < 2 or #b.tuple > 3 then
+            return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects 2 or 3)")
+         end
+
+         local rets: TupleType
+         local pat = b.tuple[2]
+
+         if pat is StringType and pat.literal then
+            local st = pat.literal
+            local items, e = parse_pattern_string(node, st, true)
+
+            if e then
+               if items then
+                  -- just a warning
+                  self.errs:add_warning("hint", pat, e)
+               else
+                  return self.errs:invalid_at(pat, e)
+               end
+            end
+
+            -- set the returns to match the response
+            rets = a_tuple(node, {
+               a_function(node, {
+                  min_arity = 0,
+                  args = a_tuple(node, {}),
+                  rets = a_tuple(node, items),
+               })
+            })
+         end
+
+         return (self:type_check_function_call(node, a, b, argdelta, nil, rets))
+      end,
+
+      ["string_gsub"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+         -- if the second argument is a literal, we can parse it and change the matchers
+         -- gsub: function(string, string, <matcher>, ? integer): string, integer
+
+         if #b.tuple < 3 or #b.tuple > 4 then
+            return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects 3 or 4)")
+         end
+         local pat = b.tuple[2]
+         local orig_t = b.tuple[3]
+         local trepl = self:to_structural(orig_t)
+
+         local has_fourth = b.tuple[4]
+
+         local args: TupleType
+
+         if pat is StringType and pat.literal then
+            local st = pat.literal
+            local items, e = parse_pattern_string(node, st, true)
+
+            if e then
+               if items then
+                  -- just a warning
+                  self.errs:add_warning("hint", pat, e)
+               else
+                  return self.errs:invalid_at(pat, e)
+               end
+            end
+
+            local i1 = items[1]
+
+            -- we expect replarg to be one of:
+            -- string
+            -- {(items[1]):string}
+            -- function(table.unpack(items)): ((string|integer|number)...)
+
+            local replarg_type: Type
+
+            local expected_pat_return = a_union(node, {
+               a_type(node, "string", {}),
+               a_type(node, "integer", {}),
+               a_type(node, "number", {}),
+            })
+            if self:is_a(trepl, expected_pat_return) then
+               -- fine
+               replarg_type = expected_pat_return
+            elseif trepl is MapType then
+               replarg_type = a_map(node, i1, expected_pat_return)
+            elseif trepl is RecordLikeType then
+               if not (i1 is StringType) then
+                  self.errs:invalid_at(trepl, "expected a table with integers as keys")
+               end
+               replarg_type = a_map(node, i1, expected_pat_return)
+            elseif trepl is ArrayLikeType then
+               if not (i1 is IntegerType) then
+                  self.errs:invalid_at(trepl, "expected a table with strings as keys")
+               end
+               replarg_type = an_array(node, expected_pat_return)
+            elseif trepl is FunctionType then
+               local validftype = a_function(node, {
+                  min_arity = self.feat_arity and #items or 0,
+                  args = a_tuple(node, items),
+                  rets = a_vararg(node, { expected_pat_return }),
+               })
+               replarg_type = validftype
+            end
+            -- other types should be taken care of by the type_check_function_call below
+
+            if replarg_type then
+               args = a_tuple(node, {
+                  a_type(node, "string", {}),
+                  a_type(node, "string", {}),
+                  replarg_type,
+                  has_fourth and a_type(node, "integer", {}) or nil,
+               })
+            end
+         end
+
+         return (self:type_check_function_call(node, a, b, argdelta, args, nil))
+      end,
    }
 
    function TypeChecker:type_check_funcall(node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
@@ -11354,8 +11683,22 @@ do
          else
             return (self:type_check_function_call(node, a, b, argdelta))
          end
+      elseif node.e1.op and node.e1.op.op == "." and node.e1.e1.kind == "variable" and node.e1.e1.tk == "string" then
+         local special = special_functions["string_" .. node.e1.e2.tk]
+         if special then
+            return special(self, node, a, b, argdelta)
+         else
+            return (self:type_check_function_call(node, a, b, argdelta))
+         end
       elseif node.e1.op and node.e1.op.op == ":" then
          table.insert(b.tuple, 1, node.e1.receiver)
+         if b.tuple[1].typename == "string" then
+            -- test for a special function
+            local special = special_functions["string_" .. node.e1.e2.tk]
+            if special then
+               return special(self, node, a, b, -1)
+            end
+         end
          return (self:type_check_function_call(node, a, b, -1))
       else
          return (self:type_check_function_call(node, a, b, argdelta))

--- a/tl.tl
+++ b/tl.tl
@@ -316,8 +316,9 @@ do
       gmatch: function(string, string, ? integer): (function(): string...)
 
       gsub: function(string, string, string, ? integer): string, integer
-      gsub: function(string, string, {string:string}, ? integer): string, integer
-      gsub: function(string, string, function(string...): ((string | integer | number)...), ? integer): string, integer
+      gsub: function(string, string, {string:string|integer|number}, ? integer): string, integer
+      gsub: function(string, string, {integer:string|integer|number}, ? integer): string, integer
+      gsub: function(string, string, function((string|integer)...): ((string|integer|number)...), ? integer): string, integer
 
       len: function(string): integer
       lower: function(string): string

--- a/tl.tl
+++ b/tl.tl
@@ -11400,6 +11400,43 @@ do
       return results
    end
 
+   local function parse_format_string(node: Node, pat: string): {Type}, string
+      local pos = 1
+      local results: {Type} = {}
+      while pos <= #pat do
+         -- TODO: remove once bootstrap
+         local endc = pat:match("%%[-+#0-9. ]*()", pos) as integer
+         if not endc then return results end
+         local c = pat:sub(endc, endc)
+         if c == "" then
+            return nil, "missing pattern specifier at end"
+         end
+         if c:match"[AaEefGg]" then
+            table.insert(results, a_type(node, "number", {}))
+         elseif c:match"[cdiouXx]" then
+            table.insert(results, a_type(node, "integer", {}))
+         elseif c == "q" then
+            table.insert(results,
+               a_union(node, {
+                  a_type(node, "string", {}),
+                  a_type(node, "number", {}),
+                  a_type(node, "integer", {}),
+                  a_type(node, "boolean", {}),
+                  a_type(node, "nil", {}),
+               })
+            )
+         elseif c == "p" or c == "s" then
+            table.insert(results, a_type(node, "any", {}))
+         elseif c == "%" then
+            -- escaped percent sign
+         else
+            return nil, "invalid pattern specifier: '" .. c .. "'"
+         end
+         pos = endc + 1
+      end
+      return results
+   end
+
    local special_functions: {string : function(TypeChecker, Node, Type, TupleType, ? integer):InvalidOrTupleType } = {
       ["pairs"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
          if not b.tuple[1] then
@@ -11494,6 +11531,39 @@ do
          local r = self:type_check_function_call(node, a, b, argdelta)
          self:apply_facts(node, node.e2[1].known)
          return r
+      end,
+
+      ["string_format"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType
+         if #b.tuple < 1 then
+            return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects at least 1)")
+         end
+
+         local fstr = b.tuple[1]
+
+         if fstr is StringType and fstr.literal and a is FunctionType then
+            local st = fstr.literal
+            local items, e = parse_format_string(node, st)
+
+            if e then
+               if items then
+                  -- just a warning
+                  self.errs:add_warning("hint", fstr, e)
+               else
+                  return self.errs:invalid_at(fstr, e)
+               end
+            end
+
+            table.insert(items, 1, a_type(node, "string", {}))
+
+            if #items ~= #b.tuple then
+               return self.errs:invalid_at(node, "wrong number of arguments (given " .. #b.tuple .. ", expects " .. #items .. ")")
+            end
+
+            -- check the arguments now
+            return (self:type_check_function_call(node, a, b, argdelta, a_tuple(node, items), nil))
+         else
+            return (self:type_check_function_call(node, a, b, argdelta))
+         end
       end,
 
       ["string_match"] = function(self: TypeChecker, node: Node, a: Type, b: TupleType, argdelta?: integer): InvalidOrTupleType

--- a/tl.tl
+++ b/tl.tl
@@ -11450,26 +11450,27 @@ do
       while pos <= #pat do
          local c = pat:sub(pos, pos)
          local to_add: Type
+         local goto_next: boolean
          if c:match"[<> =x]" then
             -- nothing to do with argument
             if skip_next then
                return nil, "expected argument for 'X'"
             end
             pos = pos + 1
-            goto next
+            goto_next = true
          elseif c == "X" then
             if skip_next then
                return nil, "expected argument for 'X'"
             end
             skip_next = true
             pos = pos + 1
-            goto next
+            goto_next = true
          elseif c == "!" then
             if skip_next then
                return nil, "expected argument for 'X'"
             end
             pos = pack_string_skipnum(pos + 1, pat)
-            goto next
+            goto_next = true
          elseif c:match"[Ii]" then
             pos = pack_string_skipnum(pos + 1, pat)
             to_add = a_type(node, "integer", {})
@@ -11490,12 +11491,13 @@ do
          else
             return nil, "invalid format option: '" .. c .. "'"
          end
-         if skip_next then
-            skip_next = false
-         else
-            table.insert(results, to_add)
+         if not goto_next then
+            if skip_next then
+               skip_next = false
+            else
+               table.insert(results, to_add)
+            end
          end
-         ::next::
       end
       if skip_next then
          return nil, "expected argument for 'X'"


### PR DESCRIPTION
This adds some handling for literals in:
- `string.format`
	- With the parsing, I've left it at the first stage of how Lua does it without validating the modifiers. As far as I know it should accept anything that Lua accepts.
- `string.{pack, unpack}`
    - (I could probably validate the string if it is in string.packsize, but that won't affect arguments or returns)
    - I haven't allowed numeric arguments to packing in 'z', 's' or 'c', as they always get unpacked as a string
- `string.{find, match, gsub, gmatch}`
    - I think this should be fairly complete.

In order to handle it better, I've added override arguments to the functions for validation.

I've also added a (unused) strict mode to the pattern parsing that complains when the pattern appears to be relying on implementation details (like a `*` or other repetition after a capture always being literal)