### PR TITLE
Fix duplicate interfaces in interface_list for diamond inheritance

### DIFF
--- a/spec/lang/subtyping/interface_spec.lua
+++ b/spec/lang/subtyping/interface_spec.lua
@@ -256,4 +256,32 @@ describe("subtyping of interfaces:", function()
       local _a: A = { "a", "b" }
       local _b: B = { "c" }
    ]]))
+
+   it("no duplicate interfaces in interface_list with diamond inheritance", util.check([[
+      local interface A
+         a: number
+      end
+
+      local interface B is A
+         b: string
+      end
+
+      local interface C is A
+         c: boolean
+      end
+
+      -- This should result in interface_list: {B, A, C} (no duplicate A)
+      local record D is B, C
+         d: integer
+      end
+
+      -- Test that all fields are accessible
+      local d: D = {
+         a = 1,    -- from A (via B and C)
+         b = "hi", -- from B
+         c = true, -- from C
+         d = 42    -- from D
+      }
+      print(d.a, d.b, d.c, d.d)
+   ]]))
 end)

--- a/teal/check/context.lua
+++ b/teal/check/context.lua
@@ -1496,10 +1496,12 @@ do
             if iface.typename == "nominal" then
                local ri = self:resolve_nominal(iface)
                if ri.typename == "interface" then
-                  table.insert(list, iface)
-                  if ri.interfaces_expanded and not seen[ri] then
+                  if not seen[ri] then
                      seen[ri] = true
-                     collect_interfaces(self, list, ri, seen)
+                     table.insert(list, iface)
+                     if ri.interfaces_expanded then
+                        collect_interfaces(self, list, ri, seen)
+                     end
                   end
                else
                   self.errs:add(iface, "attempted to use %s as interface, but its type is %s", iface, ri)

--- a/teal/check/context.tl
+++ b/teal/check/context.tl
@@ -1496,10 +1496,12 @@ do
             if iface is NominalType then
                local ri = self:resolve_nominal(iface)
                if ri is InterfaceType then
-                  table.insert(list, iface)
-                  if ri.interfaces_expanded and not seen[ri] then
+                  if not seen[ri] then
                      seen[ri] = true
-                     collect_interfaces(self, list, ri, seen)
+                     table.insert(list, iface)
+                     if ri.interfaces_expanded then
+                        collect_interfaces(self, list, ri, seen)
+                     end
                   end
                else
                   self.errs:add(iface, "attempted to use %s as interface, but its type is %s", iface, ri)

--- a/tl.lua
+++ b/tl.lua
@@ -1942,10 +1942,12 @@ do
             if iface.typename == "nominal" then
                local ri = self:resolve_nominal(iface)
                if ri.typename == "interface" then
-                  table.insert(list, iface)
-                  if ri.interfaces_expanded and not seen[ri] then
+                  if not seen[ri] then
                      seen[ri] = true
-                     collect_interfaces(self, list, ri, seen)
+                     table.insert(list, iface)
+                     if ri.interfaces_expanded then
+                        collect_interfaces(self, list, ri, seen)
+                     end
                   end
                else
                   self.errs:add(iface, "attempted to use %s as interface, but its type is %s", iface, ri)


### PR DESCRIPTION
When records inherit from multiple interfaces that share a common parent interface (diamond inheritance), the interface_list was incorrectly containing duplicate entries. For example:

    local interface A end
    local interface B is A end
    local interface C is A end
    local record D is B, C end  -- interface_list was {B, A, C, A}

This was caused by the collect_interfaces function adding interfaces to the list before checking if they had already been seen. The fix ensures that interfaces are only added to the list if they haven't been processed before, maintaining the correct order while eliminating duplicates.

The interface_list for the example above now correctly contains {B, A, C}.

Changes:
- Fixed collect_interfaces() in context.lua and tl.lua to check seen[] before insert
- Added comprehensive test case for diamond inheritance scenarios
- Preserves interface order for proper conflict resolution

Fixes the issue where duplicate entries appeared in complex interface hierarchies while maintaining deterministic behavior for type checking.