### PR TITLE
Update the typechecking for `or` expressions

### DIFF
--- a/spec/lang/inference/or_spec.lua
+++ b/spec/lang/inference/or_spec.lua
@@ -23,4 +23,14 @@ describe("inference in 'or' expressions", function()
    it("works with expected types", util.check([[
       local a: integer|string = 5 or "string"
    ]]))
+   it("works with sub and superclasses", util.check([[
+      local interface Super end
+      local interface SubA is Super end
+      local interface SubB is Super end
+
+      local sa: SubA
+      local sb: SubB
+
+      local sc: Super = sa or sb
+   ]]))
 end)

--- a/spec/lang/inference/or_spec.lua
+++ b/spec/lang/inference/or_spec.lua
@@ -20,6 +20,10 @@ describe("inference in 'or' expressions", function()
          test("", y or 0)
       end
    ]]))
+   it("doesn't immediately convert to any", util.check([[
+      local a: any = 5 or 7
+      local a_is_integer: integer = a
+   ]]))
    it("works with expected types", util.check([[
       local a: integer|string = 5 or "string"
    ]]))

--- a/spec/lang/inference/or_spec.lua
+++ b/spec/lang/inference/or_spec.lua
@@ -12,4 +12,15 @@ describe("inference in 'or' expressions", function()
          and u
          or convert(u)
    ]]))
+   it("or expressions work in function args", util.check([[
+      local function test(_s: string, _x ?: integer) end
+
+      local function do_the_test(y ?: integer)
+         test("", y)
+         test("", y or 0)
+      end
+   ]]))
+   it("works with expected types", util.check([[
+      local a: integer|string = 5 or "string"
+   ]]))
 end)

--- a/spec/lang/operator/or_spec.lua
+++ b/spec/lang/operator/or_spec.lua
@@ -166,6 +166,7 @@ describe("or", function()
       wants_b(also_still_not_b)
    ]], {
       { y = 20, x = 15, msg = "got A | B, expected B" },
+      { y = 24, x = 15, msg = "got A | B, expected B" },
       { y = 27, x = 15, msg = "got A | B, expected B" },
    }))
 

