### PR TITLE
Preserve comments during lexing

### DIFF
--- a/spec/lang/lexer/comments_spec.lua
+++ b/spec/lang/lexer/comments_spec.lua
@@ -7,6 +7,23 @@ local function map(f, xs)
    end
    return rs
 end
+--- removes leading whitespace from every line of a multiline string
+local function dedent(s)
+  local min, lines = math.huge, {}
+  
+  for line in s:gmatch("([^\n]*)\n?") do
+    local indent = line:match("^(%s*)%S")
+    if indent then min = math.min(min, #indent) end
+    table.insert(lines, line)
+  end
+
+  for i, line in ipairs(lines) do
+    lines[i] = line:gsub("^" .. string.rep(" ", min), "")
+  end
+
+  return table.concat(lines, "\n")
+end
+
 
 describe("lexer", function()
    it("line comment at the end of a line", function()
@@ -17,4 +34,106 @@ describe("lexer", function()
       assert.same(5, #tokens)
       assert.same({"local", "x", "=", "1", "$EOF$"}, map(function(x) return x.tk end, tokens))
    end)
+
+   it("preserves single line comments", function()
+      local syntax_errors = {}
+      local tokens = tl.lex(dedent([[
+         -- This is a single line comment
+         local x = 1
+      ]]))
+      tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors)
+      assert.same(5, #tokens)
+      assert.same({"local", "x", "=", "1", "$EOF$"}, map(function(x) return x.tk end, tokens))
+      assert.same({
+         {text = "-- This is a single line comment", x = 1, y = 1}
+      }, tokens[1].comments)
+   end)
+
+   it("preserves multi-line comments", function()
+      local syntax_errors = {}
+      local tokens = tl.lex(dedent([[
+         -- This is a multi-line comment
+         -- that spans multiple lines.
+         local x = 1
+      ]]))
+      tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors)
+      assert.same(5, #tokens)
+      assert.same({"local", "x", "=", "1", "$EOF$"}, map(function(x) return x.tk end, tokens))
+      assert.same({
+         {text = "-- This is a multi-line comment", x = 1, y = 1},
+         {text = "-- that spans multiple lines.", x = 1, y = 2}
+      }, tokens[1].comments)
+   end)
+
+   it("always attaches comments to the leading token", function()
+      local syntax_errors = {}
+      local tokens = tl.lex(dedent([[
+         local x = 1 -- trailing comment
+         local y = 2
+      ]]))
+      tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors)
+      assert.same(9, #tokens)
+      assert.same({"local", "x", "=", "1", "local", "y", "=", "2", "$EOF$"}, map(function(x) return x.tk end, tokens))
+      assert.same({}, tokens[4].comments)
+      assert.same({
+         {text = "-- trailing comment", x = 13, y = 1}
+      }, tokens[5].comments)
+   end)
+
+   it("preserves multi-line comments with whitespace between lines", function()
+      local syntax_errors = {}
+      local tokens = tl.lex(dedent([[
+         -- This is a multi-line comment
+
+         -- that spans multiple lines.
+         -- It has some whitespace in between.
+         local x = 1
+      ]]))
+      tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors)
+      assert.same(5, #tokens)
+      assert.same({"local", "x", "=", "1", "$EOF$"}, map(function(x) return x.tk end, tokens))
+      assert.same({
+         {text = "-- This is a multi-line comment", x = 1, y = 1},
+         {text = "-- that spans multiple lines.", x = 1, y = 3},
+         {text = "-- It has some whitespace in between.", x = 1, y = 4}
+      }, tokens[1].comments)
+   end)
+
+   it("attaches comments to correct tokens in complex statements", function()
+      local syntax_errors = {}
+
+      local tokens = tl.lex(dedent([[
+         -- comment before local
+         local
+         -- comment before function
+         function
+         -- comment before function name
+         foo(): number
+           return 1
+         end
+         -- comment after function
+      ]]))
+
+      tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors)
+      assert.same(11, #tokens)
+      assert.same({"local", "function", "foo", "(", ")", ":", "number", "return", "1", "end", "$EOF$"}, map(function(x) return x.tk end, tokens))
+      assert.same({
+         {text = "-- comment before local", x = 1, y = 1},
+      }, tokens[1].comments)
+      assert.same({
+         {text = "-- comment before function", x = 1, y = 3},
+      }, tokens[2].comments)
+      assert.same({
+         {text = "-- comment before function name", x = 1, y = 5},
+      }, tokens[3].comments)
+      assert.same({
+         {text = "-- comment after function", x = 1, y = 9},
+      }, tokens[11].comments)
+   end)
+
 end)

--- a/spec/lang/lexer/comments_spec.lua
+++ b/spec/lang/lexer/comments_spec.lua
@@ -1,4 +1,5 @@
 local tl = require("tl")
+local util = require("spec.util")
 
 local function map(f, xs)
    local rs = {}
@@ -7,23 +8,8 @@ local function map(f, xs)
    end
    return rs
 end
---- removes leading whitespace from every line of a multiline string
-local function dedent(s)
-  local min, lines = math.huge, {}
-  
-  for line in s:gmatch("([^\n]*)\n?") do
-    local indent = line:match("^(%s*)%S")
-    if indent then min = math.min(min, #indent) end
-    table.insert(lines, line)
-  end
 
-  for i, line in ipairs(lines) do
-    lines[i] = line:gsub("^" .. string.rep(" ", min), "")
-  end
-
-  return table.concat(lines, "\n")
-end
-
+local dedent = util.dedent
 
 describe("lexer", function()
    it("line comment at the end of a line", function()

--- a/spec/lang/lexer/comments_spec.lua
+++ b/spec/lang/lexer/comments_spec.lua
@@ -77,7 +77,7 @@ describe("lexer", function()
       assert.same({}, syntax_errors)
       assert.same(9, #tokens)
       assert.same({"local", "x", "=", "1", "local", "y", "=", "2", "$EOF$"}, map(function(x) return x.tk end, tokens))
-      assert.same({}, tokens[4].comments)
+      assert.same(nil, tokens[4].comments)
       assert.same({
          {text = "-- trailing comment", x = 13, y = 1}
       }, tokens[5].comments)

--- a/spec/lang/lexer/long_comment_spec.lua
+++ b/spec/lang/lexer/long_comment_spec.lua
@@ -144,7 +144,7 @@ describe("long comment", function()
       assert.same({}, syntax_errors)
       assert.same(9, #tokens)
       assert.same({"local", "x", "=", "1", "local", "y", "=", "2", "$EOF$"}, map(function(x) return x.tk end, tokens))
-      assert.same({}, tokens[4].comments)
+      assert.same(nil, tokens[4].comments)
       assert.same({
          {text = "--[[\ntrailing long comment\n]]", x = 13, y = 1}
       }, tokens[5].comments)

--- a/spec/lang/lexer/long_comment_spec.lua
+++ b/spec/lang/lexer/long_comment_spec.lua
@@ -6,6 +6,30 @@ local function string_trim(s)
    return (s:gsub("^%s*(.-)%s*$", "%1"))
 end
 
+--- removes leading whitespace from every line of a multiline string
+local function dedent(s)
+  local min, lines = math.huge, {}
+  
+  for line in s:gmatch("([^\n]*)\n?") do
+    local indent = line:match("^(%s*)%S")
+    if indent then min = math.min(min, #indent) end
+    table.insert(lines, line)
+  end
+
+  for i, line in ipairs(lines) do
+    lines[i] = line:gsub("^" .. string.rep(" ", min), "")
+  end
+
+  return table.concat(lines, "\n")
+end
+
+local function map(f, xs)
+   local rs = {}
+   for i, x in ipairs(xs) do
+      rs[i] = f(x)
+   end
+   return rs
+end
 
 describe("long comment", function()
    it("accepts a level 0 long comment", util.check [=[
@@ -71,4 +95,82 @@ describe("long comment", function()
       "print --[[ unfinished long comment\n", {
       { y = 1, msg = "unfinished long comment" },
    }))
+
+   it("preseves long comments in tokens", function()
+      local syntax_errors = {}
+      local tokens = tl.lex(dedent([[
+         --[==[
+            This is a multi-line comment
+            that spans multiple lines.
+         ]==]
+         local x = 1
+      ]]))
+      tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors)
+      assert.same(5, #tokens)
+      assert.same({"local", "x", "=", "1", "$EOF$"}, map(function(x) return x.tk end, tokens))
+      assert.same({
+         {text = "--[==[\n   This is a multi-line comment\n   that spans multiple lines.\n]==]", x = 1, y = 1},
+      }, tokens[1].comments)
+   end)
+
+   it("correctly attaches inline long comments to the leading token", function()
+      local syntax_errors = {}
+      local tokens = tl.lex(dedent([=[
+         local --[[inline long comment]] x --[[another inline comment]] --[[one more inline comment]] = 1
+      ]=]))
+      tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors)
+      assert.same(5, #tokens)
+      assert.same({"local", "x", "=", "1", "$EOF$"}, map(function(x) return x.tk end, tokens))
+      assert.same({
+         {text = "--[[inline long comment]]", x = 7, y = 1},
+      }, tokens[2].comments)
+      assert.same({
+         {text = "--[[another inline comment]]", x = 35, y = 1},
+         {text = "--[[one more inline comment]]", x = 64, y = 1}
+      }, tokens[3].comments)
+   end)
+
+   it("correctly attaches trailling long comments to the leading token", function()
+      local syntax_errors = {}
+      local tokens = tl.lex(dedent([=[
+         local x = 1 --[[
+         trailing long comment
+         ]]
+         local y = 2
+      ]=]))
+      tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors)
+      assert.same(9, #tokens)
+      assert.same({"local", "x", "=", "1", "local", "y", "=", "2", "$EOF$"}, map(function(x) return x.tk end, tokens))
+      assert.same({}, tokens[4].comments)
+      assert.same({
+         {text = "--[[\ntrailing long comment\n]]", x = 13, y = 1}
+      }, tokens[5].comments)
+   end)
+
+   it("preserves long comments with whitespace between lines", function()
+      local syntax_errors = {}
+      local tokens = tl.lex(dedent([=[
+         --[[
+            This is a multi-line comment
+            that spans multiple lines.
+         ]]
+
+         --[[
+            This is another multi-line comment
+            that also spans multiple lines.
+         ]]
+         local x = 1
+      ]=]))
+      tl.parse_program(tokens, syntax_errors)
+      assert.same({}, syntax_errors)
+      assert.same(5, #tokens)
+      assert.same({"local", "x", "=", "1", "$EOF$"}, map(function(x) return x.tk end, tokens))
+      assert.same({
+         {text = "--[[\n   This is a multi-line comment\n   that spans multiple lines.\n]]", x = 1, y = 1},
+         {text = "--[[\n   This is another multi-line comment\n   that also spans multiple lines.\n]]", x = 1, y = 6}
+      }, tokens[1].comments)
+   end)
 end)

--- a/spec/lang/lexer/long_comment_spec.lua
+++ b/spec/lang/lexer/long_comment_spec.lua
@@ -6,22 +6,7 @@ local function string_trim(s)
    return (s:gsub("^%s*(.-)%s*$", "%1"))
 end
 
---- removes leading whitespace from every line of a multiline string
-local function dedent(s)
-  local min, lines = math.huge, {}
-  
-  for line in s:gmatch("([^\n]*)\n?") do
-    local indent = line:match("^(%s*)%S")
-    if indent then min = math.min(min, #indent) end
-    table.insert(lines, line)
-  end
-
-  for i, line in ipairs(lines) do
-    lines[i] = line:gsub("^" .. string.rep(" ", min), "")
-  end
-
-  return table.concat(lines, "\n")
-end
+local dedent = util.dedent
 
 local function map(f, xs)
    local rs = {}

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -782,8 +782,12 @@ function util.dedent(s)
       table.insert(lines, line)
    end
 
+   if min == math.huge then
+      return s
+   end
+
    for i, line in ipairs(lines) do
-      lines[i] = line:gsub("^" .. string.rep(" ", min), "")
+      lines[i] = line:sub(min + 1)
    end
 
    return table.concat(lines, "\n")

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -772,4 +772,22 @@ function util.check_lines(prelude, testcases)
    return util.check_type_error(code, errs)
 end
 
+--- removes leading whitespace from every line of a multiline string
+function util.dedent(s)
+   local min, lines = math.huge, {}
+  
+   for line in s:gmatch("([^\n]*)\n?") do
+      local indent = line:match("^(%s*)%S")
+      if indent then min = math.min(min, #indent) end
+      table.insert(lines, line)
+   end
+
+   for i, line in ipairs(lines) do
+      lines[i] = line:gsub("^" .. string.rep(" ", min), "")
+   end
+
+   return table.concat(lines, "\n")
+end
+
+
 return util

--- a/tl.lua
+++ b/tl.lua
@@ -1128,7 +1128,7 @@ do
       local ti
       local in_token = false
 
-      local comments = {}
+      local comments
 
       local function begin_token()
          tx = x
@@ -1146,7 +1146,7 @@ do
             kind = kind,
             comments = comments,
          }
-         comments = {}
+         comments = nil
          in_token = false
       end
 
@@ -1160,7 +1160,7 @@ do
             kind = keywords[tk] and "keyword" or "identifier",
             comments = comments,
          }
-         comments = {}
+         comments = nil
          in_token = false
       end
 
@@ -1174,7 +1174,7 @@ do
             kind = kind,
             comments = comments,
          }
-         comments = {}
+         comments = nil
          in_token = false
       end
 
@@ -1189,7 +1189,7 @@ do
             comments = comments,
 
          }
-         comments = {}
+         comments = nil
          in_token = false
       end
 
@@ -1205,6 +1205,17 @@ do
             x = t.x,
             msg = msg or "invalid token '" .. t.tk .. "'",
          })
+      end
+
+      local function add_comment(text)
+         if not comments then
+            comments = {}
+         end
+         comments[#comments + 1] = {
+            x = tx,
+            y = ty,
+            text = text,
+         }
       end
 
       local len = #input
@@ -1272,11 +1283,7 @@ do
             end
          elseif state == "comment short" then
             if c == "\n" then
-               comments[#comments + 1] = {
-                  x = tx,
-                  y = ty,
-                  text = input:sub(ti, i - 1),
-               }
+               add_comment(input:sub(ti, i - 1))
                state = "any"
             end
          elseif state == "got =" then
@@ -1431,11 +1438,7 @@ do
             end
          elseif state == "comment long got ]" then
             if c == "]" and lc_close_lvl == lc_open_lvl then
-               comments[#comments + 1] = {
-                  x = tx,
-                  y = ty,
-                  text = input:sub(ti, i),
-               }
+               add_comment(input:sub(ti, i))
                drop_token()
                state = "any"
                lc_open_lvl = 0

--- a/tl.tl
+++ b/tl.tl
@@ -667,11 +667,18 @@ local record tl
       "$EOF$"
    end
 
+   record Comment
+      x: integer
+      y: integer
+      text: string
+   end
+
    record Token
       x: integer
       y: integer
       tk: string
       kind: TokenKind
+      comments: {Comment}
    end
 
    -----------------------------------------------------------------------------
@@ -804,6 +811,7 @@ local type Result = tl.Result
 local type CheckOptions = tl.CheckOptions
 local type Token = tl.Token
 local type TokenKind = tl.TokenKind
+local type Comment = tl.Comment
 local type TypeInfo = tl.TypeInfo
 local type TypeReport = tl.TypeReport
 local type WarningKind = tl.WarningKind
@@ -1120,6 +1128,8 @@ do
       local ti: integer
       local in_token = false
 
+      local comments: {Comment} = {}
+
       local function begin_token()
          tx = x
          ty = y
@@ -1134,7 +1144,9 @@ do
             y = ty,
             tk = tk,
             kind = kind,
+            comments = comments,
          }
+         comments = {}
          in_token = false
       end
 
@@ -1145,8 +1157,10 @@ do
             x = tx,
             y = ty,
             tk = tk,
-            kind = keywords[tk] and "keyword" or "identifier"
+            kind = keywords[tk] and "keyword" or "identifier",
+            comments = comments,
          }
+         comments = {}
          in_token = false
       end
 
@@ -1157,8 +1171,10 @@ do
             x = tx,
             y = ty,
             tk = tk,
-            kind = kind
+            kind = kind,
+            comments = comments,
          }
+         comments = {}
          in_token = false
       end
 
@@ -1169,8 +1185,11 @@ do
             x = tx,
             y = ty,
             tk = tk,
-            kind = kind
+            kind = kind,
+            comments = comments,
+
          }
+         comments = {}
          in_token = false
       end
 
@@ -1253,6 +1272,11 @@ do
             end
          elseif state == "comment short" then
             if c == "\n" then
+               comments[#comments + 1] = {
+                  x = tx,
+                  y = ty,
+                  text = input:sub(ti, i - 1),
+               }
                state = "any"
             end
          elseif state == "got =" then
@@ -1407,6 +1431,11 @@ do
             end
          elseif state == "comment long got ]" then
             if c == "]" and lc_close_lvl == lc_open_lvl then
+               comments[#comments + 1] = {
+                  x = tx,
+                  y = ty,
+                  text = input:sub(ti, i),
+               }
                drop_token()
                state = "any"
                lc_open_lvl = 0
@@ -1561,7 +1590,7 @@ do
          end
       end
 
-      table.insert(tokens, { x = x + 1, y = y, i = i, tk = "$EOF$", kind = "$EOF$" })
+      table.insert(tokens, { x = x + 1, y = y, i = i, tk = "$EOF$", kind = "$EOF$", comments = comments })
 
       return tokens, errs
    end

--- a/tl.tl
+++ b/tl.tl
@@ -1128,7 +1128,7 @@ do
       local ti: integer
       local in_token = false
 
-      local comments: {Comment} = {}
+      local comments: {Comment}
 
       local function begin_token()
          tx = x
@@ -1146,7 +1146,7 @@ do
             kind = kind,
             comments = comments,
          }
-         comments = {}
+         comments = nil
          in_token = false
       end
 
@@ -1160,7 +1160,7 @@ do
             kind = keywords[tk] and "keyword" or "identifier",
             comments = comments,
          }
-         comments = {}
+         comments = nil
          in_token = false
       end
 
@@ -1174,7 +1174,7 @@ do
             kind = kind,
             comments = comments,
          }
-         comments = {}
+         comments = nil
          in_token = false
       end
 
@@ -1189,7 +1189,7 @@ do
             comments = comments,
 
          }
-         comments = {}
+         comments = nil
          in_token = false
       end
 
@@ -1205,6 +1205,17 @@ do
             x = t.x,
             msg = msg or "invalid token '" .. t.tk .. "'",
          })
+      end
+
+      local function add_comment(text: string) 
+         if not comments then
+            comments = {}
+         end
+         comments[#comments + 1] = {
+            x = tx,
+            y = ty,
+            text = text,
+         }
       end
 
       local len = #input
@@ -1272,11 +1283,7 @@ do
             end
          elseif state == "comment short" then
             if c == "\n" then
-               comments[#comments + 1] = {
-                  x = tx,
-                  y = ty,
-                  text = input:sub(ti, i - 1),
-               }
+               add_comment(input:sub(ti, i - 1))
                state = "any"
             end
          elseif state == "got =" then
@@ -1431,11 +1438,7 @@ do
             end
          elseif state == "comment long got ]" then
             if c == "]" and lc_close_lvl == lc_open_lvl then
-               comments[#comments + 1] = {
-                  x = tx,
-                  y = ty,
-                  text = input:sub(ti, i),
-               }
+               add_comment(input:sub(ti, i))
                drop_token()
                state = "any"
                lc_open_lvl = 0


### PR DESCRIPTION
Part of tealdoc project. Stores comments inside of `comments` field of `Token`. Always attaches comments to the leading token.