### PR TITLE
feat: implement no_stdlib option

### DIFF
--- a/docs/project-words.txt
+++ b/docs/project-words.txt
@@ -53,6 +53,7 @@ recordkey
 retlist
 retstat
 setmetatable
+stdlib
 subtyping
 tableconstructor
 tlconfig

--- a/docs/src/compiler_options.md
+++ b/docs/src/compiler_options.md
@@ -29,6 +29,7 @@ return {
 | `--wdisable`         | `disable_warnings`         | `{string}` | `check` `run`        | Disable the given warnings.
 | `--werror`           | `warning_error`            | `{string}` | `check` `run`        | Promote the given warnings to errors.
 | `--global-env-def`   | `global_env_def`           | `string`   | `check` `gen` `run`  | Specify a definition module declaring any custom globals predefined in your Lua environment. See the [declaration files](declaration_files.md#global-environment-definition) page for details. |
+| `--no-stdlib`        | `no_stdlib`                | `boolean`  | `check` `gen` `run`  | Don't include the standard library definitions in the type checker. This is useful when using a custom environment that differs from the PUC-Rio Lua standard library. |
 
 ### Generated code
 

--- a/spec/cli/no_stdlib_spec.lua
+++ b/spec/cli/no_stdlib_spec.lua
@@ -1,0 +1,34 @@
+local assert = require("luassert")
+local util = require("spec.util")
+
+describe("--no-stdlib argument", function()
+   it("prevent the Lua stdlib to be used", function()
+      util.do_in(util.write_tmp_dir(finally, {
+         ["test.tl"] = [[
+                print("hello world")
+            ]],
+      }), function()
+         local pd = io.popen(util.tl_cmd("check", "--no-stdlib", "test.tl") .. " 2>&1 1>" .. util.os_null, "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(1, pd:close())
+         assert.match("1 error:", output, 1, true)
+      end)
+   end)
+   it("reads no_std from tlconfig.lua", function()
+      util.do_in(util.write_tmp_dir(finally, {
+         ["test.tl"] = [[
+                print("hello world")
+            ]],
+         ["tlconfig.lua"] = [[
+                return {
+                    no_stdlib = true,
+                }
+            ]],
+      }), function()
+         local pd = io.popen(util.tl_cmd("check", "test.tl") .. " 2>&1 1>" .. util.os_null, "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(1, pd:close())
+         assert.match("1 error:", output, 1, true)
+      end)
+   end)
+end)

--- a/spec/cli/no_stdlib_spec.lua
+++ b/spec/cli/no_stdlib_spec.lua
@@ -2,11 +2,11 @@ local assert = require("luassert")
 local util = require("spec.util")
 
 describe("--no-stdlib argument", function()
-   it("prevent the Lua stdlib to be used", function()
+   it("prevents the Lua stdlib from being used", function()
       util.do_in(util.write_tmp_dir(finally, {
          ["test.tl"] = [[
-                print("hello world")
-            ]],
+            print("hello world")
+         ]],
       }), function()
          local pd = io.popen(util.tl_cmd("check", "--no-stdlib", "test.tl") .. " 2>&1 1>" .. util.os_null, "r")
          local output = pd:read("*a")
@@ -14,21 +14,40 @@ describe("--no-stdlib argument", function()
          assert.match("1 error:", output, 1, true)
       end)
    end)
+
    it("reads no_std from tlconfig.lua", function()
       util.do_in(util.write_tmp_dir(finally, {
          ["test.tl"] = [[
-                print("hello world")
-            ]],
+            print("hello world")
+         ]],
          ["tlconfig.lua"] = [[
-                return {
-                    no_stdlib = true,
-                }
+               return {
+                  no_stdlib = true,
+               }
             ]],
       }), function()
          local pd = io.popen(util.tl_cmd("check", "test.tl") .. " 2>&1 1>" .. util.os_null, "r")
          local output = pd:read("*a")
          util.assert_popen_close(1, pd:close())
          assert.match("1 error:", output, 1, true)
+      end)
+   end)
+
+   it("keeps prelude available when --no-stdlib is used", function()
+      util.do_in(util.write_tmp_dir(finally, {
+         ["test.tl"] = [[
+            local function id(x: any): any return x end
+            local record Rec end
+            local rec_mt: metatable<Rec>
+         ]],
+      }), function()
+         local pd = io.popen(util.tl_cmd("check", "--no-stdlib", "test.tl") .. " 2>&1 1>" .. util.os_null, "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(0, pd:close())
+         assert.match("2 warnings", output, 1, t1, true)
+         -- 2 warnings:
+         -- test.tl:1:13: unused function id: function(<any type>): <any type>
+         -- test.tl:3:19: unused variable rec_mt: metatable<Rec>
       end)
    end)
 end)

--- a/teal/check/context.lua
+++ b/teal/check/context.lua
@@ -1613,6 +1613,7 @@ do
 
             self.errs:add(t, string.format("inherits incompatible array %s and tuple %s", array_type_str, tuple_type_str))
          else
+
             self.errs:add_warning("inheritance", t, "inherits overlapping array %s and tuple %s", array_type_str, tuple_type_str)
          end
       end

--- a/teal/environment.lua
+++ b/teal/environment.lua
@@ -87,6 +87,7 @@ local environment = { EnvOptions = {}, Env = {}, Result = {} }
 
 
 
+
 environment.VERSION = VERSION
 environment.DEFAULT_GEN_COMPAT = "optional"
 environment.DEFAULT_GEN_TARGET = "5.3"
@@ -140,7 +141,9 @@ end
 function environment.new(opts)
    local env = empty_environment()
    env.opts = opts or env.opts
-   load_precompiled_default_env(env)
+   if not env.opts.no_stdlib then
+      load_precompiled_default_env(env)
+   end
    return env
 end
 

--- a/teal/environment.lua
+++ b/teal/environment.lua
@@ -143,6 +143,10 @@ function environment.new(opts)
    env.opts = opts or env.opts
    if not env.opts.no_stdlib then
       load_precompiled_default_env(env)
+   else
+
+
+      env:require_module("teal.default.prelude")
    end
    return env
 end

--- a/teal/environment.tl
+++ b/teal/environment.tl
@@ -143,6 +143,10 @@ function environment.new(opts?: EnvOptions): Env
    env.opts = opts or env.opts
    if not env.opts.no_stdlib then
       load_precompiled_default_env(env)
+   else
+      -- We still need to load the prelude, which contains language fundamental
+      -- definitions that should always be available.
+      env:require_module("teal.default.prelude")
    end
    return env
 end

--- a/teal/environment.tl
+++ b/teal/environment.tl
@@ -51,6 +51,7 @@ local record environment
       gen_compat: GenCompat
       gen_target: GenTarget
       run_internal_compiler_checks: boolean
+      no_stdlib: boolean
    end
 
    type RequireModuleFn = function(env: Env, module_name: string): Type, string
@@ -140,7 +141,9 @@ end
 function environment.new(opts?: EnvOptions): Env
    local env = empty_environment()
    env.opts = opts or env.opts
-   load_precompiled_default_env(env)
+   if not env.opts.no_stdlib then
+      load_precompiled_default_env(env)
+   end
    return env
 end
 

--- a/teal/init.lua
+++ b/teal/init.lua
@@ -132,6 +132,7 @@ local teal = { CheckError = {}, Compiler = {}, Input = {}, TokenList = {}, Parse
 
 
 
+
 local Compiler = teal.Compiler
 local Module = teal.Module
 
@@ -369,6 +370,7 @@ function teal.compiler(opts)
       feat_arity = opts and opts.feat_arity,
       gen_compat = opts and opts.gen_compat,
       gen_target = opts and opts.gen_target,
+      no_stdlib = opts and not not opts.no_stdlib,
    }
 
    compiler.env = environment.new(env_opts)

--- a/teal/init.tl
+++ b/teal/init.tl
@@ -120,6 +120,7 @@ local record teal
       feat_arity: Feat
       gen_compat: GenCompat
       gen_target: GenTarget
+      no_stdlib: boolean
    end
 
    compiler: function(opts?: CompilerOptions): Compiler
@@ -369,6 +370,7 @@ function teal.compiler(opts?: CompilerOptions): Compiler
       feat_arity = opts and opts.feat_arity,
       gen_compat = opts and opts.gen_compat,
       gen_target = opts and opts.gen_target,
+      no_stdlib = opts and not not opts.no_stdlib,
    }
 
    compiler.env = environment.new(env_opts)

--- a/tl.lua
+++ b/tl.lua
@@ -10666,6 +10666,10 @@ function environment.new(opts)
    env.opts = opts or env.opts
    if not env.opts.no_stdlib then
       load_precompiled_default_env(env)
+   else
+
+
+      env:require_module("teal.default.prelude")
    end
    return env
 end

--- a/tl.lua
+++ b/tl.lua
@@ -4924,6 +4924,7 @@ do
 
             self.errs:add(t, string.format("inherits incompatible array %s and tuple %s", array_type_str, tuple_type_str))
          else
+
             self.errs:add_warning("inheritance", t, "inherits overlapping array %s and tuple %s", array_type_str, tuple_type_str)
          end
       end
@@ -10609,6 +10610,7 @@ local environment = { EnvOptions = {}, Env = {}, Result = {} }
 
 
 
+
 environment.VERSION = VERSION
 environment.DEFAULT_GEN_COMPAT = "optional"
 environment.DEFAULT_GEN_TARGET = "5.3"
@@ -10662,7 +10664,9 @@ end
 function environment.new(opts)
    local env = empty_environment()
    env.opts = opts or env.opts
-   load_precompiled_default_env(env)
+   if not env.opts.no_stdlib then
+      load_precompiled_default_env(env)
+   end
    return env
 end
 

--- a/tlcli/args.d.tl
+++ b/tlcli/args.d.tl
@@ -7,6 +7,7 @@ local record Args
    file: {string}
    gen_target: string
    gen_compat: string
+   no_stdlib: boolean
    global_env_def: {string} -- FIXME should be `string`, but argparse can't handle `:count("0-1")`?...
    include_dir: {string}
    keep_hashbang: boolean

--- a/tlcli/configuration.lua
+++ b/tlcli/configuration.lua
@@ -80,6 +80,7 @@ local function validate_config(config)
       gen_target = { ["5.1"] = true, ["5.3"] = true, ["5.4"] = true },
       disable_warnings = "{string}",
       warning_error = "{string}",
+      no_stdlib = "boolean",
    }
 
    local function check_key(k, v)
@@ -236,6 +237,8 @@ function configuration.merge_config_and_args(tlconfig, args)
    tlconfig["gen_target"] = args["gen_target"] or tlconfig["gen_target"]
    tlconfig["gen_compat"] = args["gen_compat"] or tlconfig["gen_compat"] or
    (tlconfig["skip_compat53"] and "off")
+
+   tlconfig["no_stdlib"] = args["no_stdlib"] or tlconfig["no_stdlib"]
 
    if args["global_env_def"] then
       if #args["global_env_def"] > 1 then

--- a/tlcli/configuration.tl
+++ b/tlcli/configuration.tl
@@ -80,6 +80,7 @@ local function validate_config(config: {any:any}): TlConfig, {string}, {string}
       gen_target = { ["5.1"] = true, ["5.3"] = true, ["5.4"] = true },
       disable_warnings = "{string}",
       warning_error = "{string}",
+      no_stdlib = "boolean"
    }
 
    local function check_key(k: any, v: any)
