### PR TITLE
update typechecking for `or` expressions, take 2

### DIFF
--- a/spec/lang/inference/or_spec.lua
+++ b/spec/lang/inference/or_spec.lua
@@ -56,4 +56,20 @@ describe("inference in 'or' expressions", function()
    ]], {
       { msg = "unused function f" }
    }, {}))
+
+   it("infers `A|B or B` to `A|B`, avoiding ambiguity", util.check_warnings([[
+      local record A where self.field == "a"
+         field: string
+      end
+      local record B where self.field == "b"
+         field: string
+      end
+
+      local ab: A|B
+      local b: B
+
+      local c = ab or b
+   ]], {
+      { msg = "unused variable c: A | B" }
+   }, {}))
 end)

--- a/spec/lang/inference/or_spec.lua
+++ b/spec/lang/inference/or_spec.lua
@@ -27,4 +27,14 @@ describe("inference in 'or' expressions", function()
    it("works with expected types", util.check([[
       local a: integer|string = 5 or "string"
    ]]))
+   it("works with sub and superclasses", util.check([[
+      local interface Super end
+      local interface SubA is Super end
+      local interface SubB is Super end
+
+      local sa: SubA
+      local sb: SubB
+
+      local sc: Super = sa or sb
+   ]]))
 end)

--- a/spec/lang/inference/or_spec.lua
+++ b/spec/lang/inference/or_spec.lua
@@ -37,4 +37,23 @@ describe("inference in 'or' expressions", function()
 
       local sc: Super = sa or sb
    ]]))
+   it("does not drop nominal type on assignment, avoiding ambiguity", util.check_warnings([[
+      local interface Type
+      end
+
+      local record UnionType is Type
+         types: {Type}
+      end
+
+      local function g(t: Type): Type
+         return t
+      end
+
+      local function f(t: Type)
+         t = g(t)
+         local _ = t is UnionType and t.types or { t }
+      end
+   ]], {
+      { msg = "unused function f" }
+   }, {}))
 end)

--- a/spec/lang/inference/or_spec.lua
+++ b/spec/lang/inference/or_spec.lua
@@ -20,6 +20,10 @@ describe("inference in 'or' expressions", function()
          test("", y or 0)
       end
    ]]))
+   it("doesn't immediately convert to any", util.check([[
+      local a: any = 5 or 7
+      local a_is_integer: integer = a
+   ]]))
    it("works with expected types", util.check([[
       local a: integer|string = 5 or "string"
    ]]))

--- a/spec/lang/inference/or_spec.lua
+++ b/spec/lang/inference/or_spec.lua
@@ -12,4 +12,15 @@ describe("inference in 'or' expressions", function()
          and u
          or convert(u)
    ]]))
+   it("or expressions work in function args", util.check([[
+      local function test(_s: string, _x ?: integer) end
+
+      local function do_the_test(y ?: integer)
+         test("", y)
+         test("", y or 0)
+      end
+   ]]))
+   it("works with expected types", util.check([[
+      local a: integer|string = 5 or "string"
+   ]]))
 end)

--- a/spec/lang/operator/or_spec.lua
+++ b/spec/lang/operator/or_spec.lua
@@ -166,6 +166,7 @@ describe("or", function()
       wants_b(also_still_not_b)
    ]], {
       { y = 20, x = 15, msg = "got A | B, expected B" },
+      { y = 24, x = 15, msg = "got A | B, expected B" },
       { y = 27, x = 15, msg = "got A | B, expected B" },
    }))
 

