### PR TITLE
Fix incorrect `math.mininteger` polyfill

### DIFF
--- a/spec/cli/gen_spec.lua
+++ b/spec/cli/gen_spec.lua
@@ -379,7 +379,7 @@ describe("tl gen", function()
    ]]
 
    local output_code_with_optional_compat = [[
-      local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local math = _tl_compat and _tl_compat.math or math; local _tl_math_maxinteger = math.maxinteger or math.pow(2, 53); local _tl_math_mininteger = math.mininteger or -math.pow(2, 53) - 1; local table = _tl_compat and _tl_compat.table or table; local _tl_table_pack = table.pack or function(...) return { n = select("#", ...), ... } end; local _tl_table_unpack = unpack or table.unpack
+      local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local math = _tl_compat and _tl_compat.math or math; local _tl_math_maxinteger = math.maxinteger or math.pow(2, 53); local _tl_math_mininteger = math.mininteger or -math.pow(2, 53); local table = _tl_compat and _tl_compat.table or table; local _tl_table_pack = table.pack or function(...) return { n = select("#", ...), ... } end; local _tl_table_unpack = unpack or table.unpack
       local t = { 1, 2, 3, 4 }
       print(_tl_table_unpack(t))
       local t2 = _tl_table_pack(1, 2, "any")
@@ -401,7 +401,7 @@ describe("tl gen", function()
    ]]
 
    local output_code_with_required_compat = [[
-      local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = true, require('compat53.module'); if p then _tl_compat = m end end; local math = _tl_compat and _tl_compat.math or math; local _tl_math_maxinteger = math.maxinteger or math.pow(2, 53); local _tl_math_mininteger = math.mininteger or -math.pow(2, 53) - 1; local table = _tl_compat and _tl_compat.table or table; local _tl_table_pack = table.pack or function(...) return { n = select("#", ...), ... } end; local _tl_table_unpack = unpack or table.unpack
+      local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = true, require('compat53.module'); if p then _tl_compat = m end end; local math = _tl_compat and _tl_compat.math or math; local _tl_math_maxinteger = math.maxinteger or math.pow(2, 53); local _tl_math_mininteger = math.mininteger or -math.pow(2, 53); local table = _tl_compat and _tl_compat.table or table; local _tl_table_pack = table.pack or function(...) return { n = select("#", ...), ... } end; local _tl_table_unpack = unpack or table.unpack
       local t = { 1, 2, 3, 4 }
       print(_tl_table_unpack(t))
       local t2 = _tl_table_pack(1, 2, "any")

--- a/teal.lua
+++ b/teal.lua
@@ -11106,7 +11106,7 @@ local function add_compat_entries(program, used_set, gen_compat)
       elseif name == "math.maxinteger" then
          load_code(name, "local _tl_math_maxinteger = math.maxinteger or math.pow(2,53)")
       elseif name == "math.mininteger" then
-         load_code(name, "local _tl_math_mininteger = math.mininteger or -math.pow(2,53) - 1")
+         load_code(name, "local _tl_math_mininteger = math.mininteger or -math.pow(2,53)")
       elseif name == "type" then
          load_code(name, "local type = type")
       else

--- a/teal/gen/lua_compat.lua
+++ b/teal/gen/lua_compat.lua
@@ -69,7 +69,7 @@ local function add_compat_entries(program, used_set, gen_compat)
       elseif name == "math.maxinteger" then
          load_code(name, "local _tl_math_maxinteger = math.maxinteger or math.pow(2,53)")
       elseif name == "math.mininteger" then
-         load_code(name, "local _tl_math_mininteger = math.mininteger or -math.pow(2,53) - 1")
+         load_code(name, "local _tl_math_mininteger = math.mininteger or -math.pow(2,53)")
       elseif name == "type" then
          load_code(name, "local type = type")
       else

--- a/teal/gen/lua_compat.tl
+++ b/teal/gen/lua_compat.tl
@@ -69,7 +69,7 @@ local function add_compat_entries(program: Node, used_set: {string: boolean}, ge
       elseif name == "math.maxinteger" then
          load_code(name, "local _tl_math_maxinteger = math.maxinteger or math.pow(2,53)")
       elseif name == "math.mininteger" then
-         load_code(name, "local _tl_math_mininteger = math.mininteger or -math.pow(2,53) - 1")
+         load_code(name, "local _tl_math_mininteger = math.mininteger or -math.pow(2,53)")
       elseif name == "type" then
          load_code(name, "local type = type")
       else

--- a/tl.lua
+++ b/tl.lua
@@ -11366,7 +11366,7 @@ local function add_compat_entries(program, used_set, gen_compat)
       elseif name == "math.maxinteger" then
          load_code(name, "local _tl_math_maxinteger = math.maxinteger or math.pow(2,53)")
       elseif name == "math.mininteger" then
-         load_code(name, "local _tl_math_mininteger = math.mininteger or -math.pow(2,53) - 1")
+         load_code(name, "local _tl_math_mininteger = math.mininteger or -math.pow(2,53)")
       elseif name == "type" then
          load_code(name, "local type = type")
       else


### PR DESCRIPTION
`-2^53 - 1` is not a valid integer in Lua 5.2, which didn't have true integer support and thus relied on floats. You can verify that it's not an integer because `-2^53 - 1` compares equal to `-2^53`. `-2^53` is the smallest integer that is actually distinguishable from every other integer up until `math.maxinteger`.

`math.maxinteger` is fine.