### PR TITLE
feat: add luacats generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SOURCES = teal/debug.tl teal/attributes.tl teal/errors.tl teal/lexer.tl \
 	teal/check/type_checker.tl teal/check/node_checker.tl \
 	teal/input.tl \
 	teal/check/require_file.tl \
-	teal/gen/targets.tl teal/gen/lua_generator.tl teal/gen/lua_compat.tl \
+	teal/gen/targets.tl teal/gen/luacats.tl teal/gen/lua_generator.tl teal/gen/lua_compat.tl \
 	teal/package_loader.tl teal/loader.tl \
 	teal/api/v2.tl teal/api/v1.tl \
 	teal/init.tl \

--- a/docs/src/compiler_options.md
+++ b/docs/src/compiler_options.md
@@ -25,6 +25,7 @@ return {
 |                      | `source_dir`               | `string`   | `check` `gen` `run`  | Set the project source directory and add it to the module search path.
 | `--gen-compat`       | `gen_compat`               | `string`   | `gen` `run`          | Generate compatibility code for targeting different Lua VM versions. See [below](#generated-code) for details.
 | `--gen-target`       | `gen_target`               | `string`   | `gen` `run`          | Minimum targeted Lua version for generated code. Options are `5.1`, `5.3` and `5.4`. See [below](#generated-code) for details.
+| `--emit-luacats`     | `emit_luacats`             | `boolean`  | `gen`                | Generate LuaCATS annotations from explicit Teal type declarations.
 | `--keep-hashbang`    |                            |            | `gen`                | Preserve hashbang line (`#!`) at the top of file if present.
 | `-p --pretend`       |                            |            | `gen`                | Don't compile/write to any files, but type check and log what files would be written to.
 | `--wdisable`         | `disable_warnings`         | `{string}` | `check` `run`        | Disable the given warnings.

--- a/teal.lua
+++ b/teal.lua
@@ -11356,10 +11356,12 @@ local types = require("teal.types")
 
 
 local traversal = require("teal.traversal")
+local luacats = require("teal.gen.luacats")
 
 
 
 local lua_generator = { Options = {} }
+
 
 
 
@@ -11418,12 +11420,14 @@ lua_generator.default_opts = {
    preserve_indent = true,
    preserve_newlines = true,
    preserve_hashbang = false,
+   emit_luacats = false,
 }
 
 lua_generator.fast_opts = {
    preserve_indent = false,
    preserve_newlines = true,
    preserve_hashbang = false,
+   emit_luacats = false,
 }
 
 function lua_generator.generate(ast, gen_target, opts)
@@ -11431,11 +11435,28 @@ function lua_generator.generate(ast, gen_target, opts)
 
    opts = opts or lua_generator.default_opts
 
+   local function annotation(node)
+      local s = opts.emit_luacats and luacats.for_node(node) or ""
+      local annotation_indent = indent
+      if node.kind == "local_function" or node.kind == "global_function" or node.kind == "record_function" then
+         annotation_indent = annotation_indent - 1
+      end
+      if s ~= "" and opts.preserve_indent and annotation_indent > 0 then
+         s = s:gsub("\n", "\n" .. ("   "):rep(annotation_indent))
+      end
+      return s
+   end
 
 
 
 
 
+
+
+   local function add_annotation(out, node)
+      local s = annotation(node)
+      if s ~= "" then table.insert(out, s) end
+   end
 
    local function increment_indent(_, node)
       local child = node.body or node[1]
@@ -11610,6 +11631,7 @@ function lua_generator.generate(ast, gen_target, opts)
       local arguments_index, body_index = _tl_table_unpack(function_indexes[kind])
       return function(_, node, children)
          local out = { y = node.y, h = 0 }
+         add_annotation(out, node)
 
          if kind == "local" then
             table.insert(out, "local ")
@@ -11659,6 +11681,10 @@ function lua_generator.generate(ast, gen_target, opts)
             end
             local space
             for i, child in ipairs(children) do
+               if i > 1 and annotation(node[i]) ~= "" then
+                  add_string(out, "\n")
+                  space = nil
+               end
                add_child(out, child, space, indent)
                if node[i].semicolon then
                   table.insert(out, ";")
@@ -11673,6 +11699,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["local_declaration"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             table.insert(out, "local ")
             for i, var in ipairs(node.vars) do
                if i > 1 then
@@ -11693,6 +11720,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["local_type"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if not node.var.elide_type then
                table.insert(out, "local")
                add_child(out, children[1], " ")
@@ -11705,6 +11733,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["global_type"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if children[2] then
                add_child(out, children[1])
                table.insert(out, " =")
@@ -11716,6 +11745,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["global_declaration"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if children[3] then
                add_child(out, children[1])
                table.insert(out, " =")
@@ -12181,6 +12211,255 @@ function lua_generator.generate(ast, gen_target, opts)
 end
 
 return lua_generator
+
+end
+
+-- module teal.gen.luacats from teal/gen/luacats.lua
+package.preload["teal.gen.luacats"] = function(...)
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local types = require("teal.types")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+local luacats = {}
+
+
+
+
+local primitive_types = {
+   any = true,
+   boolean = true,
+   integer = true,
+   ["nil"] = true,
+   number = true,
+   string = true,
+   thread = true,
+   userdata = true,
+}
+
+local type_string_context
+
+local function nominal_type_string(nominal)
+   local result = table.concat(nominal.names, ".")
+   if not nominal.typevals or #nominal.typevals == 0 then
+      return result
+   end
+
+   local type_values = {}
+   for _, type_value in ipairs(nominal.typevals) do
+      table.insert(type_values, type_string_context(type_value, false))
+   end
+   return result .. "<" .. table.concat(type_values, ", ") .. ">"
+end
+
+local function union_type_string(union)
+   local union_types = {}
+   for _, union_type in ipairs(union.types) do
+      table.insert(union_types, type_string_context(union_type, false))
+   end
+   return table.concat(union_types, "|")
+end
+
+local function function_type_string(fn)
+   if fn.rets.is_va then
+      return "function", false
+   end
+
+   local arguments = {}
+   for i, argument in ipairs(fn.args.tuple) do
+      if fn.args.is_va and i == #fn.args.tuple then
+         table.insert(arguments, "...: " .. type_string_context(argument, false))
+      else
+         local argument_type = type_string_context(argument, false)
+         if i > fn.min_arity then
+            argument_type = argument_type .. "|nil"
+         end
+         table.insert(arguments, "arg" .. i .. ": " .. argument_type)
+      end
+   end
+
+   local returns = {}
+   for i, return_type in ipairs(fn.rets.tuple) do
+      table.insert(returns, type_string_context(return_type, false) .. (fn.rets.is_va and i == #fn.rets.tuple and "..." or ""))
+   end
+
+   local return_annotation = #returns == 0 and "" or
+   #returns == 1 and ": " .. returns[1] or
+   ": (" .. table.concat(returns, ", ") .. ")"
+   return "fun(" .. table.concat(arguments, ", ") .. ")" .. return_annotation, true
+end
+
+local function array_component_string(result, is_array_component, is_compound)
+   return is_array_component and is_compound and "(" .. result .. ")" or result
+end
+
+type_string_context = function(t, is_array_component)
+   if not t then return "any" end
+
+   if t.typename == "string" and (t).literal then return string.format("%q", (t).literal) end
+   if t.typename == "nominal" then return nominal_type_string(t) end
+   if t.typename == "typearg" then
+      local name = ((t).typearg or "any"):gsub("@.*$", "")
+      return name
+   end
+   if t.typename == "typevar" then
+      local name = ((t).typevar or "any"):gsub("@.*$", "")
+      return name
+   end
+   if t.typename == "generic" then
+      local generic = t
+      return generic.t.typename == "function" and "function" or type_string_context(generic.t, is_array_component)
+   end
+   if t.typename == "array" then return type_string_context((t).elements, true) .. "[]" end
+   if t.typename == "map" then
+      local map = t
+      return "table<" .. type_string_context(map.keys, false) .. ", " .. type_string_context(map.values, false) .. ">"
+   end
+   if t.typename == "union" then
+      return array_component_string(union_type_string(t), is_array_component, true)
+   end
+   if t.typename == "function" then
+      local result, is_compound = function_type_string(t)
+      return array_component_string(result, is_array_component, is_compound)
+   end
+
+   return primitive_types[t.typename] and t.typename or "any"
+end
+
+local function type_string(t)
+   return type_string_context(t, false)
+end
+
+local function function_annotations(node)
+   local out = {}
+   if node.typeargs and #node.typeargs > 0 then
+      local a = {}
+      for _, t in ipairs(node.typeargs) do
+         local constraint = t.constraint and type_string(t.constraint)
+         local name = t.typearg:gsub("@.*$", "")
+         table.insert(a, name .. (constraint and constraint ~= "any" and ": " .. constraint or ""))
+      end
+      table.insert(out, "---@generic " .. table.concat(a, ", "))
+   end
+   for _, param in ipairs(node.args or {}) do
+      if not param.is_self and param.argtype then
+         table.insert(out, "---@param " .. (param.tk == "..." and "..." or param.tk .. (param.opt and "?" or "")) .. " " .. type_string(param.argtype))
+      end
+   end
+   if node.rets then
+      for i, r in ipairs(node.rets.tuple) do
+         table.insert(out, "---@return " .. type_string(r) .. (node.rets.is_va and i == #node.rets.tuple and " ..." or ""))
+      end
+   end
+   return #out > 0 and table.concat(out, "\n") .. "\n" or ""
+end
+
+local function field_name(name)
+   return name:match("^[%a_][%w_]*$") and name or "[" .. string.format("%q", name) .. "]"
+end
+
+local function generic_suffix(typeargs)
+   if not typeargs or #typeargs == 0 then return "" end
+
+   local names = {}
+   for _, typearg in ipairs(typeargs) do
+      local name = typearg.typearg:gsub("@.*$", "")
+      table.insert(names, name)
+   end
+   return "<" .. table.concat(names, ", ") .. ">"
+end
+
+local function is_checker_method(field_type)
+   return field_type.typename == "poly" or
+   (field_type.typename == "function" and (field_type).is_record_function) or
+   (field_type.typename == "generic" and field_type.t.typename == "function")
+end
+
+local function record_annotation(name, suffix, record_type)
+   local annotations = { "---@class " .. name .. suffix }
+   for _, field in ipairs(record_type.field_order or {}) do
+      local field_type = record_type.fields[field]
+      if not (field_type.typename == "typedecl") and not is_checker_method(field_type) then
+         table.insert(annotations, "---@field " .. field_name(field) .. " " .. type_string(field_type))
+      end
+   end
+   return table.concat(annotations, "\n") .. "\n"
+end
+
+local function enum_annotation(name, suffix, enum_type)
+   local values = {}
+   for value in pairs(enum_type.enumset) do
+      table.insert(values, string.format("%q", value))
+   end
+   table.sort(values)
+   return "---@alias " .. name .. suffix .. " " .. table.concat(values, "|") .. "\n"
+end
+
+local function type_annotations(node)
+   local nt = node.value and node.value.newtype
+
+   if not nt then
+      return ""
+   end
+
+   local name, def = node.var.tk, (nt).def
+   local typeargs
+
+   if def.typename == "generic" then
+      typeargs, def = def.typeargs, def.t
+   end
+
+   if typeargs and #typeargs > 0 and not def.fields then
+      return ""
+   end
+
+   local suffix = generic_suffix(typeargs)
+   if def.fields then
+      return record_annotation(name, suffix, def)
+   end
+   if def.typename == "enum" then
+      return enum_annotation(name, suffix, def)
+   end
+
+   return "---@alias " .. name .. suffix .. " " .. type_string(def) .. "\n"
+end
+
+local function declaration_annotation(node)
+   if #node.vars ~= 1 or (node.kind == "global_declaration" and not node.exps) then return "" end
+
+   local declaration_type = node.decltuple and node.decltuple.tuple[1]
+   return declaration_type and "---@type " .. type_string(declaration_type) .. "\n" or ""
+end
+
+function luacats.for_node(node)
+   if node.kind == "local_function" or node.kind == "global_function" or node.kind == "record_function" then
+      return function_annotations(node)
+   end
+
+   if node.kind == "local_type" or node.kind == "global_type" then
+      return type_annotations(node)
+   end
+
+   if node.kind == "local_declaration" or node.kind == "global_declaration" then
+      return declaration_annotation(node)
+   end
+
+   return ""
+end
+
+luacats.type_string = type_string
+return luacats
 
 end
 

--- a/teal/gen/lua_generator.lua
+++ b/teal/gen/lua_generator.lua
@@ -21,10 +21,12 @@ local types = require("teal.types")
 
 
 local traversal = require("teal.traversal")
+local luacats = require("teal.gen.luacats")
 
 
 
 local lua_generator = { Options = {} }
+
 
 
 
@@ -83,12 +85,14 @@ lua_generator.default_opts = {
    preserve_indent = true,
    preserve_newlines = true,
    preserve_hashbang = false,
+   emit_luacats = false,
 }
 
 lua_generator.fast_opts = {
    preserve_indent = false,
    preserve_newlines = true,
    preserve_hashbang = false,
+   emit_luacats = false,
 }
 
 function lua_generator.generate(ast, gen_target, opts)
@@ -96,11 +100,28 @@ function lua_generator.generate(ast, gen_target, opts)
 
    opts = opts or lua_generator.default_opts
 
+   local function annotation(node)
+      local s = opts.emit_luacats and luacats.for_node(node) or ""
+      local annotation_indent = indent
+      if node.kind == "local_function" or node.kind == "global_function" or node.kind == "record_function" then
+         annotation_indent = annotation_indent - 1
+      end
+      if s ~= "" and opts.preserve_indent and annotation_indent > 0 then
+         s = s:gsub("\n", "\n" .. ("   "):rep(annotation_indent))
+      end
+      return s
+   end
 
 
 
 
 
+
+
+   local function add_annotation(out, node)
+      local s = annotation(node)
+      if s ~= "" then table.insert(out, s) end
+   end
 
    local function increment_indent(_, node)
       local child = node.body or node[1]
@@ -275,6 +296,7 @@ function lua_generator.generate(ast, gen_target, opts)
       local arguments_index, body_index = _tl_table_unpack(function_indexes[kind])
       return function(_, node, children)
          local out = { y = node.y, h = 0 }
+         add_annotation(out, node)
 
          if kind == "local" then
             table.insert(out, "local ")
@@ -324,6 +346,10 @@ function lua_generator.generate(ast, gen_target, opts)
             end
             local space
             for i, child in ipairs(children) do
+               if i > 1 and annotation(node[i]) ~= "" then
+                  add_string(out, "\n")
+                  space = nil
+               end
                add_child(out, child, space, indent)
                if node[i].semicolon then
                   table.insert(out, ";")
@@ -338,6 +364,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["local_declaration"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             table.insert(out, "local ")
             for i, var in ipairs(node.vars) do
                if i > 1 then
@@ -358,6 +385,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["local_type"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if not node.var.elide_type then
                table.insert(out, "local")
                add_child(out, children[1], " ")
@@ -370,6 +398,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["global_type"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if children[2] then
                add_child(out, children[1])
                table.insert(out, " =")
@@ -381,6 +410,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["global_declaration"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if children[3] then
                add_child(out, children[1])
                table.insert(out, " =")

--- a/teal/gen/lua_generator.tl
+++ b/teal/gen/lua_generator.tl
@@ -21,6 +21,7 @@ local type Node = ast_types.Node
 local type NodeKind = ast_types.NodeKind
 
 local traversal = require("teal.traversal")
+local luacats = require("teal.gen.luacats")
 local type Visitor = traversal.Visitor
 local type VisitorCallbacks = traversal.VisitorCallbacks
 
@@ -29,6 +30,7 @@ local record lua_generator
       preserve_indent: boolean
       preserve_newlines: boolean
       preserve_hashbang: boolean
+      emit_luacats: boolean
    end
 
    default_opts: Options
@@ -83,12 +85,14 @@ lua_generator.default_opts = {
    preserve_indent = true,
    preserve_newlines = true,
    preserve_hashbang = false,
+   emit_luacats = false,
 }
 
 lua_generator.fast_opts = {
    preserve_indent = false,
    preserve_newlines = true,
    preserve_hashbang = false,
+   emit_luacats = false,
 }
 
 function lua_generator.generate(ast: Node, gen_target: GenTarget, opts?: Options): string
@@ -96,10 +100,27 @@ function lua_generator.generate(ast: Node, gen_target: GenTarget, opts?: Options
 
    opts = opts or lua_generator.default_opts
 
+   local function annotation(node: Node): string
+      local s = opts.emit_luacats and luacats.for_node(node) or ""
+      local annotation_indent = indent
+      if node.kind == "local_function" or node.kind == "global_function" or node.kind == "record_function" then
+         annotation_indent = annotation_indent - 1
+      end
+      if s ~= "" and opts.preserve_indent and annotation_indent > 0 then
+         s = s:gsub("\n", "\n" .. ("   "):rep(annotation_indent))
+      end
+      return s
+   end
+
    local record Output
       {string}
       y: integer
       h: integer
+   end
+
+   local function add_annotation(out: Output, node: Node)
+      local s = annotation(node)
+      if s ~= "" then table.insert(out, s) end
    end
 
    local function increment_indent(_: nil, node: Node)
@@ -275,6 +296,7 @@ function lua_generator.generate(ast: Node, gen_target: GenTarget, opts?: Options
       local arguments_index <const>, body_index <const> = table.unpack(function_indexes[kind])
       return function(_: nil, node: Node, children: {Output}): Output
          local out <const>: Output = { y = node.y, h = 0 }
+         add_annotation(out, node)
 
          if kind == "local" then
             table.insert(out, "local ")
@@ -324,6 +346,10 @@ function lua_generator.generate(ast: Node, gen_target: GenTarget, opts?: Options
             end
             local space: string
             for i, child in ipairs(children) do
+               if i > 1 and annotation(node[i]) ~= "" then
+                  add_string(out, "\n")
+                  space = nil
+               end
                add_child(out, child, space, indent)
                if node[i].semicolon then
                   table.insert(out, ";")
@@ -338,6 +364,7 @@ function lua_generator.generate(ast: Node, gen_target: GenTarget, opts?: Options
       ["local_declaration"] = {
          after = function(_: nil, node: Node, children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
+            add_annotation(out, node)
             table.insert(out, "local ")
             for i, var in ipairs(node.vars) do
                if i > 1 then
@@ -358,6 +385,7 @@ function lua_generator.generate(ast: Node, gen_target: GenTarget, opts?: Options
       ["local_type"] = {
          after = function(_: nil, node: Node, children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if not node.var.elide_type then
                table.insert(out, "local")
                add_child(out, children[1], " ")
@@ -370,6 +398,7 @@ function lua_generator.generate(ast: Node, gen_target: GenTarget, opts?: Options
       ["global_type"] = {
          after = function(_: nil, node: Node, children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if children[2] then
                add_child(out, children[1])
                table.insert(out, " =")
@@ -381,6 +410,7 @@ function lua_generator.generate(ast: Node, gen_target: GenTarget, opts?: Options
       ["global_declaration"] = {
          after = function(_: nil, node: Node, children: {Output}): Output
             local out: Output = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if children[3] then
                add_child(out, children[1])
                table.insert(out, " =")

--- a/teal/gen/luacats.lua
+++ b/teal/gen/luacats.lua
@@ -1,0 +1,244 @@
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local types = require("teal.types")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+local luacats = {}
+
+
+
+
+local primitive_types = {
+   any = true,
+   boolean = true,
+   integer = true,
+   ["nil"] = true,
+   number = true,
+   string = true,
+   thread = true,
+   userdata = true,
+}
+
+local type_string_context
+
+local function nominal_type_string(nominal)
+   local result = table.concat(nominal.names, ".")
+   if not nominal.typevals or #nominal.typevals == 0 then
+      return result
+   end
+
+   local type_values = {}
+   for _, type_value in ipairs(nominal.typevals) do
+      table.insert(type_values, type_string_context(type_value, false))
+   end
+   return result .. "<" .. table.concat(type_values, ", ") .. ">"
+end
+
+local function union_type_string(union)
+   local union_types = {}
+   for _, union_type in ipairs(union.types) do
+      table.insert(union_types, type_string_context(union_type, false))
+   end
+   return table.concat(union_types, "|")
+end
+
+local function function_type_string(fn)
+   if fn.rets.is_va then
+      return "function", false
+   end
+
+   local arguments = {}
+   for i, argument in ipairs(fn.args.tuple) do
+      if fn.args.is_va and i == #fn.args.tuple then
+         table.insert(arguments, "...: " .. type_string_context(argument, false))
+      else
+         local argument_type = type_string_context(argument, false)
+         if i > fn.min_arity then
+            argument_type = argument_type .. "|nil"
+         end
+         table.insert(arguments, "arg" .. i .. ": " .. argument_type)
+      end
+   end
+
+   local returns = {}
+   for i, return_type in ipairs(fn.rets.tuple) do
+      table.insert(returns, type_string_context(return_type, false) .. (fn.rets.is_va and i == #fn.rets.tuple and "..." or ""))
+   end
+
+   local return_annotation = #returns == 0 and "" or
+   #returns == 1 and ": " .. returns[1] or
+   ": (" .. table.concat(returns, ", ") .. ")"
+   return "fun(" .. table.concat(arguments, ", ") .. ")" .. return_annotation, true
+end
+
+local function array_component_string(result, is_array_component, is_compound)
+   return is_array_component and is_compound and "(" .. result .. ")" or result
+end
+
+type_string_context = function(t, is_array_component)
+   if not t then return "any" end
+
+   if t.typename == "string" and (t).literal then return string.format("%q", (t).literal) end
+   if t.typename == "nominal" then return nominal_type_string(t) end
+   if t.typename == "typearg" then
+      local name = ((t).typearg or "any"):gsub("@.*$", "")
+      return name
+   end
+   if t.typename == "typevar" then
+      local name = ((t).typevar or "any"):gsub("@.*$", "")
+      return name
+   end
+   if t.typename == "generic" then
+      local generic = t
+      return generic.t.typename == "function" and "function" or type_string_context(generic.t, is_array_component)
+   end
+   if t.typename == "array" then return type_string_context((t).elements, true) .. "[]" end
+   if t.typename == "map" then
+      local map = t
+      return "table<" .. type_string_context(map.keys, false) .. ", " .. type_string_context(map.values, false) .. ">"
+   end
+   if t.typename == "union" then
+      return array_component_string(union_type_string(t), is_array_component, true)
+   end
+   if t.typename == "function" then
+      local result, is_compound = function_type_string(t)
+      return array_component_string(result, is_array_component, is_compound)
+   end
+
+   return primitive_types[t.typename] and t.typename or "any"
+end
+
+local function type_string(t)
+   return type_string_context(t, false)
+end
+
+local function function_annotations(node)
+   local out = {}
+   if node.typeargs and #node.typeargs > 0 then
+      local a = {}
+      for _, t in ipairs(node.typeargs) do
+         local constraint = t.constraint and type_string(t.constraint)
+         local name = t.typearg:gsub("@.*$", "")
+         table.insert(a, name .. (constraint and constraint ~= "any" and ": " .. constraint or ""))
+      end
+      table.insert(out, "---@generic " .. table.concat(a, ", "))
+   end
+   for _, param in ipairs(node.args or {}) do
+      if not param.is_self and param.argtype then
+         table.insert(out, "---@param " .. (param.tk == "..." and "..." or param.tk .. (param.opt and "?" or "")) .. " " .. type_string(param.argtype))
+      end
+   end
+   if node.rets then
+      for i, r in ipairs(node.rets.tuple) do
+         table.insert(out, "---@return " .. type_string(r) .. (node.rets.is_va and i == #node.rets.tuple and " ..." or ""))
+      end
+   end
+   return #out > 0 and table.concat(out, "\n") .. "\n" or ""
+end
+
+local function field_name(name)
+   return name:match("^[%a_][%w_]*$") and name or "[" .. string.format("%q", name) .. "]"
+end
+
+local function generic_suffix(typeargs)
+   if not typeargs or #typeargs == 0 then return "" end
+
+   local names = {}
+   for _, typearg in ipairs(typeargs) do
+      local name = typearg.typearg:gsub("@.*$", "")
+      table.insert(names, name)
+   end
+   return "<" .. table.concat(names, ", ") .. ">"
+end
+
+local function is_checker_method(field_type)
+   return field_type.typename == "poly" or
+   (field_type.typename == "function" and (field_type).is_record_function) or
+   (field_type.typename == "generic" and field_type.t.typename == "function")
+end
+
+local function record_annotation(name, suffix, record_type)
+   local annotations = { "---@class " .. name .. suffix }
+   for _, field in ipairs(record_type.field_order or {}) do
+      local field_type = record_type.fields[field]
+      if not (field_type.typename == "typedecl") and not is_checker_method(field_type) then
+         table.insert(annotations, "---@field " .. field_name(field) .. " " .. type_string(field_type))
+      end
+   end
+   return table.concat(annotations, "\n") .. "\n"
+end
+
+local function enum_annotation(name, suffix, enum_type)
+   local values = {}
+   for value in pairs(enum_type.enumset) do
+      table.insert(values, string.format("%q", value))
+   end
+   table.sort(values)
+   return "---@alias " .. name .. suffix .. " " .. table.concat(values, "|") .. "\n"
+end
+
+local function type_annotations(node)
+   local nt = node.value and node.value.newtype
+
+   if not nt then
+      return ""
+   end
+
+   local name, def = node.var.tk, (nt).def
+   local typeargs
+
+   if def.typename == "generic" then
+      typeargs, def = def.typeargs, def.t
+   end
+
+   if typeargs and #typeargs > 0 and not def.fields then
+      return ""
+   end
+
+   local suffix = generic_suffix(typeargs)
+   if def.fields then
+      return record_annotation(name, suffix, def)
+   end
+   if def.typename == "enum" then
+      return enum_annotation(name, suffix, def)
+   end
+
+   return "---@alias " .. name .. suffix .. " " .. type_string(def) .. "\n"
+end
+
+local function declaration_annotation(node)
+   if #node.vars ~= 1 or (node.kind == "global_declaration" and not node.exps) then return "" end
+
+   local declaration_type = node.decltuple and node.decltuple.tuple[1]
+   return declaration_type and "---@type " .. type_string(declaration_type) .. "\n" or ""
+end
+
+function luacats.for_node(node)
+   if node.kind == "local_function" or node.kind == "global_function" or node.kind == "record_function" then
+      return function_annotations(node)
+   end
+
+   if node.kind == "local_type" or node.kind == "global_type" then
+      return type_annotations(node)
+   end
+
+   if node.kind == "local_declaration" or node.kind == "global_declaration" then
+      return declaration_annotation(node)
+   end
+
+   return ""
+end
+
+luacats.type_string = type_string
+return luacats

--- a/teal/gen/luacats.tl
+++ b/teal/gen/luacats.tl
@@ -1,0 +1,271 @@
+local types = require("teal.types")
+local type Type = types.Type
+local type GenericType = types.GenericType
+local type NominalType = types.NominalType
+local type RecordLikeType = types.RecordLikeType
+local type TypeDeclType = types.TypeDeclType
+local type StringType = types.StringType
+local type TypeArgType = types.TypeArgType
+local type TypeVarType = types.TypeVarType
+local type ArrayType = types.ArrayType
+local type MapType = types.MapType
+local type UnionType = types.UnionType
+local type FunctionType = types.FunctionType
+local type EnumType = types.EnumType
+local type Node = require("teal.ast").Node
+
+local record luacats
+   for_node: function(Node): string
+   type_string: function(Type): string
+end
+
+local primitive_types: {string:boolean} = {
+   any=true,
+   boolean=true,
+   integer=true,
+   ["nil"]=true,
+   number=true,
+   string=true,
+   thread=true,
+   userdata=true,
+}
+
+local type_string_context: function(Type, boolean): string
+
+local function nominal_type_string(nominal: NominalType): string
+   local result = table.concat(nominal.names, ".")
+   if not nominal.typevals or #nominal.typevals == 0 then
+      return result
+   end
+
+   local type_values = {}
+   for _, type_value in ipairs(nominal.typevals) do
+      table.insert(type_values, type_string_context(type_value, false))
+   end
+
+   return result .. "<" .. table.concat(type_values, ", ") .. ">"
+end
+
+local function union_type_string(union: UnionType): string
+   local union_types = {}
+   for _, union_type in ipairs(union.types) do
+      table.insert(union_types, type_string_context(union_type, false))
+   end
+
+   return table.concat(union_types, "|")
+end
+
+local function function_type_string(fn: FunctionType): string, boolean
+   if fn.rets.is_va then
+      return "function", false
+   end
+
+   local arguments = {}
+   for i, argument in ipairs(fn.args.tuple) do
+      if fn.args.is_va and i == #fn.args.tuple then
+         table.insert(arguments, "...: " .. type_string_context(argument, false))
+      else
+         local argument_type = type_string_context(argument, false)
+         if i > fn.min_arity then
+            argument_type = argument_type .. "|nil"
+         end
+         table.insert(arguments, "arg" .. i .. ": " .. argument_type)
+      end
+   end
+
+   local returns = {}
+   for i, return_type in ipairs(fn.rets.tuple) do
+      table.insert(returns, type_string_context(return_type, false) .. (fn.rets.is_va and i == #fn.rets.tuple and "..." or ""))
+   end
+
+   local return_annotation = #returns == 0 and "" or
+                             #returns == 1 and ": " .. returns[1] or
+                             ": (" .. table.concat(returns, ", ") .. ")"
+   return "fun(" .. table.concat(arguments, ", ") .. ")" .. return_annotation, true
+end
+
+local function array_component_string(result: string, is_array_component: boolean, is_compound: boolean): string
+   return is_array_component and is_compound and "(" .. result .. ")" or result
+end
+
+type_string_context = function(t: Type, is_array_component: boolean): string
+   if not t then
+      return "any"
+   end
+
+   if t.typename == "string" and (t as StringType).literal then
+      return string.format("%q", (t as StringType).literal)
+   end
+
+   if t.typename == "nominal" then
+      return nominal_type_string(t as NominalType)
+   end
+
+   if t.typename == "typearg" then
+      local name = ((t as TypeArgType).typearg or "any"):gsub("@.*$", "")
+      return name
+   end
+
+   if t.typename == "typevar" then
+      local name = ((t as TypeVarType).typevar or "any"):gsub("@.*$", "")
+      return name
+   end
+
+   if t.typename == "generic" then
+      local generic = t as GenericType
+      return generic.t.typename == "function" and "function" or type_string_context(generic.t, is_array_component)
+   end
+
+   if t.typename == "array" then
+      return type_string_context((t as ArrayType).elements, true) .. "[]"
+   end
+
+   if t.typename == "map" then
+      local map = t as MapType
+      return "table<" .. type_string_context(map.keys, false) .. ", " .. type_string_context(map.values, false) .. ">"
+   end
+
+   if t.typename == "union" then
+      return array_component_string(union_type_string(t as UnionType), is_array_component, true)
+   end
+
+   if t.typename == "function" then
+      local result, is_compound = function_type_string(t as FunctionType)
+      return array_component_string(result, is_array_component, is_compound)
+   end
+
+   return primitive_types[t.typename] and t.typename or "any"
+end
+
+local function type_string(t: Type): string
+   return type_string_context(t, false)
+end
+
+local function function_annotations(node: Node): string
+   local out = {}
+   if node.typeargs and #node.typeargs > 0 then
+      local a = {}
+      for _, t in ipairs(node.typeargs) do
+         local constraint = t.constraint and type_string(t.constraint)
+         local name = t.typearg:gsub("@.*$", "")
+         table.insert(a, name .. (constraint and constraint ~= "any" and ": " .. constraint or ""))
+      end
+      table.insert(out, "---@generic " .. table.concat(a, ", "))
+   end
+
+   for _, param in ipairs(node.args or {}) do
+      if not param.is_self and param.argtype then
+         table.insert(out, "---@param " .. (param.tk == "..." and "..." or param.tk .. (param.opt and "?" or "")) .. " " .. type_string(param.argtype))
+      end
+   end
+
+   if node.rets then
+      for i, r in ipairs(node.rets.tuple) do
+         table.insert(out, "---@return " .. type_string(r) .. (node.rets.is_va and i == #node.rets.tuple and " ..." or ""))
+      end
+   end
+
+   return #out > 0 and table.concat(out, "\n") .. "\n" or ""
+end
+
+local function field_name(name: string): string
+   return name:match("^[%a_][%w_]*$") and name or "[" .. string.format("%q", name) .. "]"
+end
+
+local function generic_suffix(typeargs: {TypeArgType}): string
+   if not typeargs or #typeargs == 0 then return "" end
+
+   local names = {}
+   for _, typearg in ipairs(typeargs) do
+      local name = typearg.typearg:gsub("@.*$", "")
+      table.insert(names, name)
+   end
+
+   return "<" .. table.concat(names, ", ") .. ">"
+end
+
+local function is_checker_method(field_type: Type): boolean
+   return field_type.typename == "poly" or
+          (field_type.typename == "function" and (field_type as FunctionType).is_record_function) or
+          (field_type is GenericType and field_type.t.typename == "function")
+end
+
+local function record_annotation(name: string, suffix: string, record_type: RecordLikeType): string
+   local annotations = { "---@class " .. name .. suffix }
+   for _, field in ipairs(record_type.field_order or {}) do
+      local field_type = record_type.fields[field]
+      if not field_type is TypeDeclType and not is_checker_method(field_type) then
+         table.insert(annotations, "---@field " .. field_name(field) .. " " .. type_string(field_type))
+      end
+   end
+
+   return table.concat(annotations, "\n") .. "\n"
+end
+
+local function enum_annotation(name: string, suffix: string, enum_type: EnumType): string
+   local values = {}
+   for value in pairs(enum_type.enumset) do
+      table.insert(values, string.format("%q", value))
+   end
+
+   table.sort(values)
+   return "---@alias " .. name .. suffix .. " " .. table.concat(values, "|") .. "\n"
+end
+
+local function type_annotations(node: Node): string
+   local nt = node.value and node.value.newtype
+
+   if not nt then
+      return ""
+   end
+
+   local name, def = node.var.tk, (nt as TypeDeclType).def
+   local typeargs: {TypeArgType}
+
+   if def is GenericType then
+      typeargs, def = def.typeargs, def.t
+   end
+
+   if typeargs and #typeargs > 0 and not def is RecordLikeType then
+      return ""
+   end
+
+   local suffix = generic_suffix(typeargs)
+   if def is RecordLikeType then
+      return record_annotation(name, suffix, def)
+   end
+
+   if def.typename == "enum" then
+      return enum_annotation(name, suffix, def as EnumType)
+   end
+
+   return "---@alias " .. name .. suffix .. " " .. type_string(def) .. "\n"
+end
+
+local function declaration_annotation(node: Node): string
+   if #node.vars ~= 1 or (node.kind == "global_declaration" and not node.exps) then
+      return ""
+   end
+
+   local declaration_type = node.decltuple and node.decltuple.tuple[1]
+   return declaration_type and "---@type " .. type_string(declaration_type) .. "\n" or ""
+end
+
+function luacats.for_node(node: Node): string
+   if node.kind == "local_function" or node.kind == "global_function" or node.kind == "record_function" then
+      return function_annotations(node)
+   end
+
+   if node.kind == "local_type" or node.kind == "global_type" then
+      return type_annotations(node)
+   end
+
+   if node.kind == "local_declaration" or node.kind == "global_declaration" then
+      return declaration_annotation(node)
+   end
+
+   return ""
+end
+
+luacats.type_string = type_string
+return luacats

--- a/tl-dev-2.rockspec
+++ b/tl-dev-2.rockspec
@@ -2,7 +2,7 @@ rockspec_format = "3.0"
 package = "tl"
 version = "dev-2"
 source = {
-   url = "git+https://github.com/teal-language/tl"
+   url = "git+https://github.com/teal-language/tl",
 }
 description = {
    summary = "Teal, a typed dialect of Lua",
@@ -58,6 +58,7 @@ build = {
       ["teal.facts"] = "teal/facts.lua",
       ["teal.gen.lua_compat"] = "teal/gen/lua_compat.lua",
       ["teal.gen.lua_generator"] = "teal/gen/lua_generator.lua",
+      ["teal.gen.luacats"] = "teal/gen/luacats.lua",
       ["teal.gen.targets"] = "teal/gen/targets.lua",
       ["teal.init"] = "teal/init.lua",
       ["teal.input"] = "teal/input.lua",
@@ -77,7 +78,6 @@ build = {
       ["teal.util"] = "teal/util.lua",
       ["teal.variables"] = "teal/variables.lua",
 
-
       -- Ship the compiled Lua modules from the `tlcli` namespace for the `tl` program:
       ["tlcli.commands.dump_blocks"] = "tlcli/commands/dump_blocks.lua",
       ["tlcli.commands.warnings"] = "tlcli/commands/warnings.lua",
@@ -95,7 +95,7 @@ build = {
    install = {
       bin = {
          -- Ship the `tl` CLI program:
-         "tl"
+         "tl",
       },
 
       lua = {
@@ -133,6 +133,7 @@ build = {
          ["teal.facts"] = "teal/facts.tl",
          ["teal.gen.lua_compat"] = "teal/gen/lua_compat.tl",
          ["teal.gen.lua_generator"] = "teal/gen/lua_generator.tl",
+         ["teal.gen.luacats"] = "teal/gen/luacats.tl",
          ["teal.gen.targets"] = "teal/gen/targets.tl",
          ["teal.init"] = "teal/init.tl",
          ["teal.input"] = "teal/input.tl",
@@ -151,6 +152,6 @@ build = {
          ["teal.types"] = "teal/types.tl",
          ["teal.util"] = "teal/util.tl",
          ["teal.variables"] = "teal/variables.tl",
-      }
+      },
    },
 }

--- a/tl.lua
+++ b/tl.lua
@@ -11616,10 +11616,12 @@ local types = require("teal.types")
 
 
 local traversal = require("teal.traversal")
+local luacats = require("teal.gen.luacats")
 
 
 
 local lua_generator = { Options = {} }
+
 
 
 
@@ -11678,12 +11680,14 @@ lua_generator.default_opts = {
    preserve_indent = true,
    preserve_newlines = true,
    preserve_hashbang = false,
+   emit_luacats = false,
 }
 
 lua_generator.fast_opts = {
    preserve_indent = false,
    preserve_newlines = true,
    preserve_hashbang = false,
+   emit_luacats = false,
 }
 
 function lua_generator.generate(ast, gen_target, opts)
@@ -11691,11 +11695,28 @@ function lua_generator.generate(ast, gen_target, opts)
 
    opts = opts or lua_generator.default_opts
 
+   local function annotation(node)
+      local s = opts.emit_luacats and luacats.for_node(node) or ""
+      local annotation_indent = indent
+      if node.kind == "local_function" or node.kind == "global_function" or node.kind == "record_function" then
+         annotation_indent = annotation_indent - 1
+      end
+      if s ~= "" and opts.preserve_indent and annotation_indent > 0 then
+         s = s:gsub("\n", "\n" .. ("   "):rep(annotation_indent))
+      end
+      return s
+   end
 
 
 
 
 
+
+
+   local function add_annotation(out, node)
+      local s = annotation(node)
+      if s ~= "" then table.insert(out, s) end
+   end
 
    local function increment_indent(_, node)
       local child = node.body or node[1]
@@ -11870,6 +11891,7 @@ function lua_generator.generate(ast, gen_target, opts)
       local arguments_index, body_index = _tl_table_unpack(function_indexes[kind])
       return function(_, node, children)
          local out = { y = node.y, h = 0 }
+         add_annotation(out, node)
 
          if kind == "local" then
             table.insert(out, "local ")
@@ -11919,6 +11941,10 @@ function lua_generator.generate(ast, gen_target, opts)
             end
             local space
             for i, child in ipairs(children) do
+               if i > 1 and annotation(node[i]) ~= "" then
+                  add_string(out, "\n")
+                  space = nil
+               end
                add_child(out, child, space, indent)
                if node[i].semicolon then
                   table.insert(out, ";")
@@ -11933,6 +11959,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["local_declaration"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             table.insert(out, "local ")
             for i, var in ipairs(node.vars) do
                if i > 1 then
@@ -11953,6 +11980,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["local_type"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if not node.var.elide_type then
                table.insert(out, "local")
                add_child(out, children[1], " ")
@@ -11965,6 +11993,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["global_type"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if children[2] then
                add_child(out, children[1])
                table.insert(out, " =")
@@ -11976,6 +12005,7 @@ function lua_generator.generate(ast, gen_target, opts)
       ["global_declaration"] = {
          after = function(_, node, children)
             local out = { y = node.y, h = 0 }
+            add_annotation(out, node)
             if children[3] then
                add_child(out, children[1])
                table.insert(out, " =")
@@ -12441,6 +12471,255 @@ function lua_generator.generate(ast, gen_target, opts)
 end
 
 return lua_generator
+
+end
+
+-- module teal.gen.luacats from teal/gen/luacats.lua
+package.preload["teal.gen.luacats"] = function(...)
+local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local pairs = _tl_compat and _tl_compat.pairs or pairs; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local types = require("teal.types")
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+local luacats = {}
+
+
+
+
+local primitive_types = {
+   any = true,
+   boolean = true,
+   integer = true,
+   ["nil"] = true,
+   number = true,
+   string = true,
+   thread = true,
+   userdata = true,
+}
+
+local type_string_context
+
+local function nominal_type_string(nominal)
+   local result = table.concat(nominal.names, ".")
+   if not nominal.typevals or #nominal.typevals == 0 then
+      return result
+   end
+
+   local type_values = {}
+   for _, type_value in ipairs(nominal.typevals) do
+      table.insert(type_values, type_string_context(type_value, false))
+   end
+   return result .. "<" .. table.concat(type_values, ", ") .. ">"
+end
+
+local function union_type_string(union)
+   local union_types = {}
+   for _, union_type in ipairs(union.types) do
+      table.insert(union_types, type_string_context(union_type, false))
+   end
+   return table.concat(union_types, "|")
+end
+
+local function function_type_string(fn)
+   if fn.rets.is_va then
+      return "function", false
+   end
+
+   local arguments = {}
+   for i, argument in ipairs(fn.args.tuple) do
+      if fn.args.is_va and i == #fn.args.tuple then
+         table.insert(arguments, "...: " .. type_string_context(argument, false))
+      else
+         local argument_type = type_string_context(argument, false)
+         if i > fn.min_arity then
+            argument_type = argument_type .. "|nil"
+         end
+         table.insert(arguments, "arg" .. i .. ": " .. argument_type)
+      end
+   end
+
+   local returns = {}
+   for i, return_type in ipairs(fn.rets.tuple) do
+      table.insert(returns, type_string_context(return_type, false) .. (fn.rets.is_va and i == #fn.rets.tuple and "..." or ""))
+   end
+
+   local return_annotation = #returns == 0 and "" or
+   #returns == 1 and ": " .. returns[1] or
+   ": (" .. table.concat(returns, ", ") .. ")"
+   return "fun(" .. table.concat(arguments, ", ") .. ")" .. return_annotation, true
+end
+
+local function array_component_string(result, is_array_component, is_compound)
+   return is_array_component and is_compound and "(" .. result .. ")" or result
+end
+
+type_string_context = function(t, is_array_component)
+   if not t then return "any" end
+
+   if t.typename == "string" and (t).literal then return string.format("%q", (t).literal) end
+   if t.typename == "nominal" then return nominal_type_string(t) end
+   if t.typename == "typearg" then
+      local name = ((t).typearg or "any"):gsub("@.*$", "")
+      return name
+   end
+   if t.typename == "typevar" then
+      local name = ((t).typevar or "any"):gsub("@.*$", "")
+      return name
+   end
+   if t.typename == "generic" then
+      local generic = t
+      return generic.t.typename == "function" and "function" or type_string_context(generic.t, is_array_component)
+   end
+   if t.typename == "array" then return type_string_context((t).elements, true) .. "[]" end
+   if t.typename == "map" then
+      local map = t
+      return "table<" .. type_string_context(map.keys, false) .. ", " .. type_string_context(map.values, false) .. ">"
+   end
+   if t.typename == "union" then
+      return array_component_string(union_type_string(t), is_array_component, true)
+   end
+   if t.typename == "function" then
+      local result, is_compound = function_type_string(t)
+      return array_component_string(result, is_array_component, is_compound)
+   end
+
+   return primitive_types[t.typename] and t.typename or "any"
+end
+
+local function type_string(t)
+   return type_string_context(t, false)
+end
+
+local function function_annotations(node)
+   local out = {}
+   if node.typeargs and #node.typeargs > 0 then
+      local a = {}
+      for _, t in ipairs(node.typeargs) do
+         local constraint = t.constraint and type_string(t.constraint)
+         local name = t.typearg:gsub("@.*$", "")
+         table.insert(a, name .. (constraint and constraint ~= "any" and ": " .. constraint or ""))
+      end
+      table.insert(out, "---@generic " .. table.concat(a, ", "))
+   end
+   for _, param in ipairs(node.args or {}) do
+      if not param.is_self and param.argtype then
+         table.insert(out, "---@param " .. (param.tk == "..." and "..." or param.tk .. (param.opt and "?" or "")) .. " " .. type_string(param.argtype))
+      end
+   end
+   if node.rets then
+      for i, r in ipairs(node.rets.tuple) do
+         table.insert(out, "---@return " .. type_string(r) .. (node.rets.is_va and i == #node.rets.tuple and " ..." or ""))
+      end
+   end
+   return #out > 0 and table.concat(out, "\n") .. "\n" or ""
+end
+
+local function field_name(name)
+   return name:match("^[%a_][%w_]*$") and name or "[" .. string.format("%q", name) .. "]"
+end
+
+local function generic_suffix(typeargs)
+   if not typeargs or #typeargs == 0 then return "" end
+
+   local names = {}
+   for _, typearg in ipairs(typeargs) do
+      local name = typearg.typearg:gsub("@.*$", "")
+      table.insert(names, name)
+   end
+   return "<" .. table.concat(names, ", ") .. ">"
+end
+
+local function is_checker_method(field_type)
+   return field_type.typename == "poly" or
+   (field_type.typename == "function" and (field_type).is_record_function) or
+   (field_type.typename == "generic" and field_type.t.typename == "function")
+end
+
+local function record_annotation(name, suffix, record_type)
+   local annotations = { "---@class " .. name .. suffix }
+   for _, field in ipairs(record_type.field_order or {}) do
+      local field_type = record_type.fields[field]
+      if not (field_type.typename == "typedecl") and not is_checker_method(field_type) then
+         table.insert(annotations, "---@field " .. field_name(field) .. " " .. type_string(field_type))
+      end
+   end
+   return table.concat(annotations, "\n") .. "\n"
+end
+
+local function enum_annotation(name, suffix, enum_type)
+   local values = {}
+   for value in pairs(enum_type.enumset) do
+      table.insert(values, string.format("%q", value))
+   end
+   table.sort(values)
+   return "---@alias " .. name .. suffix .. " " .. table.concat(values, "|") .. "\n"
+end
+
+local function type_annotations(node)
+   local nt = node.value and node.value.newtype
+
+   if not nt then
+      return ""
+   end
+
+   local name, def = node.var.tk, (nt).def
+   local typeargs
+
+   if def.typename == "generic" then
+      typeargs, def = def.typeargs, def.t
+   end
+
+   if typeargs and #typeargs > 0 and not def.fields then
+      return ""
+   end
+
+   local suffix = generic_suffix(typeargs)
+   if def.fields then
+      return record_annotation(name, suffix, def)
+   end
+   if def.typename == "enum" then
+      return enum_annotation(name, suffix, def)
+   end
+
+   return "---@alias " .. name .. suffix .. " " .. type_string(def) .. "\n"
+end
+
+local function declaration_annotation(node)
+   if #node.vars ~= 1 or (node.kind == "global_declaration" and not node.exps) then return "" end
+
+   local declaration_type = node.decltuple and node.decltuple.tuple[1]
+   return declaration_type and "---@type " .. type_string(declaration_type) .. "\n" or ""
+end
+
+function luacats.for_node(node)
+   if node.kind == "local_function" or node.kind == "global_function" or node.kind == "record_function" then
+      return function_annotations(node)
+   end
+
+   if node.kind == "local_type" or node.kind == "global_type" then
+      return type_annotations(node)
+   end
+
+   if node.kind == "local_declaration" or node.kind == "global_declaration" then
+      return declaration_annotation(node)
+   end
+
+   return ""
+end
+
+luacats.type_string = type_string
+return luacats
 
 end
 

--- a/tlcli/args.d.tl
+++ b/tlcli/args.d.tl
@@ -7,6 +7,7 @@ local record Args
    file: {string}
    gen_target: string
    gen_compat: string
+   emit_luacats: boolean
    no_stdlib: boolean
    global_env_def: {string} -- FIXME should be `string`, but argparse can't handle `:count("0-1")`?...
    include_dir: {string}

--- a/tlcli/commands/gen.lua
+++ b/tlcli/commands/gen.lua
@@ -87,6 +87,7 @@ return function(tlconfig, args)
       preserve_indent = true,
       preserve_newlines = true,
       preserve_hashbang = args["keep_hashbang"],
+      emit_luacats = tlconfig["emit_luacats"],
    }
 
    for i, input_file in ipairs(args["file"]) do

--- a/tlcli/commands/gen.tl
+++ b/tlcli/commands/gen.tl
@@ -86,7 +86,8 @@ return function(tlconfig: TlConfig, args: Args)
    local gen_opts: GenOptions = {
       preserve_indent = true,
       preserve_newlines = true,
-      preserve_hashbang = args["keep_hashbang"]
+      preserve_hashbang = args["keep_hashbang"],
+      emit_luacats = tlconfig["emit_luacats"]
    }
 
    for i, input_file in ipairs(args["file"]) do

--- a/tlcli/configuration.lua
+++ b/tlcli/configuration.lua
@@ -79,6 +79,7 @@ local function validate_config(config)
       feat_arity = { ["off"] = true, ["on"] = true },
       gen_compat = { ["off"] = true, ["optional"] = true, ["required"] = true },
       gen_target = { ["5.1"] = true, ["5.3"] = true, ["5.4"] = true, ["5.5"] = true },
+      emit_luacats = "boolean",
       disable_warnings = "{string}",
       warning_error = "{string}",
       no_stdlib = "boolean",
@@ -243,6 +244,7 @@ function configuration.merge_config_and_args(tlconfig, args)
    tlconfig["gen_target"] = args["gen_target"] or tlconfig["gen_target"]
    tlconfig["gen_compat"] = args["gen_compat"] or tlconfig["gen_compat"] or
    (tlconfig["skip_compat53"] and "off")
+   tlconfig["emit_luacats"] = args["emit_luacats"] or tlconfig["emit_luacats"]
 
    tlconfig["no_stdlib"] = args["no_stdlib"] or tlconfig["no_stdlib"]
 

--- a/tlcli/configuration.tl
+++ b/tlcli/configuration.tl
@@ -79,6 +79,7 @@ local function validate_config(config: {any:any}): TlConfig, {string}, {string}
       feat_arity = { ["off"] = true, ["on"] = true },
       gen_compat = { ["off"] = true, ["optional"] = true, ["required"] = true },
       gen_target = { ["5.1"] = true, ["5.3"] = true, ["5.4"] = true, ["5.5"] = true },
+      emit_luacats = "boolean",
       disable_warnings = "{string}",
       warning_error = "{string}",
       no_stdlib = "boolean"
@@ -243,6 +244,7 @@ function configuration.merge_config_and_args(tlconfig: TlConfig, args: Args)
    tlconfig["gen_target"] = args["gen_target"] or tlconfig["gen_target"]
    tlconfig["gen_compat"] = args["gen_compat"] or tlconfig["gen_compat"]
                                                or (tlconfig["skip_compat53"] and "off")
+   tlconfig["emit_luacats"] = args["emit_luacats"] or tlconfig["emit_luacats"]
 
    tlconfig["no_stdlib"] = args["no_stdlib"] or tlconfig["no_stdlib"]
 

--- a/tlcli/main.lua
+++ b/tlcli/main.lua
@@ -72,6 +72,7 @@ local function get_args_parser()
    hidden(true)
    gen_command:flag("--no-check", "Do not fail on type errors, only on syntax errors.")
    gen_command:flag("--keep-hashbang", "Preserve hashbang line (#!) at the top of file if present.")
+   gen_command:flag("--emit-luacats", "Generate LuaCATS annotations from explicit Teal type declarations.")
    gen_command:option("-o --output", "Write to <filename> instead."):
    argname("<filename>")
    gen_command:option("--output-dir", "Base directory to use for output files. " ..

--- a/tlcli/main.tl
+++ b/tlcli/main.tl
@@ -72,6 +72,7 @@ local function get_args_parser(): argparse.Parser
               :hidden(true)
    gen_command:flag("--no-check", "Do not fail on type errors, only on syntax errors.")
    gen_command:flag("--keep-hashbang", "Preserve hashbang line (#!) at the top of file if present.")
+   gen_command:flag("--emit-luacats", "Generate LuaCATS annotations from explicit Teal type declarations.")
    gen_command:option("-o --output", "Write to <filename> instead.")
               :argname("<filename>")
    gen_command:option("--output-dir", "Base directory to use for output files. " ..

--- a/tlcli/tlconfig.d.tl
+++ b/tlcli/tlconfig.d.tl
@@ -5,6 +5,7 @@ local record TlConfig
    feat_arity: string
    gen_target: string
    gen_compat: string
+   emit_luacats: boolean
    no_stdlib: boolean
    global_env_def: string
    pretend: boolean


### PR DESCRIPTION
Creating this as a draft PR so people can look at it, I've been playing around with different versions of this for a while.

This creates the command gen arg/config `emit-luacats` which will create luacat comments for functions params/returns, union, records enums etc.

This is mostly working and I'll try and create specs for this so there will be tests to ensure it's working, namespaces are still gonna be a pain especially if it's cross package so that is something I'll need to think about too.

As a POC, I cloned https://github.com/FourierTransformer/tinytoml/compare/main...ALameLlama:tinytoml:luacats-gen and ran `tl gen tinytoml.tl --emit-luacats`

I'm also not sure if this should be `emit-luacats` or `gen-luacats` since internally we use `gen` a little differently