### PR TITLE
Various stdlib updates

### DIFF
--- a/spec/cli/types_spec.lua
+++ b/spec/cli/types_spec.lua
@@ -385,7 +385,7 @@ describe("tl types works like check", function()
          assert.same({
             ["17"] = 'string',
             ["20"] = 'boolean',
-            ["25"] = 'function({K : V}): function(): (K, V)',
+            ["25"] = 'function({K : V}): (function({K : V}, ? K): (K, V), {K : V}, K)',
             ["31"] = '{string : boolean}',
          }, map_to_str(by_pos["2"]))
       end)

--- a/spec/cli/types_spec.lua
+++ b/spec/cli/types_spec.lua
@@ -367,19 +367,27 @@ describe("tl types works like check", function()
          local types = json.decode(output)
          assert(types.by_pos)
          local by_pos = types.by_pos[next(types.by_pos)]
+         local function map_to_str(tbl)
+            local ntbl = {}
+            for k, v in pairs(tbl) do
+               ntbl[k] = assert(types.types[tostring(v)]).str
+            end
+            return ntbl
+         end
+
          assert.same({
-            ["19"] = 9,
-            ["22"] = 9,
-            ["23"] = 7,
-            ["30"] = 2,
-            ["41"] = 9,
-         }, by_pos["1"])
+            ["19"] = '{string : boolean}',
+            ["22"] = '{string : boolean}',
+            ["23"] = 'string',
+            ["30"] = 'boolean',
+            ["41"] = '{string : boolean}',
+         }, map_to_str(by_pos["1"]))
          assert.same({
-            ["17"] = 7,
-            ["20"] = 2,
-            ["25"] = 17,
-            ["31"] = 9,
-         }, by_pos["2"])
+            ["17"] = 'string',
+            ["20"] = 'boolean',
+            ["25"] = 'function({K : V}): function(): (K, V)',
+            ["31"] = '{string : boolean}',
+         }, map_to_str(by_pos["2"]))
       end)
    end)
 end)

--- a/spec/lang/stdlib/xpcall_spec.lua
+++ b/spec/lang/stdlib/xpcall_spec.lua
@@ -120,6 +120,10 @@ describe("xpcall", function()
       { y = 6, x = 35, msg = "argument 3: got integer, expected string" },
    }))
 
