### PR TITLE
Add detection of conflicting global type redefinitions

### DIFF
--- a/spec/lang/declaration/global_spec.lua
+++ b/spec/lang/declaration/global_spec.lua
@@ -205,6 +205,105 @@ describe("global", function()
       end)
    end)
 
+   describe("redeclared type", function()
+      it("fails if a global record is redeclared with different fields", util.check_type_error([[
+         global record Widget
+            id: integer
+         end
+
+         global record Widget
+            name: string
+         end
+      ]], {
+         { msg = "cannot redeclare global with a different type" },
+      }))
+
+      it("works if a global record is redeclared with the same fields", util.check([[
+         global record Widget
+            id: integer
+         end
+
+         global record Widget
+            id: integer
+         end
+      ]]))
+
+      it("works if a global generic record is redeclared identically", util.check([[
+         global record Foo<R>
+            item: R
+         end
+
+         global record Foo<R>
+            item: R
+         end
+      ]]))
+
+      it("fails if a global type alias is redeclared with a different type", util.check_type_error([[
+         global type X = number
+         global type X = string
+      ]], {
+         { msg = "cannot redeclare global with a different type" },
+      }))
+
+      it("does not crash when a global type alias is redeclared identically", util.check([[
+         global record Widget
+            id: integer
+         end
+
+         global type Handle = Widget
+         global type Handle = Widget
+      ]]))
+
+      it("fails if a global type alias is redeclared pointing at a different type", util.check_type_error([[
+         global record Widget
+            id: integer
+         end
+
+         global record Gadget
+            name: string
+         end
+
+         global type Handle = Widget
+         global type Handle = Gadget
+      ]], {
+         { msg = "cannot redeclare global with a different type" },
+      }))
+
+      it("fails if a global record is redeclared with different fields across files", function()
+         util.mock_io(finally, {
+            ["foo.tl"] = [[
+               global record Widget
+                  id: integer
+               end
+            ]]
+         })
+         util.run_check_type_error([[
+            local foo = require("foo")
+            global record Widget
+               name: string
+            end
+         ]], {
+            { msg = "cannot redeclare global with a different type" },
+         })
+      end)
+
+      it("does not crash when a global type alias is redeclared across files", function()
+         util.mock_io(finally, {
+            ["foo.tl"] = [[
+               global record Widget
+                  id: integer
+               end
+
+               global type Handle = Widget
+            ]],
+         })
+         util.run_check([[
+            local foo = require("foo")
+            global type Handle = Widget
+         ]])
+      end)
+   end)
+
    describe("with types", function()
       it("can be forward-declared to resolve circular type dependencies", function()
          util.mock_io(finally, {

--- a/teal/check/relations.lua
+++ b/teal/check/relations.lua
@@ -425,6 +425,11 @@ relations.eqtype_relations = {
       end,
       ["emptytable"] = compare_true_inferring_emptytable_if_not_userdata,
    },
+   ["typedecl"] = {
+      ["typedecl"] = function(ck, a, b)
+         return ck:same_type(a.def, b.def)
+      end,
+   },
    ["function"] = {
       ["function"] = function(ck, a, b)
          local argdelta = a.is_method and 1 or 0

--- a/teal/check/relations.tl
+++ b/teal/check/relations.tl
@@ -425,6 +425,11 @@ relations.eqtype_relations = {
       end,
       ["emptytable"] = compare_true_inferring_emptytable_if_not_userdata,
    },
+   ["typedecl"] = {
+      ["typedecl"] = function(ck: TypeChecker, a: TypeDeclType, b: TypeDeclType): boolean, {Error}
+         return ck:same_type(a.def, b.def)
+      end,
+   },
    ["function"] = {
       ["function"] = function(ck:TypeChecker, a: FunctionType, b: FunctionType): boolean, {Error}
          local argdelta = a.is_method and 1 or 0

--- a/teal/check/visitors.lua
+++ b/teal/check/visitors.lua
@@ -836,7 +836,7 @@ visit_node.cbs = {
             if resolved.typename == "invalid" then
                return
             end
-            if aliasing then
+            if added and aliasing then
                added.aliasing = aliasing
             end
 

--- a/teal/check/visitors.tl
+++ b/teal/check/visitors.tl
@@ -836,7 +836,7 @@ visit_node.cbs = {
             if resolved is InvalidType then
                return
             end
-            if aliasing then
+            if added and aliasing then
                added.aliasing = aliasing
             end
 

--- a/tl.lua
+++ b/tl.lua
@@ -6051,6 +6051,11 @@ relations.eqtype_relations = {
       end,
       ["emptytable"] = compare_true_inferring_emptytable_if_not_userdata,
    },
+   ["typedecl"] = {
+      ["typedecl"] = function(ck, a, b)
+         return ck:same_type(a.def, b.def)
+      end,
+   },
    ["function"] = {
       ["function"] = function(ck, a, b)
          local argdelta = a.is_method and 1 or 0
@@ -8364,7 +8369,7 @@ visit_node.cbs = {
             if resolved.typename == "invalid" then
                return
             end
-            if aliasing then
+            if added and aliasing then
                added.aliasing = aliasing
             end
 


### PR DESCRIPTION
Initially, I ran into the crash described in #1126. 
My first idea was to simply ignore duplicate declarations. That would be fine for identical types. 

But what if we wanted to do something like this:

```teal
global record Widget
  id: integer
end

global record Gadget
  name: string
end

global type Handle = Widget
global type Handle = Gadget
```

Simply ignoring the duplicate declaration would be a footgun here. 

And that's where I ran into another problem. Related to #1032. Currently, redeclaring a `global` type (`record`, `interface`, or `type` alias) with a different definition isn't reported as an error, and the compiler keeps the first one it finds.

So let's fix that.

Resolves #1126.