### PR TITLE
Check for missing fields when subtyping records

### DIFF
--- a/spec/lang/subtyping/record_spec.lua
+++ b/spec/lang/subtyping/record_spec.lua
@@ -26,6 +26,20 @@ describe("records", function()
       { y = 17, msg = "in record field: m: got integer, expected string" },
    }))
 
+   it("reports an error on extra fields", util.check_type_error([[
+      local record A
+         a: string
+      end
+
+      local test_a = { a = "test", bad = "this" }
+      local test_b = { a = "test" }
+
+      local test_it: A = test_a
+      local test_it_2: A = test_b
+   ]], {
+      { y = 8, msg = ") is not a record A: record field doesn't exist: bad" },
+   }))
+
    it("refines self on fields inherited from interfaces (regression test for #877)", util.check([[
       -- Define an interface that uses self.
       -- Using self should automatically refine implementations to map self to the impl.

--- a/tl.lua
+++ b/tl.lua
@@ -729,6 +729,7 @@ local tl = { GenerateOptions = {}, CheckOptions = {}, Env = {}, Result = {}, Err
 
 
 
+
 local TypeReporter = {}
 
 
@@ -1132,6 +1133,7 @@ do
          tokens[nt] = {
             x = tx,
             y = ty,
+            i = ti,
             tk = tk,
             kind = kind,
          }
@@ -1144,6 +1146,7 @@ do
          tokens[nt] = {
             x = tx,
             y = ty,
+            i = ti,
             tk = tk,
             kind = keywords[tk] and "keyword" or "identifier",
          }
@@ -1156,6 +1159,7 @@ do
          tokens[nt] = {
             x = tx,
             y = ty,
+            i = ti,
             tk = tk,
             kind = kind,
          }
@@ -1168,6 +1172,7 @@ do
          tokens[nt] = {
             x = tx,
             y = ty,
+            i = ti,
             tk = tk,
             kind = kind,
          }
@@ -3627,7 +3632,7 @@ do
       local selfx, selfy = ps.tokens[i].x, ps.tokens[i].y
       i = parse_function_args_rets_body(ps, i, fn)
       if fn.is_method and fn.args then
-         table.insert(fn.args, 1, { f = ps.filename, x = selfx, y = selfy, tk = "self", kind = "identifier", is_self = true })
+         table.insert(fn.args, 1, { f = ps.filename, x = selfx, y = selfy, tk = "self", kind = "identifier" })
          fn.min_arity = fn.min_arity + 1
       end
 
@@ -9044,6 +9049,8 @@ do
             if not ok then
                self.errs:add_prefixing(nil, fielderrs, "record field doesn't match: " .. k .. ": ", errs)
             end
+         elseif (not bk) and b.typename == "record" then
+            table.insert(errs, Err("record field doesn't exist: " .. k))
          end
       end
       if #errs > 0 then
@@ -14846,7 +14853,6 @@ function tl.check_string(input, env, filename, parse_lang)
 
    if (not env.keep_going) and #syntax_errors > 0 then
       local result = {
-         ok = false,
          filename = filename,
          type = a_type({ f = filename, y = 1, x = 1 }, "boolean", {}),
          type_errors = {},

--- a/tl.tl
+++ b/tl.tl
@@ -670,6 +670,7 @@ local record tl
    record Token
       x: integer
       y: integer
+      i: integer
       tk: string
       kind: TokenKind
    end
@@ -1132,6 +1133,7 @@ do
          tokens[nt] = {
             x = tx,
             y = ty,
+            i = ti,
             tk = tk,
             kind = kind,
          }
@@ -1144,8 +1146,9 @@ do
          tokens[nt] = {
             x = tx,
             y = ty,
+            i = ti,
             tk = tk,
-            kind = keywords[tk] and "keyword" or "identifier"
+            kind = keywords[tk] and "keyword" or "identifier",
          }
          in_token = false
       end
@@ -1156,8 +1159,9 @@ do
          tokens[nt] = {
             x = tx,
             y = ty,
+            i = ti,
             tk = tk,
-            kind = kind
+            kind = kind,
          }
          in_token = false
       end
@@ -1168,8 +1172,9 @@ do
          tokens[nt] = {
             x = tx,
             y = ty,
+            i = ti,
             tk = tk,
-            kind = kind
+            kind = kind,
          }
          in_token = false
       end
@@ -3627,7 +3632,7 @@ local function parse_function(ps: ParseState, i: integer, fk: FunctionKind): int
    local selfx, selfy = ps.tokens[i].x, ps.tokens[i].y
    i = parse_function_args_rets_body(ps, i, fn)
    if fn.is_method and fn.args then
-      table.insert(fn.args, 1, { f = ps.filename, x = selfx, y = selfy, tk = "self", kind = "identifier", is_self = true })
+      table.insert(fn.args, 1, { f = ps.filename, x = selfx, y = selfy, tk = "self", kind = "identifier" })
       fn.min_arity = fn.min_arity + 1
    end
 
@@ -9022,7 +9027,7 @@ do
       return false
    end
 
-   function TypeChecker:subtype_record(a: RecordLikeType, b: RecordLikeType): boolean, {Error}
+   function TypeChecker:subtype_record(a: RecordType, b: RecordLikeType): boolean, {Error}
       -- assert(b.typename == "record")
       if a.elements and b.elements then
          if not self:is_a(a.elements, b.elements) then
@@ -9044,6 +9049,8 @@ do
             if not ok then
                self.errs:add_prefixing(nil, fielderrs, "record field doesn't match: " .. k .. ": ", errs)
             end
+         elseif (not bk) and b is RecordType then
+            table.insert(errs, Err("record field doesn't exist: " .. k))
          end
       end
       if #errs > 0 then
@@ -9200,7 +9207,7 @@ do
       assert(et is EmptyTableType, u.typename)
       local keys = et.keys
       if not (values is EmptyTableType or values is UnresolvedEmptyTableValueType) then
-         local infer_to = keys is NumericType -- ideally integer only
+         local infer_to: ArrayType | MapType = keys is NumericType -- ideally integer only
                           and an_array(w, values)
                           or  a_map(w, keys, values)
          self:infer_emptytable(et, self:infer_at(w, infer_to))
@@ -14846,7 +14853,6 @@ function tl.check_string(input: string, env?: Env, filename?: string, parse_lang
 
    if (not env.keep_going) and #syntax_errors > 0 then
       local result = {
-         ok = false,
          filename = filename,
          type = a_type({ f = filename, y = 1, x = 1 }, "boolean", {}),
          type_errors = {},


### PR DESCRIPTION
This does also break a fair bit of stuff (interestingly no tests)

The compiler was only filling out the `i` field on tokens on the `$EOF$` token. Let me know if you want it to not fill it out at all or whether you are happy with exposing that field everywhere.