### PR TITLE
Set the main build to target Lua 5.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ all: selfbuild suite
 
 selfbuild:
 	cp tl.lua tl.lua.bak
-	$(LUA) ./tl gen --check tl.tl && cp tl.lua tl.lua.1 || { cp tl.lua tl.lua.1; cp tl.lua.bak tl.lua; exit 1; }
-	$(LUA) ./tl gen --check tl.tl && cp tl.lua tl.lua.2 || { cp tl.lua tl.lua.2; cp tl.lua.bak tl.lua; exit 1; }
+	$(LUA) ./tl gen --check --gen-target=5.1 tl.tl && cp tl.lua tl.lua.1 || { cp tl.lua tl.lua.1; cp tl.lua.bak tl.lua; exit 1; }
+	$(LUA) ./tl gen --check --gen-target=5.1 tl.tl && cp tl.lua tl.lua.2 || { cp tl.lua tl.lua.2; cp tl.lua.bak tl.lua; exit 1; }
 	diff tl.lua.1 tl.lua.2
 
 suite:

--- a/tl.tl
+++ b/tl.tl
@@ -1605,7 +1605,7 @@ local function binary_search<T, U>(list: {T}, item: U, cmp: function(T, U): bool
    local mid: integer
    local s, e = 1, len
    while s <= e do
-      mid = math.floor((s + e) / 2)
+      mid = (s + e) // 2
       local val <const> = list[mid]
       local res <const> = cmp(val, item)
       if res then


### PR DESCRIPTION
This makes it convert `//` ops into the appropriate `math.floor(x/y)` to be compatible with Lua 5.1