### PR TITLE
Early-out within TypeChecker:find_type to avoid invalid call to unwrap_for_find_type

### DIFF
--- a/spec/lang/subtyping/interface_spec.lua
+++ b/spec/lang/subtyping/interface_spec.lua
@@ -218,4 +218,13 @@ describe("subtyping of interfaces:", function()
    ]], {
       { y = 12, msg = "'move' does not match definition in interface Animal" }
    }))
+
+   it("early-outs on nonexistent nested interface types (regression test for #986)", util.check_type_error([[
+      local interface Example
+      end
+
+      local fails: Example.A.B = {}
+   ]], {
+      { y = 4, msg = "unknown type Example.A.B" }
+   }))
 end)

--- a/spec/lang/subtyping/record_spec.lua
+++ b/spec/lang/subtyping/record_spec.lua
@@ -88,5 +88,13 @@ describe("records", function()
       end
    ]]))
 
+   it("early-outs on nonexistent nested record types (regression test for #986)", util.check_type_error([[
+      local record Example
+      end
+
+      local fails: Example.A.B = {}
+   ]], {
+      { y = 4, msg = "unknown type Example.A.B" }
+   }))
 end)
 

--- a/tl.lua
+++ b/tl.lua
@@ -7739,6 +7739,9 @@ do
          end
 
          typ = fields[names[i]]
+         if typ == nil then
+            return nil
+         end
       end
 
 

--- a/tl.tl
+++ b/tl.tl
@@ -7739,6 +7739,9 @@ do
          end
 
          typ = fields[names[i]]
+         if typ == nil then
+            return nil
+         end
       end
 
       -- FIXME doing this at the and lets all nominals be used as types (see #891)


### PR DESCRIPTION
With some limited testing, it seems that this extra nil check is enough to fix #986.