@@ -236,6 +237,8 @@ function configuration.merge_config_and_args(tlconfig: TlConfig, args: Args)
    tlconfig["gen_target"] = args["gen_target"] or tlconfig["gen_target"]
    tlconfig["gen_compat"] = args["gen_compat"] or tlconfig["gen_compat"]
                                                or (tlconfig["skip_compat53"] and "off")
+
+   tlconfig["no_stdlib"] = args["no_stdlib"] or tlconfig["no_stdlib"]
 
    if args["global_env_def"] then
       if #args["global_env_def"] > 1 then

--- a/tlcli/driver.lua
+++ b/tlcli/driver.lua
@@ -40,6 +40,7 @@ function driver.setup_compiler(tlconfig)
       feat_arity = tlconfig["feat_arity"],
       gen_compat = tlconfig["gen_compat"],
       gen_target = tlconfig["gen_target"],
+      no_stdlib = tlconfig["no_stdlib"] == true,
    }
 
    if opts.gen_target == "5.4" and opts.gen_compat ~= "off" then

--- a/tlcli/driver.tl
+++ b/tlcli/driver.tl
@@ -40,6 +40,7 @@ function driver.setup_compiler(tlconfig: TlConfig): teal.Compiler
       feat_arity = tlconfig["feat_arity"] as teal.Feat,
       gen_compat = tlconfig["gen_compat"] as teal.GenCompat,
       gen_target = tlconfig["gen_target"] as teal.GenTarget,
