### PR TITLE
fix: do not match interfaces to records structurally

### DIFF
--- a/spec/lang/subtyping/interface_spec.lua
+++ b/spec/lang/subtyping/interface_spec.lua
@@ -218,4 +218,24 @@ describe("subtyping of interfaces:", function()
    ]], {
       { y = 12, msg = "'move' does not match definition in interface Animal" }
    }))
+
+   it("interface :> record but not the other way around", util.check_type_error([[
+      local interface I
+      end
+
+      local record R is I
+      end
+
+      local r: R
+      local i: I
+
+      local wants_i1: I = i or r
+      local wants_i2: I = r or i
+
+      local wants_r1: R = i or r
+      local wants_r2: R = r or i
+   ]], {
+      { y = 13, msg = "I is not a R" },
+      { y = 14, msg = "I is not a R" },
+   }))
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -9467,7 +9467,6 @@ do
             return self:same_type(a, b)
          end,
          ["array"] = TypeChecker.subtype_array,
-         ["record"] = TypeChecker.subtype_record,
          ["tupletable"] = function(self, a, b)
             return self.subtype_relations["record"]["tupletable"](self, a, b)
          end,

--- a/tl.tl
+++ b/tl.tl
@@ -2580,7 +2580,7 @@ local function failskip(ps: ParseState, i: integer, msg: string, skip_fn: SkipFu
    return skip_i
 end
 
-local function parse_type_body(ps: ParseState, i: integer, istart: integer, node: Node, tn: BodyTypeName): integer, GenericType | StructuralType
+local function parse_type_body(ps: ParseState, i: integer, istart: integer, node: Node, tn: BodyTypeName): integer, GenericType | FirstOrderType
    local typeargs: {TypeArgType}
    local def: FirstOrderType
    i, typeargs = parse_typeargs_if_any(ps, i)
@@ -3973,7 +3973,7 @@ parse_interface_name = function(ps: ParseState, i: integer): integer, FirstOrder
    return i, typ
 end
 
-local function parse_array_interface_type(ps: ParseState, i: integer, def: RecordLikeType): integer, Type
+local function parse_array_interface_type(ps: ParseState, i: integer, def: RecordLikeType): integer, ArrayType
    if def.interface_list then
       local first = def.interface_list[1]
       if first is ArrayType then
@@ -9467,7 +9467,6 @@ do
             return self:same_type(a, b)
          end,
          ["array"] = TypeChecker.subtype_array,
-         ["record"] = TypeChecker.subtype_record,
          ["tupletable"] = function(self: TypeChecker, a: Type, b: Type): boolean, {Error}
             return self.subtype_relations["record"]["tupletable"](self, a, b)
          end,


### PR DESCRIPTION
This rule was causing a situation where we could get a declarations `interface I` and `record R is I` resulting in `I :> R` and `R :> I` at the same time, depending on their contents. This produces ambiguities down the line: See https://github.com/teal-language/tl/pull/979/commits/a61a3c6234d1a0f8df742d88da2e14ce24ecfd22#r2091225922

I'm not sure why that rule ended up there in the first place.

The fact that removing that rule caught real type declaration bugs in the compiler is a good sign.

Perhaps I was assuming that checks between those types would happen earlier on at the nominal stage, or I added that line in a transitional stage in the introduction of interfaces.

I'm happy that the declarative style of the `subtype_relations` table made it easy to spot what was going on, though!