### PR TITLE
fix: include source_dir when checking modules

### DIFF
--- a/docs/src/compiler_options.md
+++ b/docs/src/compiler_options.md
@@ -22,6 +22,7 @@ return {
 | -------------------- | -------------------------- | ---------- | -------------------- | ----------- |
 | `-l --require`       |                            | `{string}` | `run`                | Require a module prior to executing the script. This is similar in behavior to the `-l` flag in the Lua interpreter. |
 | `-I --include-dir`   | `include_dir`              | `{string}` | `check` `gen` `run`  | Prepend this directory to the module search path.
+|                      | `source_dir`               | `string`   | `check` `gen` `run`  | Set the project source directory and add it to the module search path.
 | `--gen-compat`       | `gen_compat`               | `string`   | `gen` `run`          | Generate compatibility code for targeting different Lua VM versions. See [below](#generated-code) for details.
 | `--gen-target`       | `gen_target`               | `string`   | `gen` `run`          | Minimum targeted Lua version for generated code. Options are `5.1`, `5.3` and `5.4`. See [below](#generated-code) for details.
 | `--keep-hashbang`    |                            |            | `gen`                | Preserve hashbang line (`#!`) at the top of file if present.
@@ -30,6 +31,11 @@ return {
 | `--werror`           | `warning_error`            | `{string}` | `check` `run`        | Promote the given warnings to errors.
 | `--global-env-def`   | `global_env_def`           | `string`   | `check` `gen` `run`  | Specify a definition module declaring any custom globals predefined in your Lua environment. See the [declaration files](declaration_files.md#global-environment-definition) page for details. |
 | `--no-stdlib`        | `no_stdlib`                | `boolean`  | `check` `gen` `run`  | Don't include the standard library definitions in the type checker. This is useful when using a custom environment that differs from the PUC-Rio Lua standard library. |
+
+When `source_dir` is set in `tlconfig.lua`, Teal also uses it when resolving
+required modules. This lets a project keep its modules under a source directory
+such as `src` without repeating that directory in `include_dir`; any explicit
+`include_dir` entries are preserved.
 
 ### Generated code
 

--- a/spec/cli/include_dir_spec.lua
+++ b/spec/cli/include_dir_spec.lua
@@ -2,6 +2,51 @@ local assert = require("luassert")
 local util = require("spec.util")
 
 describe("-I --include-dir argument", function()
+   it("adds source_dir from tlconfig.lua without replacing include_dir", function()
+      util.do_in(util.write_tmp_dir(finally, {
+         include = {
+            ["external.d.tl"] = [[
+               local record External
+                  name: string
+               end
+
+               return External
+            ]],
+         },
+         src = {
+            ["main.tl"] = [[
+               local vec = require("vec")
+               local type External = require("external")
+
+               local value = vec(1, 2)
+               local external: External = { name = "dependency" }
+               print(value.x, value.y, external.name)
+            ]],
+            ["vec.tl"] = [[
+               local record Vec
+                  x: number
+                  y: number
+               end
+
+               return function(x: number, y: number): Vec
+                  return { x = x, y = y }
+               end
+            ]],
+         },
+         ["tlconfig.lua"] = [[
+            return {
+               include_dir = { "include" },
+               source_dir = "src",
+            }
+         ]],
+      }), function()
+         local pd = io.popen(util.tl_cmd("check", "src/main.tl"), "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(0, pd:close())
+         assert.match("0 errors detected", output, 1, true)
+      end)
+   end)
+
    it("adds a directory to package.path", function()
       util.do_in(util.write_tmp_dir(finally, {
          mod = {

--- a/tlcli/configuration.lua
+++ b/tlcli/configuration.lua
@@ -72,6 +72,7 @@ local function validate_config(config)
 
    local valid_keys = {
       include_dir = "{string}",
+      source_dir = "string",
       global_env_def = "string",
       quiet = "boolean",
       skip_compat53 = "boolean",
@@ -216,6 +217,11 @@ function configuration.merge_config_and_args(tlconfig, args)
             enable(tlconfig._warning_errors_set, warning)
          end
       end
+   end
+
+   local source_dir = tlconfig["source_dir"]
+   if source_dir and not find_in_sequence(tlconfig.include_dir, source_dir) then
+      table.insert(tlconfig.include_dir, source_dir)
    end
 
    for _, include_dir_cli in ipairs(args["include_dir"]) do

--- a/tlcli/configuration.tl
+++ b/tlcli/configuration.tl
@@ -72,6 +72,7 @@ local function validate_config(config: {any:any}): TlConfig, {string}, {string}
 
    local valid_keys: {string:(string|{string:boolean})} = {
       include_dir = "{string}",
+      source_dir = "string",
       global_env_def = "string",
       quiet = "boolean",
       skip_compat53 = "boolean",
@@ -216,6 +217,11 @@ function configuration.merge_config_and_args(tlconfig: TlConfig, args: Args)
             enable(tlconfig._warning_errors_set, warning)
          end
       end
+   end
+
+   local source_dir = tlconfig["source_dir"]
+   if source_dir and not find_in_sequence(tlconfig.include_dir, source_dir) then
+      table.insert(tlconfig.include_dir, source_dir)
    end
 
    for _, include_dir_cli in ipairs(args["include_dir"]) do

--- a/tlcli/tlconfig.d.tl
+++ b/tlcli/tlconfig.d.tl
@@ -1,6 +1,7 @@
 local record TlConfig
    disable_warnings: {string}
    include_dir: {string}
+   source_dir: string
    feat_arity: string
    gen_target: string
    gen_compat: string


### PR DESCRIPTION
## Summary

- recognize `source_dir` as a validated string option in `tlconfig.lua`
- add `source_dir` to the effective module search path while preserving configured `include_dir` entries and CLI `-I` precedence
- add a CLI regression covering imports from both `source_dir` and `include_dir`

Fixes #1119.

## Testing

- `busted --suppress-pending -v spec/cli/include_dir_spec.lua` (3 successes)
- `luarocks lint tl-dev-2.rockspec`
- `make selfbuild`
- `luarocks test` (1924 successes, 0 failures, 9 pending)
- manual reproduction from #1119 with `source_dir = "src"` and a separate `include_dir`

## AI assistance

This contribution was implemented with assistance from OpenAI Codex. The reported failure was reproduced before the change, and the focused regression plus the full upstream test suite were run after it.