### PR TITLE
check for indices with longstrings better

### DIFF
--- a/spec/lang/lexer/long_string_spec.lua
+++ b/spec/lang/lexer/long_string_spec.lua
@@ -103,11 +103,15 @@ describe("long string", function()
       local result = tl.process_string([==[
          local t: {string: boolean} = {}
          t[ [["random_string"]] ] = true
+         t[ [["random_string"]] .. 'test' ] = true
+         t[ [["random_string"]] .. 'test' .. 'other' ] = true
       ]==])
       local lua = tl.pretty_print_ast(result.ast)
       assert.equal(multitrim([==[
          local t = {}
          t[ [["random_string"]] ] = true
+         t[ [["random_string"]] .. 'test' ] = true
+         t[ [["random_string"]] .. 'test' .. 'other' ] = true
       ]==]), multitrim(lua))
    end)
 

--- a/tl.lua
+++ b/tl.lua
@@ -5378,6 +5378,11 @@ function tl.generate(ast, gen_target, opts)
       end,
    }
 
+   local function starts_with_longstring(n)
+      while n.e1 do n = n.e1 end
+      return n.is_longstring
+   end
+
    visit_node.cbs = {
       ["statements"] = {
          after = function(_, node, children)
@@ -5742,7 +5747,7 @@ function tl.generate(ast, gen_target, opts)
             elseif node.op.op == "@index" then
                add_child(out, children[1], "", indent)
                table.insert(out, "[")
-               if node.e2.is_longstring then
+               if starts_with_longstring(node.e2) then
                   table.insert(children[3], 1, " ")
                   table.insert(children[3], " ")
                end

--- a/tl.tl
+++ b/tl.tl
@@ -5378,6 +5378,11 @@ function tl.generate(ast: tl.Node, gen_target: GenTarget, opts?: GenerateOptions
       end
    }
 
+   local function starts_with_longstring(n: Node): boolean
+      while n.e1 do n = n.e1 end
+      return n.is_longstring
+   end
+
    visit_node.cbs = {
       ["statements"] = {
          after = function(_: nil, node: Node, children: {Output}): Output
@@ -5742,7 +5747,7 @@ function tl.generate(ast: tl.Node, gen_target: GenTarget, opts?: GenerateOptions
             elseif node.op.op == "@index" then
                add_child(out, children[1], "", indent)
                table.insert(out, "[")
-               if node.e2.is_longstring then
+               if starts_with_longstring(node.e2) then
                   table.insert(children[3], 1, " ")
                   table.insert(children[3], " ")
                end


### PR DESCRIPTION
Using a long string in a concatenation now correctly adds the extra space.