+      no_stdlib = tlconfig["no_stdlib"] == true,
    }
 
    if opts.gen_target == "5.4" and opts.gen_compat ~= "off" then

--- a/tlcli/main.lua
+++ b/tlcli/main.lua
@@ -18,6 +18,8 @@ local function get_args_parser()
    argname("<dtlfilename>"):
    count("*")
 
+   parser:flag("--no-stdlib", "Do not load the Lua standard library.")
+
    parser:option("-I --include-dir", "Prepend this directory to the module search path."):
    argname("<directory>"):
    count("*")

--- a/tlcli/main.tl
+++ b/tlcli/main.tl
@@ -17,6 +17,8 @@ local function get_args_parser(): argparse.Parser
    parser:option("--global-env-def", "Predefined types from a custom global environment.")
          :argname("<dtlfilename>")
          :count("*") -- `:count("0-1")` does not work? we verify by hand later then
+            
+   parser:flag("--no-stdlib", "Do not load the Lua standard library.")
 
    parser:option("-I --include-dir", "Prepend this directory to the module search path.")
          :argname("<directory>")

--- a/tlcli/tlconfig.d.tl
+++ b/tlcli/tlconfig.d.tl
@@ -4,6 +4,7 @@ local record TlConfig
    feat_arity: string
    gen_target: string
    gen_compat: string
+   no_stdlib: boolean
    global_env_def: string
    pretend: boolean
    quiet: boolean


### PR DESCRIPTION
Hello, this is a new version for the https://github.com/teal-language/tl/pull/961 I started a while back, but lacked understanding/direction to complete the implementation.

Thank you, @hishamhm for the work on decoupling the stdlib from the default types, and for your latest messages on https://github.com/teal-language/tl/issues/532 that gave me the missing pointers I needed.

This PR adds a new option `no_stdlib` (exposed to the user by CLI arg and by tlconfig field) to disable the stdlib loading by skipping `load_precompiled_default_env`.

Notes: In combination with `global_env_def`, this effectively allow redefining the stdlib. By itself, I think this solves most problems related to using Teal in custom/embedded environments. For next steps, we could allow controlling the precompiled `default_env` by either exposing it to user, or adding new `teal/default/*.d.tl` and `teal/precompiled/` definitions.