### PR TITLE
CI: cache luarocks folder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
     - uses: luarocks/gh-actions-luarocks@master
 
     - name: Restore cached LuaRocks packages
+      id: cache
       uses: actions/cache/restore@v4
       with:
         path: ${{ runner.os == 'Windows' && 'C:\\Users\\runneradmin\\AppData\\Roaming\\luarocks' || format('{0}/.luarocks', github.workspace) }}
@@ -45,6 +46,7 @@ jobs:
         luarocks test
 
     - name: Save LuaRocks packages
+      if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v4
       with:
         path: ${{ runner.os == 'Windows' && 'C:\\Users\\runneradmin\\AppData\\Roaming\\luarocks' || format('{0}/.luarocks', github.workspace) }}


### PR DESCRIPTION
Should fix #858.

I went for the whole folder instead of just Busted and it's dependencies because doing just Busted would've left me trying to reference multiple specific paths per platform and that felt way too messy. Hope that's ok.