### PR TITLE
fix: allow goto to a label at the end of a block

### DIFF
--- a/spec/lang/statement/goto_spec.lua
+++ b/spec/lang/statement/goto_spec.lua
@@ -141,4 +141,55 @@ describe("goto", function()
    ]], {
       { y = 2, msg = "goto jumps into scope of a local variable" }
    }))
+
+   it("accepts a goto over a local to a label at the end of a block", util.check([[
+      for i = 1, 5 do
+         goto next
+         local _this = i
+         ::next::
+      end
+   ]]))
+
+   it("accepts the continue idiom with locals in the loop body", util.check([[
+      for i = 1, 3 do
+         if i == 2 then
+            goto continue
+         end
+         local doubled = i * 2
+         print(doubled)
+         ::continue::
+      end
+   ]]))
+
+   it("accepts a goto over a local to stacked labels at the end of a block", util.check([[
+      do
+         goto first
+         local _foo = 0
+         ::first::
+         ::second::
+      end
+      local _bar = 0
+   ]]))
+
+   it("rejects a goto over a local to a label followed by return", util.check_type_error([[
+      local function f(): integer
+         goto finish
+         local _foo = 0
+         ::finish::
+         return 1
+      end
+      f()
+   ]], {
+      { y = 2, msg = "goto jumps into scope of a local variable" }
+   }))
+
+   it("rejects a goto over a local to a label at the end of a repeat body", util.check_type_error([[
+      repeat
+         goto continue
+         local _foo = 0
+         ::continue::
+      until true
+   ]], {
+      { y = 2, msg = "goto jumps into scope of a local variable" }
+   }))
 end)

--- a/teal/ast.lua
+++ b/teal/ast.lua
@@ -235,6 +235,7 @@ local parse_typeargs_if_any
 
 
 
+
 local ast = {}
 
 

--- a/teal/ast.tl
+++ b/teal/ast.tl
@@ -193,6 +193,7 @@ local record Node
 
    -- label
    used_label: boolean
+   is_end_of_block: boolean
 
    casttype: Type
 

--- a/teal/check/visitors.lua
+++ b/teal/check/visitors.lua
@@ -797,6 +797,19 @@ visit_node.cbs = {
    ["statements"] = {
       before = function(self, node)
          self:begin_scope(node)
+
+
+
+
+
+         if not node.is_repeat then
+            for i = #node, 1, -1 do
+               if node[i].kind ~= "label" then
+                  break
+               end
+               node[i].is_end_of_block = true
+            end
+         end
       end,
       after = function(self, node, _children)
 
@@ -1064,10 +1077,12 @@ visit_node.cbs = {
 
          local scope = self.st[#self.st]
          if scope.pending_labels and scope.pending_labels[label_id] then
-            local n_scope_vars = count_scope_vars(self)
-            for _, goto_node in ipairs(scope.pending_labels[label_id]) do
-               if n_scope_vars > goto_node.n_scope_vars then
-                  self.errs:add(goto_node, "goto jumps into scope of a local variable")
+            if not node.is_end_of_block then
+               local n_scope_vars = count_scope_vars(self)
+               for _, goto_node in ipairs(scope.pending_labels[label_id]) do
+                  if n_scope_vars > goto_node.n_scope_vars then
+                     self.errs:add(goto_node, "goto jumps into scope of a local variable")
+                  end
                end
             end
             node.used_label = true

--- a/teal/check/visitors.tl
+++ b/teal/check/visitors.tl
@@ -797,6 +797,19 @@ visit_node.cbs = {
    ["statements"] = {
       before = function(self: Context, node: Node)
          self:begin_scope(node)
+         -- a goto may jump to a label at the end of a block (followed only
+         -- by other labels) even across local declarations, because the
+         -- block's locals are already out of scope at that point. This does
+         -- not apply to a repeat body, whose locals remain visible in the
+         -- until condition.
+         if not node.is_repeat then
+            for i = #node, 1, -1 do
+               if node[i].kind ~= "label" then
+                  break
+               end
+               node[i].is_end_of_block = true
+            end
+         end
       end,
       after = function(self: Context, node: Node, _children: {Type}): Type
          -- if at the top level
@@ -1064,10 +1077,12 @@ visit_node.cbs = {
 
          local scope = self.st[#self.st]
          if scope.pending_labels and scope.pending_labels[label_id] then
-            local n_scope_vars = count_scope_vars(self)
-            for _, goto_node in ipairs(scope.pending_labels[label_id]) do
-               if n_scope_vars > goto_node.n_scope_vars then
-                  self.errs:add(goto_node, "goto jumps into scope of a local variable")
+            if not node.is_end_of_block then
+               local n_scope_vars = count_scope_vars(self)
+               for _, goto_node in ipairs(scope.pending_labels[label_id]) do
+                  if n_scope_vars > goto_node.n_scope_vars then
+                     self.errs:add(goto_node, "goto jumps into scope of a local variable")
+                  end
                end
             end
             node.used_label = true

--- a/tl.lua
+++ b/tl.lua
@@ -497,6 +497,7 @@ local parse_typeargs_if_any
 
 
 
+
 local ast = {}
 
 
@@ -8325,6 +8326,19 @@ visit_node.cbs = {
    ["statements"] = {
       before = function(self, node)
          self:begin_scope(node)
+
+
+
+
+
+         if not node.is_repeat then
+            for i = #node, 1, -1 do
+               if node[i].kind ~= "label" then
+                  break
+               end
+               node[i].is_end_of_block = true
+            end
+         end
       end,
       after = function(self, node, _children)
 
@@ -8592,10 +8606,12 @@ visit_node.cbs = {
 
          local scope = self.st[#self.st]
          if scope.pending_labels and scope.pending_labels[label_id] then
-            local n_scope_vars = count_scope_vars(self)
-            for _, goto_node in ipairs(scope.pending_labels[label_id]) do
-               if n_scope_vars > goto_node.n_scope_vars then
-                  self.errs:add(goto_node, "goto jumps into scope of a local variable")
+            if not node.is_end_of_block then
+               local n_scope_vars = count_scope_vars(self)
+               for _, goto_node in ipairs(scope.pending_labels[label_id]) do
+                  if n_scope_vars > goto_node.n_scope_vars then
+                     self.errs:add(goto_node, "goto jumps into scope of a local variable")
+                  end
                end
             end
             node.used_label = true


### PR DESCRIPTION
The goto validity check from #1121 rejected jumps over local declarations to a label at the end of a block, such as the common `goto continue` idiom. Lua permits this. A label followed only by other labels at the end of a block is outside the scope of the block's locals.

The relaxation does not apply to labels at the end of a repeat body, whose locals remain visible in the until condition, nor to labels followed by a return statement, matching PUC-Lua.