### PR TITLE
fix: apply Lua compatibility code in tl.loader() and tl.load()

### DIFF
--- a/spec/api/v2/load_spec.lua
+++ b/spec/api/v2/load_spec.lua
@@ -1,5 +1,7 @@
 require("compat53")
 
+local util = require("spec.util")
+
 describe("tl.load", function()
 
    describe("loading Teal code from Lua", function()
@@ -41,6 +43,27 @@ describe("tl.load", function()
          local lua_chunk = load(lua_code)
          local result = lua_chunk()
          assert.same(result, 123)
+      end)
+
+      -- run in a subprocess: requiring compat53 above patches the stdlib
+      -- globally, which would mask a missing compat preamble on Lua < 5.3
+      it("applies Lua version compatibility code", function()
+         local dir_name = util.write_tmp_dir(finally, {
+            ["main.lua"] = [[
+            local tl = require("teal.api.v2")
+            local program = assert(tl.load("local n: number = 3.0; return math.tointeger(n)"))
+            print(program())
+            ]]
+         })
+         local pd, output
+         util.do_in(dir_name, function()
+            pd = io.popen(util.lua_cmd("main.lua"), "r")
+            output = pd:read("*a")
+         end)
+         util.assert_popen_close(0, pd:close())
+         util.assert_line_by_line([[
+            3
+         ]], output)
       end)
    end)
 end)

--- a/spec/lang/loader/loader_spec.lua
+++ b/spec/lang/loader/loader_spec.lua
@@ -30,6 +30,34 @@ describe("tl.loader", function()
             @.]] .. util.os_sep .. [[file1.tl
          ]], output)
       end)
