### PR TITLE
Type checking error when using include_dir on windows

### DIFF
--- a/spec/lang/subtyping/interface_spec.lua
+++ b/spec/lang/subtyping/interface_spec.lua
@@ -256,4 +256,32 @@ describe("subtyping of interfaces:", function()
       local _a: A = { "a", "b" }
       local _b: B = { "c" }
    ]]))
+
+   it("no duplicate interfaces in interface_list with diamond inheritance", util.check([[
+      local interface A
+         a: number
+      end
+
+      local interface B is A
+         b: string
+      end
+
+      local interface C is A
+         c: boolean
+      end
+
+      -- This should result in interface_list: {B, A, C} (no duplicate A)
+      local record D is B, C
+         d: integer
+      end
+
+      -- Test that all fields are accessible
+      local d: D = {
+         a = 1,    -- from A (via B and C)
+         b = "hi", -- from B
+         c = true, -- from C
+         d = 42    -- from D
+      }
+      print(d.a, d.b, d.c, d.d)
+   ]]))
 end)

--- a/teal/check/context.lua
+++ b/teal/check/context.lua
@@ -1496,10 +1496,12 @@ do
             if iface.typename == "nominal" then
                local ri = self:resolve_nominal(iface)
                if ri.typename == "interface" then
-                  table.insert(list, iface)
-                  if ri.interfaces_expanded and not seen[ri] then
+                  if not seen[ri] then
                      seen[ri] = true
-                     collect_interfaces(self, list, ri, seen)
+                     table.insert(list, iface)
+                     if ri.interfaces_expanded then
+                        collect_interfaces(self, list, ri, seen)
+                     end
                   end
                else
                   self.errs:add(iface, "attempted to use %s as interface, but its type is %s", iface, ri)

--- a/teal/check/context.tl
+++ b/teal/check/context.tl
@@ -1496,10 +1496,12 @@ do
             if iface is NominalType then
                local ri = self:resolve_nominal(iface)
                if ri is InterfaceType then
-                  table.insert(list, iface)
-                  if ri.interfaces_expanded and not seen[ri] then
+                  if not seen[ri] then
                      seen[ri] = true
-                     collect_interfaces(self, list, ri, seen)
+                     table.insert(list, iface)
+                     if ri.interfaces_expanded then
+                        collect_interfaces(self, list, ri, seen)
+                     end
                   end
                else
                   self.errs:add(iface, "attempted to use %s as interface, but its type is %s", iface, ri)

--- a/tl.lua
+++ b/tl.lua
@@ -1942,10 +1942,12 @@ do
             if iface.typename == "nominal" then
                local ri = self:resolve_nominal(iface)
                if ri.typename == "interface" then
-                  table.insert(list, iface)
-                  if ri.interfaces_expanded and not seen[ri] then
+                  if not seen[ri] then
                      seen[ri] = true
-                     collect_interfaces(self, list, ri, seen)
+                     table.insert(list, iface)
+                     if ri.interfaces_expanded then
+                        collect_interfaces(self, list, ri, seen)
+                     end
                   end
                else
                   self.errs:add(iface, "attempted to use %s as interface, but its type is %s", iface, ri)


### PR DESCRIPTION
Fix path normalization issue causing type mismatches on Windows

The same type was being seen as mismatching because of different path
representations, even though the paths referred to the same file.
For example, "src\cc.d.tl:6" vs ".\src/cc.d.tl:6" would be treated
as different files, causing type comparison failures.

Changes:
- Move normalize function from tlcli/common.tl to teal/util.tl to make
  it available to the core type checking system
- Update search_for() in require_file.tl to normalize returned paths
- Update input.check() to normalize filenames before processing
- Update search_and_load() to normalize paths before storing in cache
- Add test case for path normalization with different separators

This ensures all file paths are converted to a canonical form before
being used for type checking, file loading, and module resolution,
preventing the same file from being treated as different files when
referenced with different path representations.

Fixes the issue where global_env_def modules would cause type errors
on Windows due to inconsistent path normalization between backslashes
and forward slashes, relative and absolute paths.