--- a/spec/lang/operator/or_spec.lua
+++ b/spec/lang/operator/or_spec.lua
@@ -157,8 +157,16 @@ describe("or", function()
       local b = ab is A and ab.b or ab -- ab.b may be nil, causing the value of type A to be returned via 'or'
 
       wants_b(b)
+
+      local real_b: B = {tag="b"}
+      local also_not_b = ab or real_b
+      wants_b(also_not_b)
+
+      local also_still_not_b = real_b or ab
+      wants_b(also_still_not_b)
    ]], {
       { y = 20, x = 15, msg = "got A | B, expected B" },
+      { y = 27, x = 15, msg = "got A | B, expected B" },
    }))
 
    it("resolves the negation of 'or' when 'if' returns", util.check([[

--- a/spec/lang/operator/or_spec.lua
+++ b/spec/lang/operator/or_spec.lua
@@ -191,6 +191,10 @@ describe("or", function()
       local _print_testcty: nil = _testc
       local _print_testdty: nil = _testd
    ]], {
+      { y = 6, msg = "the resulting type is ambiguous: A or B" },
+      { y = 6, msg = "currently choosing B" },
+      { y = 7, msg = "the resulting type is ambiguous: B or A" },
+      { y = 7, msg = "currently choosing A" },
    }, {
       { y = 8, msg = "_print_testcty: got B" },
       { y = 9, msg = "_print_testdty: got A" },

--- a/spec/lang/operator/or_spec.lua
+++ b/spec/lang/operator/or_spec.lua
@@ -180,6 +180,22 @@ describe("or", function()
       end
    ]]))
 
+   it("chooses the second type", util.check_warnings([[
+      local interface A end
+      local record B is A end
+
+      local _testa: A = {}
+      local _testb: B = {}
+      local _testc = _testa or _testb
+      local _testd = _testb or _testa
+      local _print_testcty: nil = _testc
+      local _print_testdty: nil = _testd
+   ]], {
+   }, {
+      { y = 8, msg = "_print_testcty: got B" },
+      { y = 9, msg = "_print_testdty: got A" },
+   }))
+
    it("resolves the negation of 'or' when 'if' returns, error case", util.check_type_error([[
       local function f(b: boolean, u: string | number)
          if not b or u is number then

--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -49,7 +49,7 @@ describe("string", function()
    end)
 
    describe("format", function()
-      it("doesn't break inference", util.check([[
+      it("doesn't break inference (#975)", util.check([[
          local function f_that_is_int(): integer
             return 5
          end

--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -49,6 +49,12 @@ describe("string", function()
    end)
 
    describe("format", function()
+      it("doesn't break inference", util.check([[
+         local function do_the_test(y ?: integer)
+            string.format('%d', y)
+            string.format('%d', y or 0) -- shouldn't error
+         end
+      ]]))
       it("works with various specifiers", util.check([[
          local sfmt = string.format
          local s1: string = sfmt("%02A %a  %E %e %f %G %g %% %%", 1.1, 1.2, 1.3, 1.4, 1.4, 1.4, 1.4)

--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -50,9 +50,14 @@ describe("string", function()
 
    describe("format", function()
       it("doesn't break inference", util.check([[
+         local function f_that_is_int(): integer
+            return 5
+         end
+
          local function do_the_test(y ?: integer)
             string.format('%d', y)
             string.format('%d', y or 0) -- shouldn't error
+            string.format('%d', f_that_is_int())
          end
       ]]))
       it("works with various specifiers", util.check([[

--- a/tl.lua
+++ b/tl.lua
@@ -13755,6 +13755,15 @@ self:expand_type(node, values, elements) })
                   end
                   t = u
 
+
+               elseif ra.typename == "union" and not (rb.typename == "union") and self:is_a(rb, ra) then
+
+                  t = drop_constant_value(ra)
+
+               elseif rb.typename == "union" and not (ra.typename == "union") and self:is_a(ra, rb) then
+
+                  t = drop_constant_value(rb)
+
                else
                   local a_ge_b = self:is_a(rb, ra)
                   local b_ge_a = self:is_a(ra, rb)

--- a/tl.lua
+++ b/tl.lua
@@ -13771,16 +13771,25 @@ self:expand_type(node, values, elements) })
                   local is_same = self:same_type(ra, rb)
 
 
+                  local ambiguous = a_ge_b and b_ge_a and not is_same
+
+
 
                   if is_same then
                      t = ua
-                  elseif (a_ge_b or b_ge_a) then
+                  elseif (a_ge_b or b_ge_a) and not ambiguous then
                      local larger_type = b_ge_a and ub or ua
                      t = larger_type
                   elseif expected and self:is_a(ua, expected) and self:is_a(ub, expected) then
                      t = self:infer_at(node, expected)
                   end
 
+                  if ambiguous and not t then
+                     self.errs:add_warning("hint", node, "the resulting type is ambiguous: %s or %s", ua, ub)
+                     self.errs:add_warning("hint", node, "currently choosing %s", ub)
+
+                     t = ub
+                  end
                   if t then
                      t = drop_constant_value(t)
                   end

--- a/tl.lua
+++ b/tl.lua
@@ -13770,20 +13770,18 @@ self:expand_type(node, values, elements) })
                   node.known = facts_or(node, node.e1.known, node.e2.known)
                   local is_same = self:same_type(ra, rb)
 
+
+
                   if is_same then
                      t = ua
-                  elseif a_ge_b or b_ge_a then
-                     if expected then
-                        local a_is = self:is_a(ua, expected)
-                        local b_is = self:is_a(ub, expected)
-                        if a_is and b_is then
-                           t = self:infer_at(node, expected)
-                        end
-                     end
-                     if not t then
-                        local larger_type = b_ge_a and ub or ua
-                        t = larger_type
-                     end
+                  elseif (a_ge_b or b_ge_a) then
+                     local larger_type = b_ge_a and ub or ua
+                     t = larger_type
+                  elseif expected and self:is_a(ua, expected) and self:is_a(ub, expected) then
+                     t = self:infer_at(node, expected)
+                  end
+
+                  if t then
                      t = drop_constant_value(t)
                   end
 

--- a/tl.lua
+++ b/tl.lua
@@ -13759,7 +13759,11 @@ self:expand_type(node, values, elements) })
                   local a_ge_b = self:is_a(rb, ra)
                   local b_ge_a = self:is_a(ra, rb)
                   node.known = facts_or(node, node.e1.known, node.e2.known)
-                  if a_ge_b or b_ge_a then
+                  local is_same = self:same_type(ra, rb)
+
+                  if is_same then
+                     t = ua
+                  elseif a_ge_b or b_ge_a then
                      if expected then
                         local a_is = self:is_a(ua, expected)
                         local b_is = self:is_a(ub, expected)

--- a/tl.tl
+++ b/tl.tl
@@ -11111,7 +11111,7 @@ do
          end
 
          t2 = self:resolve_if_union(t2)
-         local t2types = t2 is UnionType and t2.types or { t2 }
+         local t2types: {Type} = t2 is UnionType and t2.types or { t2 }
 
          for _, at in ipairs(t1.types) do
             local not_present = true
@@ -12047,7 +12047,7 @@ do
    end
 
    local function set_expected_types_to_decltuple(self: TypeChecker, node: Node, children: {Type})
-      local decltuple = node.kind == "assignment" and children[1] or node.decltuple
+      local decltuple: Type = node.kind == "assignment" and children[1] or node.decltuple
       assert(decltuple is TupleType)
       local decls = decltuple.tuple
       if decls and node.exps then
@@ -13144,7 +13144,7 @@ do
                end
             end
 
-            local t = force_array and an_array(node, force_array) or node.expected
+            local t: Type = force_array and an_array(node, force_array) or node.expected
             t = self:infer_at(node, t)
 
             if decltype is RecordType then

--- a/tl.tl
+++ b/tl.tl
@@ -13770,20 +13770,18 @@ do
                   node.known = facts_or(node, node.e1.known, node.e2.known)
                   local is_same = self:same_type(ra, rb)
 
+                  -- prefer a type that we can easily work out rather than defaulting to the expected one
+                  -- (the expected one might need to be collapsed later with special functions)
                   if is_same then
                      t = ua
-                  elseif a_ge_b or b_ge_a then
-                     if expected then
-                        local a_is = self:is_a(ua, expected)
-                        local b_is = self:is_a(ub, expected)
-                        if a_is and b_is then
-                           t = self:infer_at(node, expected)
-                        end
-                     end
-                     if not t then
-                        local larger_type = b_ge_a and ub or ua
-                        t = larger_type
-                     end
+                  elseif (a_ge_b or b_ge_a) then
+                     local larger_type = b_ge_a and ub or ua
+                     t = larger_type
+                  elseif expected and self:is_a(ua, expected) and self:is_a(ub, expected) then
+                     t = self:infer_at(node, expected)
+                  end
+
+                  if t then
                      t = drop_constant_value(t)
                   end
 

--- a/tl.tl
+++ b/tl.tl
@@ -13770,17 +13770,26 @@ do
                   node.known = facts_or(node, node.e1.known, node.e2.known)
                   local is_same = self:same_type(ra, rb)
 
+                  -- we can have some types that can be converted into either
+                  local ambiguous = a_ge_b and b_ge_a and not is_same
+
                   -- prefer a type that we can easily work out rather than defaulting to the expected one
                   -- (the expected one might need to be collapsed later with special functions)
                   if is_same then
                      t = ua
-                  elseif (a_ge_b or b_ge_a) then
+                  elseif (a_ge_b or b_ge_a) and not ambiguous then
                      local larger_type = b_ge_a and ub or ua
                      t = larger_type
                   elseif expected and self:is_a(ua, expected) and self:is_a(ub, expected) then
                      t = self:infer_at(node, expected)
                   end
 
+                  if ambiguous and not t then
+                     self.errs:add_warning("hint", node, "the resulting type is ambiguous: %s or %s", ua, ub)
+                     self.errs:add_warning("hint", node, "currently choosing %s", ub)
+                     -- workaround to keep existing code working
+                     t = ub
+                  end
                   if t then
                      t = drop_constant_value(t)
                   end

--- a/tl.tl
+++ b/tl.tl
@@ -13755,6 +13755,15 @@ do
                   end
                   t = u
 
+               -- prefer the union type if it already works and the other one isn't a union
+               elseif ra is UnionType and not (rb is UnionType) and self:is_a(rb, ra) then
+                  -- convert it to the union type
+                  t = drop_constant_value(ra)
+
+               elseif rb is UnionType and not (ra is UnionType) and self:is_a(ra, rb) then
+                  -- convert it to the union type
+                  t = drop_constant_value(rb)
+
                else
                   local a_ge_b = self:is_a(rb, ra)
                   local b_ge_a = self:is_a(ra, rb)

--- a/tl.tl
+++ b/tl.tl
@@ -13759,7 +13759,11 @@ do
                   local a_ge_b = self:is_a(rb, ra)
                   local b_ge_a = self:is_a(ra, rb)
                   node.known = facts_or(node, node.e1.known, node.e2.known)
-                  if a_ge_b or b_ge_a then
+                  local is_same = self:same_type(ra, rb)
+
+                  if is_same then
+                     t = ua
+                  elseif a_ge_b or b_ge_a then
                      if expected then
                         local a_is = self:is_a(ua, expected)
                         local b_is = self:is_a(ub, expected)


### PR DESCRIPTION
Changes:
- If the types of an `or` statement are equal, then it evaluates to that type.
- If one of the types is a union and the other isn't (and it is convertible into it), then the resulting type is that union.
- If the types are each able to be converted into the other but they aren't equal, then it adds a warning and just uses the second type (this was previously accepted and always gave the second type).
- If the types aren't convertible into each other, it now accepts it if there is an expected type that they can be converted into (see the superclass test, which didn't pass before)

This should fix #975 .