+      it("applies Lua version compatibility code", function()
+         local dir_name = util.write_tmp_dir(finally, {
+            ["module.tl"] = [[
+            local module = {}
+
+            function module.to_integer(n: number): integer
+               return math.tointeger(n)
+            end
+
+            return module
+            ]],
+            ["main.lua"] = [[
+            local tl = require("teal.api.v2")
+            tl.loader()
+            local module = require("module")
+            print(module.to_integer(3.0))
+            ]]
+         })
+         local pd, output
+         util.do_in(dir_name, function()
+            pd = io.popen(util.lua_cmd("main.lua"), "r")
+            output = pd:read("*a")
+         end)
+         util.assert_popen_close(0, pd:close())
+         util.assert_line_by_line([[
+            3
+         ]], output)
+      end)
       it("works properly with the package.loaded table", function()
          local dir_name = util.write_tmp_dir(finally, {
             ["module.lua"] = [[

--- a/teal.lua
+++ b/teal.lua
@@ -13506,6 +13506,7 @@ end
 -- module teal.loader from teal/loader.lua
 package.preload["teal.loader"] = function(...)
 local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local load = _tl_compat and _tl_compat.load or load; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local environment = require("teal.environment")
+local lua_compat = require("teal.gen.lua_compat")
 local lua_generator = require("teal.gen.lua_generator")
 local package_loader = require("teal.package_loader")
 local input = require("teal.input")
@@ -13565,6 +13566,8 @@ function loader.load(teal_code, chunkname, mode, ...)
 
       mode = mode:gsub("c", "")
    end
+
+   lua_compat.apply(result)
 
    local lua_code = lua_generator.generate(result.ast, package_loader.env.opts.gen_target, lua_generator.fast_opts)
 
@@ -14170,6 +14173,7 @@ local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 th
 
 local require_file = require("teal.check.require_file")
 
+local lua_compat = require("teal.gen.lua_compat")
 local lua_generator = require("teal.gen.lua_generator")
 
 local package_loader = {}
@@ -14192,6 +14196,8 @@ local function tl_package_loader(module_name)
    if #errs > 0 then
       error(found_filename .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg)
    end
+
+   lua_compat.apply(result)
 
 
 

--- a/teal.lua
+++ b/teal.lua
@@ -11316,6 +11316,10 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
 end
 
 function lua_compat.apply(result)
+   if not (result and result.ast) then
+      return
+   end
+
    if result.compat_applied then
       return
    end
@@ -12464,9 +12468,7 @@ function Compiler:recall(filename)
    if not result then
       return nil, nil
    end
-   if result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return module_from_result(result)
 end
 
@@ -12552,9 +12554,7 @@ function ParseTree:check(module_name)
    if result then
       result.syntax_errors = self.syntax_errors
 
-      if result.ast then
-         lua_compat.apply(result)
-      end
+      lua_compat.apply(result)
 
       if module_name then
          self.env.modules[module_name] = result.type

--- a/teal/api/v2.lua
+++ b/teal/api/v2.lua
@@ -133,9 +133,7 @@ v2.check = function(ast, filename, opts, env)
    end
 
    local result = check.check(ast, env, filename or "<input>.tl")
-   if result and result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return result
 end
 
@@ -154,9 +152,7 @@ v2.check_file = function(filename, env, fd)
       return nil, err
    end
    local result = input.check(env, filename, code)
-   if result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return result
 end
 
@@ -166,9 +162,7 @@ v2.check_string = function(teal_code, env, filename, parse_lang)
       filename = parse_lang == "lua" and "<input>.lua" or "<input>.tl"
    end
    local result = input.check(env, filename, teal_code)
-   if result and result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return result
 end
 

--- a/teal/api/v2.tl
+++ b/teal/api/v2.tl
@@ -133,9 +133,7 @@ v2.check = function(ast: Node, filename?: string, opts?: CheckOptions, env?: Env
    end
 
    local result = check.check(ast as parser.Node, env, filename or "<input>.tl")
-   if result and result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return result
 end
 
@@ -154,9 +152,7 @@ v2.check_file = function(filename: string, env?: Env, fd?: FILE): (Result, strin
       return nil, err
    end
    local result = input.check(env, filename, code)
-   if result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return result
 end
 
@@ -166,9 +162,7 @@ v2.check_string = function(teal_code: string, env?: Env, filename?: string, pars
       filename = parse_lang == "lua" and "<input>.lua" or "<input>.tl"
    end
    local result = input.check(env, filename, teal_code)
-   if result and result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return result
 end
 

--- a/teal/gen/lua_compat.lua
+++ b/teal/gen/lua_compat.lua
@@ -279,6 +279,10 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
 end
 
 function lua_compat.apply(result)
+   if not (result and result.ast) then
+      return
+   end
+
    if result.compat_applied then
       return
    end

--- a/teal/gen/lua_compat.tl
+++ b/teal/gen/lua_compat.tl
@@ -279,6 +279,10 @@ local function adjust_code(ast: Node, needs_compat: {string:boolean}, gen_compat
 end
 
 function lua_compat.apply(result: Result)
+   if not (result and result.ast) then
+      return
+   end
+
    if result.compat_applied then
       return
    end

--- a/teal/init.lua
+++ b/teal/init.lua
@@ -247,9 +247,7 @@ function Compiler:recall(filename)
    if not result then
       return nil, nil
    end
-   if result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return module_from_result(result)
 end
 
@@ -335,9 +333,7 @@ function ParseTree:check(module_name)
    if result then
       result.syntax_errors = self.syntax_errors
 
-      if result.ast then
-         lua_compat.apply(result)
-      end
+      lua_compat.apply(result)
 
       if module_name then
          self.env.modules[module_name] = result.type

--- a/teal/init.tl
+++ b/teal/init.tl
@@ -247,9 +247,7 @@ function Compiler:recall(filename: string): Module, CheckError
    if not result then
       return nil, nil
    end
-   if result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return module_from_result(result)
 end
 
@@ -335,9 +333,7 @@ function ParseTree:check(module_name?: string): Module, CheckError
    if result then
       result.syntax_errors = self.syntax_errors
 
-      if result.ast then
-         lua_compat.apply(result)
-      end
+      lua_compat.apply(result)
 
       if module_name then
          self.env.modules[module_name] = result.type

--- a/teal/loader.lua
+++ b/teal/loader.lua
@@ -1,4 +1,5 @@
 local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local load = _tl_compat and _tl_compat.load or load; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local environment = require("teal.environment")
+local lua_compat = require("teal.gen.lua_compat")
 local lua_generator = require("teal.gen.lua_generator")
 local package_loader = require("teal.package_loader")
 local input = require("teal.input")
@@ -58,6 +59,8 @@ function loader.load(teal_code, chunkname, mode, ...)
 
       mode = mode:gsub("c", "")
    end
+
+   lua_compat.apply(result)
 
    local lua_code = lua_generator.generate(result.ast, package_loader.env.opts.gen_target, lua_generator.fast_opts)
 

--- a/teal/loader.tl
+++ b/teal/loader.tl
@@ -1,4 +1,5 @@
 local environment = require("teal.environment")
+local lua_compat = require("teal.gen.lua_compat")
 local lua_generator = require("teal.gen.lua_generator")
 local package_loader = require("teal.package_loader")
 local input = require("teal.input")
@@ -58,6 +59,8 @@ function loader.load(teal_code: string, chunkname?: string, mode?: LoadMode, ...
 
       mode = mode:gsub("c", "") as LoadMode
    end
+
+   lua_compat.apply(result)
 
    local lua_code = lua_generator.generate(result.ast, package_loader.env.opts.gen_target, lua_generator.fast_opts)
 

--- a/teal/package_loader.lua
+++ b/teal/package_loader.lua
@@ -3,6 +3,7 @@ local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 th
 
 local require_file = require("teal.check.require_file")
 
+local lua_compat = require("teal.gen.lua_compat")
 local lua_generator = require("teal.gen.lua_generator")
 
 local package_loader = {}
@@ -25,6 +26,8 @@ local function tl_package_loader(module_name)
    if #errs > 0 then
       error(found_filename .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg)
    end
+
+   lua_compat.apply(result)
 
 
 

--- a/teal/package_loader.tl
+++ b/teal/package_loader.tl
@@ -3,6 +3,7 @@ local type Env = environment.Env
 
 local require_file = require("teal.check.require_file")
 
+local lua_compat = require("teal.gen.lua_compat")
 local lua_generator = require("teal.gen.lua_generator")
 
 local record package_loader
@@ -25,6 +26,8 @@ local function tl_package_loader(module_name: string): any, any
    if #errs > 0 then
       error(found_filename .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg)
    end
+
+   lua_compat.apply(result)
 
    -- TODO: should this be a hard error? this seems analogous to
    -- finding a lua file with a syntax error in it

--- a/tl.lua
+++ b/tl.lua
@@ -135,9 +135,7 @@ v2.check = function(ast, filename, opts, env)
    end
 
    local result = check.check(ast, env, filename or "<input>.tl")
-   if result and result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return result
 end
 
@@ -156,9 +154,7 @@ v2.check_file = function(filename, env, fd)
       return nil, err
    end
    local result = input.check(env, filename, code)
-   if result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return result
 end
 
@@ -168,9 +164,7 @@ v2.check_string = function(teal_code, env, filename, parse_lang)
       filename = parse_lang == "lua" and "<input>.lua" or "<input>.tl"
    end
    local result = input.check(env, filename, teal_code)
-   if result and result.ast then
-      lua_compat.apply(result)
-   end
+   lua_compat.apply(result)
    return result
 end
 
@@ -11576,6 +11570,10 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
 end
 
 function lua_compat.apply(result)
+   if not (result and result.ast) then
+      return
+   end
+
    if result.compat_applied then
       return
    end

--- a/tl.lua
+++ b/tl.lua
@@ -13352,6 +13352,7 @@ end
 -- module teal.loader from teal/loader.lua
 package.preload["teal.loader"] = function(...)
 local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 then local p, m = pcall(require, 'compat53.module'); if p then _tl_compat = m end end; local assert = _tl_compat and _tl_compat.assert or assert; local ipairs = _tl_compat and _tl_compat.ipairs or ipairs; local load = _tl_compat and _tl_compat.load or load; local string = _tl_compat and _tl_compat.string or string; local table = _tl_compat and _tl_compat.table or table; local environment = require("teal.environment")
+local lua_compat = require("teal.gen.lua_compat")
 local lua_generator = require("teal.gen.lua_generator")
 local package_loader = require("teal.package_loader")
 local input = require("teal.input")
@@ -13411,6 +13412,8 @@ function loader.load(teal_code, chunkname, mode, ...)
 
       mode = mode:gsub("c", "")
    end
+
+   lua_compat.apply(result)
 
    local lua_code = lua_generator.generate(result.ast, package_loader.env.opts.gen_target, lua_generator.fast_opts)
 
@@ -14016,6 +14019,7 @@ local _tl_compat; if (tonumber((_VERSION or ''):match('[%d.]*$')) or 0) < 5.3 th
 
 local require_file = require("teal.check.require_file")
 
+local lua_compat = require("teal.gen.lua_compat")
 local lua_generator = require("teal.gen.lua_generator")
 
 local package_loader = {}
@@ -14038,6 +14042,8 @@ local function tl_package_loader(module_name)
    if #errs > 0 then
       error(found_filename .. ":" .. errs[1].y .. ":" .. errs[1].x .. ": " .. errs[1].msg)
    end
+
+   lua_compat.apply(result)
 
 
 


### PR DESCRIPTION
I ran into this while I set up a job to test Cerulean with Teal dev.

I am not 100% sure if this is the right fix. Other alternatives:
1. Call `lua_compat.apply` inside `input.check` or at the end of `check.check`, which
   restores the code to be closer to how it was in 0.24.8.
2. Thread `gen_compat` through `lua_generator.generate`, which changes its signature.

If you want I could change to either or open an issue instead.