### PR TITLE
Check for optional arguments for macroexp

### DIFF
--- a/spec/lang/code_gen/macroexp_spec.lua
+++ b/spec/lang/code_gen/macroexp_spec.lua
@@ -196,7 +196,7 @@ describe("macroexp code generation", function()
    ]]))
 
    it("works with ...", util.gen([[
-      local macroexp macroprint(a: string, ...: string): string
+      local macroexp macroprint(a: string, ...: string)
          return print(a, ...)
       end
 
@@ -207,6 +207,20 @@ describe("macroexp code generation", function()
 
 
       print('varargs', 'dis', 'appear')
+   ]]))
+
+   it("works with optional parameters", util.gen([[
+      local macroexp macroprint(a: string, b ?: string, c ?: string)
+         return print(a, b, c)
+      end
+
+      macroprint('arg1', 'arg2')
+   ]], [[
+
+
+
+
+      print('arg1', 'arg2', nil)
    ]]))
 end)
 

--- a/tl.lua
+++ b/tl.lua
@@ -9832,15 +9832,19 @@ a.types[i], b.types[i]), }
       local on_arg_id = function(node, i)
          if node.kind == '...' then
 
-            local nd = {
+            local nd = node_at(orignode, {
                kind = "expression_list",
-            }
+            })
             for n = i, #args do
                nd[n - i + 1] = args[n]
             end
             return { Node, nd }
          else
-            return { Node, args[i] }
+
+
+
+            local nd = args[i] or node_at(orignode, { kind = "nil", tk = "nil" })
+            return { Node, nd }
          end
       end
 

--- a/tl.tl
+++ b/tl.tl
@@ -9832,15 +9832,19 @@ do
       local on_arg_id = function(node: Node, i: integer): {Node, Node}
          if node.kind == '...' then
             -- we have to handle varargs specifically
-            local nd: Node = {
+            local nd: Node = node_at(orignode, {
                kind = "expression_list",
-            }
+            })
             for n = i, #args do
                nd[n - i + 1] = args[n]
             end
             return { Node, nd }
          else
-            return { Node, args[i] }
+            -- the function should have already been typechecked for optional
+            -- parameters.
+            -- this one is optional, so return nil
+            local nd: Node = args[i] or node_at(orignode, { kind = "nil", tk = "nil" })
+            return { Node, nd }
          end
       end
 


### PR DESCRIPTION
This now works properly for `macroexp`s with optional arguments where those arguments are not passed to it.