--- a/spec/lang/operator/or_spec.lua
+++ b/spec/lang/operator/or_spec.lua
@@ -157,8 +157,16 @@ describe("or", function()
       local b = ab is A and ab.b or ab -- ab.b may be nil, causing the value of type A to be returned via 'or'
 
       wants_b(b)
+
+      local real_b: B = {tag="b"}
+      local also_not_b = ab or real_b
+      wants_b(also_not_b)
+
+      local also_still_not_b = real_b or ab
+      wants_b(also_still_not_b)
    ]], {
       { y = 20, x = 15, msg = "got A | B, expected B" },
+      { y = 27, x = 15, msg = "got A | B, expected B" },
    }))
 
    it("resolves the negation of 'or' when 'if' returns", util.check([[

--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -49,7 +49,7 @@ describe("string", function()
    end)
 
    describe("format", function()
-      it("doesn't break inference", util.check([[
+      it("doesn't break inference (#975)", util.check([[
          local function do_the_test(y ?: integer)
             string.format('%d', y)
             string.format('%d', y or 0) -- shouldn't error

--- a/spec/lang/stdlib/string_spec.lua
+++ b/spec/lang/stdlib/string_spec.lua
@@ -49,6 +49,12 @@ describe("string", function()
    end)
 
    describe("format", function()
+      it("doesn't break inference", util.check([[
+         local function do_the_test(y ?: integer)
+            string.format('%d', y)
+            string.format('%d', y or 0) -- shouldn't error
+         end
+      ]]))
       it("works with various specifiers", util.check([[
          local sfmt = string.format
          local s1: string = sfmt("%02A %a  %E %e %f %G %g %% %%", 1.1, 1.2, 1.3, 1.4, 1.4, 1.4, 1.4)

--- a/spec/lang/subtyping/interface_spec.lua
+++ b/spec/lang/subtyping/interface_spec.lua
@@ -218,4 +218,24 @@ describe("subtyping of interfaces:", function()
    ]], {
       { y = 12, msg = "'move' does not match definition in interface Animal" }
    }))
+
+   it("interface :> record but not the other way around", util.check_type_error([[
+      local interface I
+      end
+
+      local record R is I
+      end
+
+      local r: R
+      local i: I
+
+      local wants_i1: I = i or r
+      local wants_i2: I = r or i
+
+      local wants_r1: R = i or r
+      local wants_r2: R = r or i
+   ]], {
+      { y = 13, msg = "I is not a R" },
+      { y = 14, msg = "I is not a R" },
+   }))
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -9467,7 +9467,6 @@ do
             return self:same_type(a, b)
          end,
          ["array"] = TypeChecker.subtype_array,
-         ["record"] = TypeChecker.subtype_record,
          ["tupletable"] = function(self, a, b)
             return self.subtype_relations["record"]["tupletable"](self, a, b)
          end,

--- a/tl.lua
+++ b/tl.lua
@@ -13762,20 +13762,18 @@ self:expand_type(node, values, elements) })
                   node.known = facts_or(node, node.e1.known, node.e2.known)
                   local is_same = self:same_type(ra, rb)
 
+
+
                   if is_same then
                      t = ua
-                  elseif a_ge_b or b_ge_a then
-                     if expected then
-                        local a_is = self:is_a(ua, expected)
-                        local b_is = self:is_a(ub, expected)
-                        if a_is and b_is then
-                           t = self:infer_at(node, expected)
-                        end
-                     end
-                     if not t then
-                        local larger_type = b_ge_a and ub or ua
-                        t = larger_type
-                     end
+                  elseif (a_ge_b or b_ge_a) then
+                     local larger_type = b_ge_a and ub or ua
+                     t = larger_type
+                  elseif expected and self:is_a(ua, expected) and self:is_a(ub, expected) then
+                     t = self:infer_at(node, expected)
+                  end
+
+                  if t then
                      t = drop_constant_value(t)
                   end
 

--- a/tl.lua
+++ b/tl.lua
@@ -13763,16 +13763,25 @@ self:expand_type(node, values, elements) })
                   local is_same = self:same_type(ra, rb)
 
 
+                  local ambiguous = a_ge_b and b_ge_a and not is_same
+
+
 
                   if is_same then
                      t = ua
-                  elseif (a_ge_b or b_ge_a) then
+                  elseif (a_ge_b or b_ge_a) and not ambiguous then
                      local larger_type = b_ge_a and ub or ua
                      t = larger_type
                   elseif expected and self:is_a(ua, expected) and self:is_a(ub, expected) then
                      t = self:infer_at(node, expected)
                   end
 
+                  if ambiguous and not t then
+                     self.errs:add_warning("hint", node, "the resulting type is ambiguous: %s or %s", ua, ub)
+                     self.errs:add_warning("hint", node, "currently choosing %s", ub)
+
+                     t = ub
+                  end
                   if t then
                      t = drop_constant_value(t)
                   end

--- a/tl.lua
+++ b/tl.lua
@@ -12688,7 +12688,7 @@ self:expand_type(node, values, elements) })
 
                   if varname and (rvar.typename == "union" or rvar.typename == "interface") then
 
-                     self:add_var(varnode, varname, rval, nil, "narrow")
+                     self:add_var(varnode, varname, valtype, nil, "narrow")
                   end
 
                   if self.collector then
@@ -13757,8 +13757,8 @@ self:expand_type(node, values, elements) })
                   t = u
 
                else
-                  local a_ge_b = self:is_a(rb, ra)
-                  local b_ge_a = self:is_a(ra, rb)
+                  local a_ge_b = self:is_a(ub, ua)
+                  local b_ge_a = self:is_a(ua, ub)
                   node.known = facts_or(node, node.e1.known, node.e2.known)
                   local is_same = self:same_type(ra, rb)
 

--- a/tl.lua
+++ b/tl.lua
@@ -13756,6 +13756,15 @@ self:expand_type(node, values, elements) })
                   end
                   t = u
 
+
+               elseif ra.typename == "union" and not (rb.typename == "union") and self:is_a(rb, ra) then
+
+                  t = drop_constant_value(ra)
+
+               elseif rb.typename == "union" and not (ra.typename == "union") and self:is_a(ra, rb) then
+
+                  t = drop_constant_value(rb)
+
                else
                   local a_ge_b = self:is_a(ub, ua)
                   local b_ge_a = self:is_a(ua, ub)

--- a/tl.lua
+++ b/tl.lua
@@ -13760,7 +13760,11 @@ self:expand_type(node, values, elements) })
                   local a_ge_b = self:is_a(rb, ra)
                   local b_ge_a = self:is_a(ra, rb)
                   node.known = facts_or(node, node.e1.known, node.e2.known)
-                  if a_ge_b or b_ge_a then
+                  local is_same = self:same_type(ra, rb)
+
+                  if is_same then
+                     t = ua
+                  elseif a_ge_b or b_ge_a then
                      if expected then
                         local a_is = self:is_a(ua, expected)
                         local b_is = self:is_a(ub, expected)

--- a/tl.tl
+++ b/tl.tl
@@ -2580,7 +2580,7 @@ local function failskip(ps: ParseState, i: integer, msg: string, skip_fn: SkipFu
    return skip_i
 end
 
-local function parse_type_body(ps: ParseState, i: integer, istart: integer, node: Node, tn: BodyTypeName): integer, GenericType | StructuralType
+local function parse_type_body(ps: ParseState, i: integer, istart: integer, node: Node, tn: BodyTypeName): integer, GenericType | FirstOrderType
    local typeargs: {TypeArgType}
    local def: FirstOrderType
    i, typeargs = parse_typeargs_if_any(ps, i)
@@ -3973,7 +3973,7 @@ parse_interface_name = function(ps: ParseState, i: integer): integer, FirstOrder
    return i, typ
 end
 
-local function parse_array_interface_type(ps: ParseState, i: integer, def: RecordLikeType): integer, Type
+local function parse_array_interface_type(ps: ParseState, i: integer, def: RecordLikeType): integer, ArrayType
    if def.interface_list then
       local first = def.interface_list[1]
       if first is ArrayType then
@@ -9467,7 +9467,6 @@ do
             return self:same_type(a, b)
          end,
          ["array"] = TypeChecker.subtype_array,
-         ["record"] = TypeChecker.subtype_record,
          ["tupletable"] = function(self: TypeChecker, a: Type, b: Type): boolean, {Error}
             return self.subtype_relations["record"]["tupletable"](self, a, b)
          end,

--- a/tl.tl
+++ b/tl.tl
@@ -12688,7 +12688,7 @@ do
 
                   if varname and (rvar is UnionType or rvar is InterfaceType) then
                      -- narrow unions and interfaces
-                     self:add_var(varnode, varname, rval, nil, "narrow")
+                     self:add_var(varnode, varname, valtype, nil, "narrow")
                   end
 
                   if self.collector then
@@ -13757,8 +13757,8 @@ do
                   t = u
 
                else
-                  local a_ge_b = self:is_a(rb, ra)
-                  local b_ge_a = self:is_a(ra, rb)
+                  local a_ge_b = self:is_a(ub, ua)
+                  local b_ge_a = self:is_a(ua, ub)
                   node.known = facts_or(node, node.e1.known, node.e2.known)
                   local is_same = self:same_type(ra, rb)
 

--- a/tl.tl
+++ b/tl.tl
@@ -13762,17 +13762,26 @@ do
                   node.known = facts_or(node, node.e1.known, node.e2.known)
                   local is_same = self:same_type(ra, rb)
 
+                  -- we can have some types that can be converted into either
+                  local ambiguous = a_ge_b and b_ge_a and not is_same
+
                   -- prefer a type that we can easily work out rather than defaulting to the expected one
                   -- (the expected one might need to be collapsed later with special functions)
                   if is_same then
                      t = ua
-                  elseif (a_ge_b or b_ge_a) then
+                  elseif (a_ge_b or b_ge_a) and not ambiguous then
                      local larger_type = b_ge_a and ub or ua
                      t = larger_type
                   elseif expected and self:is_a(ua, expected) and self:is_a(ub, expected) then
                      t = self:infer_at(node, expected)
                   end
 
+                  if ambiguous and not t then
+                     self.errs:add_warning("hint", node, "the resulting type is ambiguous: %s or %s", ua, ub)
+                     self.errs:add_warning("hint", node, "currently choosing %s", ub)
+                     -- workaround to keep existing code working
+                     t = ub
+                  end
                   if t then
                      t = drop_constant_value(t)
                   end

--- a/tl.tl
+++ b/tl.tl
@@ -13760,7 +13760,11 @@ do
                   local a_ge_b = self:is_a(rb, ra)
                   local b_ge_a = self:is_a(ra, rb)
                   node.known = facts_or(node, node.e1.known, node.e2.known)
-                  if a_ge_b or b_ge_a then
+                  local is_same = self:same_type(ra, rb)
+
+                  if is_same then
+                     t = ua
+                  elseif a_ge_b or b_ge_a then
                      if expected then
                         local a_is = self:is_a(ua, expected)
                         local b_is = self:is_a(ub, expected)

--- a/tl.tl
+++ b/tl.tl
@@ -13762,20 +13762,18 @@ do
                   node.known = facts_or(node, node.e1.known, node.e2.known)
                   local is_same = self:same_type(ra, rb)
 
+                  -- prefer a type that we can easily work out rather than defaulting to the expected one
+                  -- (the expected one might need to be collapsed later with special functions)
                   if is_same then
                      t = ua
-                  elseif a_ge_b or b_ge_a then
-                     if expected then
-                        local a_is = self:is_a(ua, expected)
-                        local b_is = self:is_a(ub, expected)
-                        if a_is and b_is then
-                           t = self:infer_at(node, expected)
-                        end
-                     end
-                     if not t then
-                        local larger_type = b_ge_a and ub or ua
-                        t = larger_type
-                     end
+                  elseif (a_ge_b or b_ge_a) then
+                     local larger_type = b_ge_a and ub or ua
+                     t = larger_type
+                  elseif expected and self:is_a(ua, expected) and self:is_a(ub, expected) then
+                     t = self:infer_at(node, expected)
+                  end
+
+                  if t then
                      t = drop_constant_value(t)
                   end
 

--- a/tl.tl
+++ b/tl.tl
@@ -13756,6 +13756,15 @@ do
                   end
                   t = u
 
+               -- prefer the union type if it already works and the other one isn't a union
+               elseif ra is UnionType and not (rb is UnionType) and self:is_a(rb, ra) then
+                  -- convert it to the union type
+                  t = drop_constant_value(ra)
+
+               elseif rb is UnionType and not (ra is UnionType) and self:is_a(ra, rb) then
+                  -- convert it to the union type
+                  t = drop_constant_value(rb)
+
                else
                   local a_ge_b = self:is_a(ub, ua)
                   local b_ge_a = self:is_a(ua, ub)


### PR DESCRIPTION
Combines #979 and #980, adding a fix to avoid dropping nominal types into their structures too early during inference.