+   it("works with debug.traceback", util.check([[
+      local worked = xpcall(print, debug.traceback, 123, 456)
+   ]]))
+
    it("does not warn when passed a method as the first argument", util.check_warnings([[
       local record Text
          text: string

--- a/tl.lua
+++ b/tl.lua
@@ -127,9 +127,8 @@ do
       debug: function()
       gethook: function(? thread): HookFunction, integer
 
-      getinfo: function(AnyFunction | integer): GetInfoTable
-      getinfo: function(AnyFunction | integer, string): GetInfoTable
-      getinfo: function(thread, AnyFunction | integer, string): GetInfoTable
+      getinfo: function(thread, AnyFunction | integer, ? string): GetInfoTable
+      getinfo: function(        AnyFunction | integer, ? string): GetInfoTable
 
       getlocal: function(thread, AnyFunction, integer): string
       getlocal: function(thread, integer, integer): string, any

--- a/tl.lua
+++ b/tl.lua
@@ -451,7 +451,7 @@ do
       next: function<K, V>({K:V}, ? K): (K, V)
       next: function<A>({A}, ? integer): (integer, A)
 
-      pairs: function<K, V>({K:V}): (function():(K, V)) --[[special_function]]
+      pairs: function<K, V>({K:V}): (function({K:V}, ? K):(K, V), {K:V}, K) --[[special_function]]
       pcall: function(function(any...):(any...), any...): boolean, any... --[[special_function]]
       print: function(any...)
       rawequal: function(any, any): boolean

--- a/tl.lua
+++ b/tl.lua
@@ -138,8 +138,8 @@ do
 
       getmetatable: function<T>(T): metatable<T>
       getregistry: function(): {any:any}
-      getupvalue: function(AnyFunction, integer): any
-      getuservalue: function(userdata, integer): any
+      getupvalue: function(AnyFunction, integer): string, any
+      getuservalue: function(userdata, ? integer): any, boolean
 
       sethook: function(thread, HookFunction, string, ? integer)
       sethook: function(HookFunction, string, ? integer)

--- a/tl.lua
+++ b/tl.lua
@@ -329,10 +329,10 @@ do
       cpath: string
       loaded: {string:any}
       loadlib: function(string, string): (function)
-      loaders: { function(string): any, any }
+      loaders: { (function(string): (function(? string, ? any): (any), any)) }
       path: string
-      preload: {any:any}
-      searchers: { function(string): any }
+      preload: {string : function(? string, ? any): (any) }
+      searchers: { (function(string): (function(? string, ? any): (any), any)) }
       searchpath: function(string, string, ? string, ? string): string, string
    end
 

--- a/tl.lua
+++ b/tl.lua
@@ -201,6 +201,7 @@ do
 
    global record FILE
       is userdata
+      where io.type(self)
 
       enum SeekWhence
          "set" "cur" "end"

--- a/tl.lua
+++ b/tl.lua
@@ -114,6 +114,8 @@ do
          isvararg: boolean
          func: any
          activelines: {integer:boolean}
+         ftransfer: integer -- TODO: what should compat be for these? (5.4+)
+         ntransfer: integer
       end
 
       enum HookEvent

--- a/tl.lua
+++ b/tl.lua
@@ -166,6 +166,11 @@ do
          "*rb" "*wb" "*ab" "*r+b" "*w+b" "*a+b"
       end
 
+      enum FileType
+         "file"
+         "closed file"
+      end
+
       close: function(? FILE)
       input: function(? FILE | string): FILE
       flush: function()
@@ -190,8 +195,8 @@ do
       stdin: FILE
       stdout: FILE
       tmpfile: function(): FILE
-      type: function(any): string
-      write: function((string | number)...): FILE, string
+      type: function(any): FileType
+      write: function((string | number)...): FILE, string, integer
    end
 
    global record FILE
@@ -206,7 +211,7 @@ do
       end
 
       close: function(FILE): boolean, string, integer
-      flush: function(FILE)
+      flush: function(FILE): boolean, string, integer
 
       lines: function(FILE): (function(): (string))
       lines: function(FILE, FileNumberMode...): (function(): (number...))
@@ -220,10 +225,10 @@ do
       read: function(FILE, (number | FileMode)...): ((string | number)...)
       read: function(FILE, (number | string)...): (string...)
 
-      seek: function(FILE, ? SeekWhence, ? integer): integer, string
-      setvbuf: function(FILE, SetVBufMode, ? integer)
+      seek: function(FILE, ? SeekWhence, ? integer): integer, string, integer
+      setvbuf: function(FILE, SetVBufMode, ? integer): boolean, string, integer
 
-      write: function(FILE, (string | number)...): FILE, string
+      write: function(FILE, (string | number)...): FILE, string, integer
 
       metamethod __close: function(FILE)
    end

--- a/tl.lua
+++ b/tl.lua
@@ -395,10 +395,10 @@ do
    global record utf8
       char: function(number...): string
       charpattern: string
-      codepoint: function(string, ? number, ? number, ? boolean): number...
-      codes: function(string, ? boolean): (function(string, ? number): (number, number))
-      len: function(string, ? number, ? number, ? boolean): number
-      offset: function(string, number, ? number): number
+      codepoint: function(string, ? number, ? number, ? boolean): integer...
+      codes: function(string, ? boolean): (function(string, ? integer): (integer, integer), string, integer)
+      len: function(string, ? number, ? number, ? boolean): integer, integer
+      offset: function(string, number, ? number): integer
    end
 
    local record StandardLibrary

--- a/tl.lua
+++ b/tl.lua
@@ -442,10 +442,11 @@ do
       getmetatable: function<T>(T): metatable<T>
       ipairs: function<A>({A}): (function():(integer, A)) --[[special_function]]
 
-      load: function((string | LoadFunction), ? string, ? LoadMode, ? table): (function, string)
-      load: function((string | LoadFunction), ? string, ? string, ? table): (function, string)
+      load: function((string | LoadFunction), ? string, ? LoadMode, ? {any:any}): (function, string)
+      load: function((string | LoadFunction), ? string, ? string,   ? {any:any}): (function, string)
 
-      loadfile: function(? string, ? string, ? {any:any}): (function, string)
+      loadfile: function(? string, ? LoadMode, ? {any:any}): (function, string)
+      loadfile: function(? string, ? string,   ? {any:any}): (function, string)
 
       next: function<K, V>({K:V}, ? K): (K, V)
       next: function<A>({A}, ? integer): (integer, A)

--- a/tl.lua
+++ b/tl.lua
@@ -440,7 +440,7 @@ do
 
       error: function(? any, ? integer)
       getmetatable: function<T>(T): metatable<T>
-      ipairs: function<A>({A}): (function():(integer, A)) --[[special_function]]
+      ipairs: function<A>({A}): (function({A}, integer): (integer, A), {A}, integer) --[[special_function]]
 
       load: function((string | LoadFunction), ? string, ? LoadMode, ? {any:any}): (function, string)
       load: function((string | LoadFunction), ? string, ? string,   ? {any:any}): (function, string)

--- a/tl.lua
+++ b/tl.lua
@@ -154,6 +154,7 @@ do
 
       traceback: function(thread, ? string, ? integer): string
       traceback: function(? string, ? integer): string
+      traceback: function(any): any
 
       upvalueid: function(AnyFunction, integer): userdata
       upvaluejoin: function(AnyFunction, integer, AnyFunction, integer)
@@ -426,7 +427,7 @@ do
          "b" "t" "bt"
       end
 
-      type XpcallMsghFunction = function(...: any): ()
+      type XpcallMsghFunction = function(any): any...
 
       arg: {string}
       assert: function<A, B>(A, ? B, ...: any): A --[[special_function]]
@@ -11614,7 +11615,7 @@ a.types[i], b.types[i]), }
          local msgh_type = a_function(arg2, {
             min_arity = self.feat_arity and 1 or 0,
             args = a_type(arg2, "tuple", { tuple = { a_type(arg2, "any", {}) } }),
-            rets = a_type(arg2, "tuple", { tuple = {} }),
+            rets = a_vararg(arg2, { a_type(arg2, "any", {}) }),
          })
          self:assert_is_a(arg2, msgh, msgh_type, "in message handler")
       end

--- a/tl.lua
+++ b/tl.lua
@@ -85,40 +85,6 @@ do
       "a" "l" "L" "*a" "*l" "*L" "n" "*n"
    end
 
-   global record FILE
-      is userdata
-
-      enum SeekWhence
-         "set" "cur" "end"
-      end
-
-      enum SetVBufMode
-         "no" "full" "line"
-      end
-
-      close: function(FILE): boolean, string, integer
-      flush: function(FILE)
-
-      lines: function(FILE): (function(): (string))
-      lines: function(FILE, FileNumberMode...): (function(): (number...))
-      lines: function(FILE, (number | FileStringMode)...): (function(): (string...))
-      lines: function(FILE, (number | FileMode)...): (function(): ((string | number)...))
-      lines: function(FILE, (number | string)...): (function(): (string...))
-
-      read: function(FILE): string
-      read: function(FILE, FileNumberMode...): number...
-      read: function(FILE, (number | FileStringMode)...): string...
-      read: function(FILE, (number | FileMode)...): ((string | number)...)
-      read: function(FILE, (number | string)...): (string...)
-
-      seek: function(FILE, ? SeekWhence, ? integer): integer, string
-      setvbuf: function(FILE, SetVBufMode, ? integer)
-
-      write: function(FILE, (string | number)...): FILE, string
-
-      metamethod __close: function(FILE)
-   end
-
    global record coroutine
       type Function = function(any...): any...
 
@@ -194,9 +160,9 @@ do
 
    global record io
       enum OpenMode
-         "r" "w" "a" "r+" "w+" "a+"
-         "rb" "wb" "ab" "r+b" "w+b" "a+b"
-         "*r" "*w" "*a" "*r+" "*w+" "*a+"
+          "r"   "w"   "a"   "r+"   "w+"   "a+"
+          "rb"  "wb"  "ab"  "r+b"  "w+b"  "a+b"
+         "*r"  "*w"  "*a"  "*r+"  "*w+"  "*a+"
          "*rb" "*wb" "*ab" "*r+b" "*w+b" "*a+b"
       end
 
@@ -226,6 +192,40 @@ do
       tmpfile: function(): FILE
       type: function(any): string
       write: function((string | number)...): FILE, string
+   end
+
+   global record FILE
+      is userdata
+
+      enum SeekWhence
+         "set" "cur" "end"
+      end
+
+      enum SetVBufMode
+         "no" "full" "line"
+      end
+
+      close: function(FILE): boolean, string, integer
+      flush: function(FILE)
+
+      lines: function(FILE): (function(): (string))
+      lines: function(FILE, FileNumberMode...): (function(): (number...))
+      lines: function(FILE, (number | FileStringMode)...): (function(): (string...))
+      lines: function(FILE, (number | FileMode)...): (function(): ((string | number)...))
+      lines: function(FILE, (number | string)...): (function(): (string...))
+
+      read: function(FILE): string
+      read: function(FILE, FileNumberMode...): number...
+      read: function(FILE, (number | FileStringMode)...): string...
+      read: function(FILE, (number | FileMode)...): ((string | number)...)
+      read: function(FILE, (number | string)...): (string...)
+
+      seek: function(FILE, ? SeekWhence, ? integer): integer, string
+      setvbuf: function(FILE, SetVBufMode, ? integer)
+
+      write: function(FILE, (string | number)...): FILE, string
+
+      metamethod __close: function(FILE)
    end
 
    global record math

--- a/tl.tl
+++ b/tl.tl
@@ -127,9 +127,8 @@ do
       debug: function()
       gethook: function(? thread): HookFunction, integer
 
-      getinfo: function(AnyFunction | integer): GetInfoTable
-      getinfo: function(AnyFunction | integer, string): GetInfoTable
-      getinfo: function(thread, AnyFunction | integer, string): GetInfoTable
+      getinfo: function(thread, AnyFunction | integer, ? string): GetInfoTable
+      getinfo: function(        AnyFunction | integer, ? string): GetInfoTable
 
       getlocal: function(thread, AnyFunction, integer): string
       getlocal: function(thread, integer, integer): string, any

--- a/tl.tl
+++ b/tl.tl
@@ -451,7 +451,7 @@ do
       next: function<K, V>({K:V}, ? K): (K, V)
       next: function<A>({A}, ? integer): (integer, A)
 
-      pairs: function<K, V>({K:V}): (function():(K, V)) --[[special_function]]
+      pairs: function<K, V>({K:V}): (function({K:V}, ? K):(K, V), {K:V}, K) --[[special_function]]
       pcall: function(function(any...):(any...), any...): boolean, any... --[[special_function]]
       print: function(any...)
       rawequal: function(any, any): boolean

--- a/tl.tl
+++ b/tl.tl
@@ -138,8 +138,8 @@ do
 
       getmetatable: function<T>(T): metatable<T>
       getregistry: function(): {any:any}
-      getupvalue: function(AnyFunction, integer): any
-      getuservalue: function(userdata, integer): any
+      getupvalue: function(AnyFunction, integer): string, any
+      getuservalue: function(userdata, ? integer): any, boolean
 
       sethook: function(thread, HookFunction, string, ? integer)
       sethook: function(HookFunction, string, ? integer)

--- a/tl.tl
+++ b/tl.tl
@@ -329,10 +329,10 @@ do
       cpath: string
       loaded: {string:any}
       loadlib: function(string, string): (function)
-      loaders: { function(string): any, any }
+      loaders: { (function(string): (function(? string, ? any): (any), any)) }
       path: string
-      preload: {any:any}
-      searchers: { function(string): any }
+      preload: {string : function(? string, ? any): (any) }
+      searchers: { (function(string): (function(? string, ? any): (any), any)) }
       searchpath: function(string, string, ? string, ? string): string, string
    end
 

--- a/tl.tl
+++ b/tl.tl
@@ -201,6 +201,7 @@ do
 
    global record FILE
       is userdata
+      where io.type(self)
 
       enum SeekWhence
          "set" "cur" "end"

--- a/tl.tl
+++ b/tl.tl
@@ -114,6 +114,8 @@ do
          isvararg: boolean
          func: any
          activelines: {integer:boolean}
+         ftransfer: integer -- TODO: what should compat be for these? (5.4+)
+         ntransfer: integer
       end
 
       enum HookEvent

--- a/tl.tl
+++ b/tl.tl
@@ -166,6 +166,11 @@ do
          "*rb" "*wb" "*ab" "*r+b" "*w+b" "*a+b"
       end
 
+      enum FileType
+         "file"
+         "closed file"
+      end
+
       close: function(? FILE)
       input: function(? FILE | string): FILE
       flush: function()
@@ -190,8 +195,8 @@ do
       stdin: FILE
       stdout: FILE
       tmpfile: function(): FILE
-      type: function(any): string
-      write: function((string | number)...): FILE, string
+      type: function(any): FileType
+      write: function((string | number)...): FILE, string, integer
    end
 
    global record FILE
@@ -206,7 +211,7 @@ do
       end
 
       close: function(FILE): boolean, string, integer
-      flush: function(FILE)
+      flush: function(FILE): boolean, string, integer
 
       lines: function(FILE): (function(): (string))
       lines: function(FILE, FileNumberMode...): (function(): (number...))
@@ -220,10 +225,10 @@ do
       read: function(FILE, (number | FileMode)...): ((string | number)...)
       read: function(FILE, (number | string)...): (string...)
 
-      seek: function(FILE, ? SeekWhence, ? integer): integer, string
-      setvbuf: function(FILE, SetVBufMode, ? integer)
+      seek: function(FILE, ? SeekWhence, ? integer): integer, string, integer
+      setvbuf: function(FILE, SetVBufMode, ? integer): boolean, string, integer
 
-      write: function(FILE, (string | number)...): FILE, string
+      write: function(FILE, (string | number)...): FILE, string, integer
 
       metamethod __close: function(FILE)
    end

--- a/tl.tl
+++ b/tl.tl
@@ -395,10 +395,10 @@ do
    global record utf8
       char: function(number...): string
       charpattern: string
-      codepoint: function(string, ? number, ? number, ? boolean): number...
-      codes: function(string, ? boolean): (function(string, ? number): (number, number))
-      len: function(string, ? number, ? number, ? boolean): number
-      offset: function(string, number, ? number): number
+      codepoint: function(string, ? number, ? number, ? boolean): integer...
+      codes: function(string, ? boolean): (function(string, ? integer): (integer, integer), string, integer)
+      len: function(string, ? number, ? number, ? boolean): integer, integer
+      offset: function(string, number, ? number): integer
    end
 
    local record StandardLibrary

--- a/tl.tl
+++ b/tl.tl
@@ -442,10 +442,11 @@ do
       getmetatable: function<T>(T): metatable<T>
       ipairs: function<A>({A}): (function():(integer, A)) --[[special_function]]
 
-      load: function((string | LoadFunction), ? string, ? LoadMode, ? table): (function, string)
-      load: function((string | LoadFunction), ? string, ? string, ? table): (function, string)
+      load: function((string | LoadFunction), ? string, ? LoadMode, ? {any:any}): (function, string)
+      load: function((string | LoadFunction), ? string, ? string,   ? {any:any}): (function, string)
 
-      loadfile: function(? string, ? string, ? {any:any}): (function, string)
+      loadfile: function(? string, ? LoadMode, ? {any:any}): (function, string)
+      loadfile: function(? string, ? string,   ? {any:any}): (function, string)
 
       next: function<K, V>({K:V}, ? K): (K, V)
       next: function<A>({A}, ? integer): (integer, A)

--- a/tl.tl
+++ b/tl.tl
@@ -440,7 +440,7 @@ do
 
       error: function(? any, ? integer)
       getmetatable: function<T>(T): metatable<T>
-      ipairs: function<A>({A}): (function():(integer, A)) --[[special_function]]
+      ipairs: function<A>({A}): (function({A}, integer): (integer, A), {A}, integer) --[[special_function]]
 
       load: function((string | LoadFunction), ? string, ? LoadMode, ? {any:any}): (function, string)
       load: function((string | LoadFunction), ? string, ? string,   ? {any:any}): (function, string)

--- a/tl.tl
+++ b/tl.tl
@@ -85,40 +85,6 @@ do
       "a" "l" "L" "*a" "*l" "*L" "n" "*n"
    end
 
-   global record FILE
-      is userdata
-
-      enum SeekWhence
-         "set" "cur" "end"
-      end
-
-      enum SetVBufMode
-         "no" "full" "line"
-      end
-
-      close: function(FILE): boolean, string, integer
-      flush: function(FILE)
-
-      lines: function(FILE): (function(): (string))
-      lines: function(FILE, FileNumberMode...): (function(): (number...))
-      lines: function(FILE, (number | FileStringMode)...): (function(): (string...))
-      lines: function(FILE, (number | FileMode)...): (function(): ((string | number)...))
-      lines: function(FILE, (number | string)...): (function(): (string...))
-
-      read: function(FILE): string
-      read: function(FILE, FileNumberMode...): number...
-      read: function(FILE, (number | FileStringMode)...): string...
-      read: function(FILE, (number | FileMode)...): ((string | number)...)
-      read: function(FILE, (number | string)...): (string...)
-
-      seek: function(FILE, ? SeekWhence, ? integer): integer, string
-      setvbuf: function(FILE, SetVBufMode, ? integer)
-
-      write: function(FILE, (string | number)...): FILE, string
-
-      metamethod __close: function(FILE)
-   end
-
    global record coroutine
       type Function = function(any...): any...
 
@@ -194,9 +160,9 @@ do
 
    global record io
       enum OpenMode
-         "r" "w" "a" "r+" "w+" "a+"
-         "rb" "wb" "ab" "r+b" "w+b" "a+b"
-         "*r" "*w" "*a" "*r+" "*w+" "*a+"
+          "r"   "w"   "a"   "r+"   "w+"   "a+"
+          "rb"  "wb"  "ab"  "r+b"  "w+b"  "a+b"
+         "*r"  "*w"  "*a"  "*r+"  "*w+"  "*a+"
          "*rb" "*wb" "*ab" "*r+b" "*w+b" "*a+b"
       end
 
@@ -226,6 +192,40 @@ do
       tmpfile: function(): FILE
       type: function(any): string
       write: function((string | number)...): FILE, string
+   end
+
+   global record FILE
+      is userdata
+
+      enum SeekWhence
+         "set" "cur" "end"
+      end
+
+      enum SetVBufMode
+         "no" "full" "line"
+      end
+
+      close: function(FILE): boolean, string, integer
+      flush: function(FILE)
+
+      lines: function(FILE): (function(): (string))
+      lines: function(FILE, FileNumberMode...): (function(): (number...))
+      lines: function(FILE, (number | FileStringMode)...): (function(): (string...))
+      lines: function(FILE, (number | FileMode)...): (function(): ((string | number)...))
+      lines: function(FILE, (number | string)...): (function(): (string...))
+
+      read: function(FILE): string
+      read: function(FILE, FileNumberMode...): number...
+      read: function(FILE, (number | FileStringMode)...): string...
+      read: function(FILE, (number | FileMode)...): ((string | number)...)
+      read: function(FILE, (number | string)...): (string...)
+
+      seek: function(FILE, ? SeekWhence, ? integer): integer, string
+      setvbuf: function(FILE, SetVBufMode, ? integer)
+
+      write: function(FILE, (string | number)...): FILE, string
+
+      metamethod __close: function(FILE)
    end
 
    global record math

--- a/tl.tl
+++ b/tl.tl
@@ -154,6 +154,7 @@ do
 
       traceback: function(thread, ? string, ? integer): string
       traceback: function(? string, ? integer): string
+      traceback: function(any): any
 
       upvalueid: function(AnyFunction, integer): userdata
       upvaluejoin: function(AnyFunction, integer, AnyFunction, integer)
@@ -426,7 +427,7 @@ do
          "b" "t" "bt"
       end
 
-      type XpcallMsghFunction = function(...: any): ()
+      type XpcallMsghFunction = function(any): any...
 
       arg: {string}
       assert: function<A, B>(A, ? B, ...: any): A --[[special_function]]
@@ -11614,7 +11615,7 @@ do
          local msgh_type = a_function(arg2, {
             min_arity = self.feat_arity and 1 or 0,
             args = a_tuple(arg2, { a_type(arg2, "any", {}) }),
-            rets = a_tuple(arg2, {})
+            rets = a_vararg(arg2, { a_type(arg2, "any", {}) })
          })
          self:assert_is_a(arg2, msgh, msgh_type, "in message handler")
       end


### PR DESCRIPTION
There are a few changes here:

- Various functions have been changed to have integer parameters/returns (utf8 library as well as some IO functions)
- IO functions now have multiple returns when they can error.
- `xpcall` and `pcall` now accept `debug.traceback` as the error handling function.
- the FILE type now can use `io.type` to allow `x is FILE`.
- `debug.getupvalue` and `debug.getuservalue` had incorrect returns.
- The tables inside `package` now have correct types.
- Added extra `ftransfer` and `ntransfer` to `debug.getinfo`'s return table. (these were introduced in 5.4, but they are only extra fields)
- Various iterator functions now have full returns (pairs, ipairs, io.lines)

I've also updated the types_spec test to be clearer.