### PR TITLE
Resolve string metatable with modules

### DIFF
--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -1,6 +1,12 @@
 local util = require("spec.util")
 
 describe("string", function()
+   describe("literal", function()
+      it("doesn't care about local string", util.check([[
+         local string = "text"
+         print(("%i"):format(42))
+      ]]))
+   end)
 
    describe("byte", function()
       it("can return multiple values", util.check([[

--- a/tl.lua
+++ b/tl.lua
@@ -10303,7 +10303,9 @@ a.types[i], b.types[i]), }
       end
 
       if t.typename == "string" or t.typename == "enum" then
-         t = self:find_var_type("string")
+
+         t = self.env.modules["string"]
+         self.all_needs_compat["string"] = true
       end
 
       if t.typename == "typedecl" then

--- a/tl.tl
+++ b/tl.tl
@@ -10303,7 +10303,9 @@ do
       end
 
       if t is StringType or t is EnumType then
-         t = self:find_var_type("string") -- simulate string metatable
+         -- simulate string metatable
+         t = self.env.modules["string"]
+         self.all_needs_compat["string"] = true
       end
 
       if t is TypeDeclType then


### PR DESCRIPTION
This results in it no longer caring about `local string` to resolve it.
Fixes #933 