### PR TITLE
Fix make with luarocks not working

### DIFF
--- a/spec/util.lua
+++ b/spec/util.lua
@@ -182,8 +182,10 @@ function util.assert_line_by_line(s1, s2)
 end
 
 local vars_prefix = { util.os_set("LUA_PATH", util.os_path(package.path)) .. util.os_join }
+table.insert(vars_prefix, util.os_set("LUA_CPATH", util.os_path(package.cpath)) .. util.os_join)
 for i = 1, 4 do
    table.insert(vars_prefix, util.os_set("LUA_PATH_5_" .. tostring(i), util.os_path(package.path)) .. util.os_join)
+   table.insert(vars_prefix, util.os_set("LUA_CPATH_5_" .. tostring(i), util.os_path(package.cpath)) .. util.os_join)
 end
 
 local first_arg = 0

--- a/tl
+++ b/tl
@@ -10,8 +10,8 @@ do
    -- get the whole API into package.loaded
    require("teal")
 
+   require("tlcli.main")({...})
+
    -- but otherwise don't pollute package.path inadvertedly
    package.path = save_package_path
 end
-
-require("tlcli.main")({...})


### PR DESCRIPTION
Before this fix, teal would get confused when you would do `make LUA=./lua` where `./lua` would be the local lua scripts that luarocks make, because the actual teal transpiler uses the modules from `./teal` but `tlcli` would use it from `./lua_modules/bin/share/lua/5.X` which causes errors. Furthermore, the tests only set `package.path`, not `package.cpath` which made them fail if the modules (`lfs`) was only in `lua_modules`