### PR TITLE
fix: TypeChecker:expand_interfaces should copy array elements, not the array

### DIFF
--- a/spec/lang/subtyping/interface_spec.lua
+++ b/spec/lang/subtyping/interface_spec.lua
@@ -247,4 +247,13 @@ describe("subtyping of interfaces:", function()
       { y = 13, msg = "I is not a R" },
       { y = 14, msg = "I is not a R" },
    }))
+
+   it("array inheritance works (regression test for #1022)", util.check([[
+      local interface A is {string}
+      end
+      local interface B is A
+      end
+      local _a: A = { "a", "b" }
+      local _b: B = { "c" }
+   ]]))
 end)

--- a/tl.lua
+++ b/tl.lua
@@ -14461,7 +14461,7 @@ self:expand_type(node, values, elements) })
                end
             else
                if not t.elements then
-                  t.elements = iface
+                  t.elements = iface.elements
                else
                   if not self:same_type(iface.elements, t.elements) then
                      self.errs:add(t, "incompatible array interfaces")

--- a/tl.tl
+++ b/tl.tl
@@ -14461,7 +14461,7 @@ do
                end
             else
                if not t.elements then
-                  t.elements = iface
+                  t.elements = iface.elements
                else
                   if not self:same_type(iface.elements, t.elements) then
                      self.errs:add(t, "incompatible array interfaces")


### PR DESCRIPTION
closes #1022