### PR TITLE
Fix compilation of Teal scripts under Lua 5.5

### DIFF
--- a/docs/src/compiler_options.md
+++ b/docs/src/compiler_options.md
@@ -90,6 +90,9 @@ generating 5.3-compatible code. If you install `tl` using LuaRocks, the CLI
 will use the Lua version you use with LuaRocks, so it will default to that
 Lua's version.
 
+The `tl run` command loads the code it generates into the Lua VM it is running
+on, so unless you set `--gen-target` it targets that exact version.
+
 If you require the `tl` Lua module and use the `tl.loader()`, it will do the
 implicit version selection, picking the right choice based on the Lua version
 you're running it on.

--- a/spec/cli/run_spec.lua
+++ b/spec/cli/run_spec.lua
@@ -28,6 +28,23 @@ describe("tl run", function()
          ]], output)
       end)
 
+      it("runs code that modifies a for loop control variable", function()
+         local name = util.write_tmp_file(finally, [[
+            local t: {string:string} = { a = "1" }
+
+            for k, v in pairs(t) do
+               k = k:upper()
+               print(k .. "=" .. v)
+            end
+         ]])
+         local pd = io.popen(util.tl_cmd("run", name), "r")
+         local output = pd:read("*a")
+         util.assert_popen_close(0, pd:close())
+         util.assert_line_by_line([[
+            A=1
+         ]], output)
+      end)
+
       it("reports number of errors in stderr and code 1 on type errors", function()
          local name = util.write_tmp_file(finally, [[
             local function add(a: number, b: number): number

--- a/tlcli/commands/run.lua
+++ b/tlcli/commands/run.lua
@@ -37,6 +37,15 @@ local function type_check_and_load(tlconfig, filename)
 end
 
 return function(tlconfig, args)
+
+   local runtime_target = teal.runtime_target()
+   if runtime_target and not tlconfig["gen_target"] then
+      tlconfig["gen_target"] = runtime_target
+      if runtime_target == "5.4" or runtime_target == "5.5" then
+         tlconfig["gen_compat"] = "off"
+      end
+   end
+
    if args["require"] then
       tlconfig._init_env_modules = {}
       for _, module in ipairs(args["require"]) do

--- a/tlcli/commands/run.tl
+++ b/tlcli/commands/run.tl
@@ -37,6 +37,15 @@ local function type_check_and_load(tlconfig: TlConfig, filename: string): functi
 end
 
 return function(tlconfig: TlConfig, args: Args): any
+   -- the script is loaded into the Lua running tl, so target that version
+   local runtime_target = teal.runtime_target()
+   if runtime_target and not tlconfig["gen_target"] then
+      tlconfig["gen_target"] = runtime_target
+      if runtime_target == "5.4" or runtime_target == "5.5" then
+         tlconfig["gen_compat"] = "off"
+      end
+   end
+
    if args["require"] then
       tlconfig._init_env_modules = {}
       for _, module in ipairs(args["require"]) do

--- a/tlcli/driver.lua
+++ b/tlcli/driver.lua
@@ -13,8 +13,8 @@ local driver = {}
 local function filename_to_module_name(filename)
    local path = os.getenv("TL_PATH") or package.path
    for entry in path:gmatch("[^;]+") do
-      entry = entry:gsub("%.", "%%.")
-      local lua_pat = "^" .. entry:gsub("%?", ".+") .. "$"
+      local escaped = entry:gsub("%.", "%%.")
+      local lua_pat = "^" .. escaped:gsub("%?", ".+") .. "$"
       local d_tl_pat = lua_pat:gsub("%%.lua%$", "%%.d%%.tl$")
       local tl_pat = lua_pat:gsub("%%.lua%$", "%%.tl$")
 

--- a/tlcli/driver.tl
+++ b/tlcli/driver.tl
@@ -13,8 +13,8 @@ end
 local function filename_to_module_name(filename: string): string
    local path = os.getenv("TL_PATH") or package.path
    for entry in path:gmatch("[^;]+") do
-      entry = entry:gsub("%.", "%%.")
-      local lua_pat = "^" .. entry:gsub("%?", ".+") .. "$"
+      local escaped = entry:gsub("%.", "%%.")
+      local lua_pat = "^" .. escaped:gsub("%?", ".+") .. "$"
       local d_tl_pat = lua_pat:gsub("%%.lua%$", "%%.d%%.tl$")
       local tl_pat = lua_pat:gsub("%%.lua%$", "%%.tl$")
 


### PR DESCRIPTION
Teal does not run on Lua 5.5. 

Lua 5.5 makes the first variable of a generic `for` loop `const`, which broke tlcli/driver.tl. So the compiler cannot load itself. That is a one line fix. I regenerated the committed .lua with make selfbuild.

The second is tl run. It compiled for the 5.3 target, then loaded the result into the running VM. The shadow that allows assigning to a for-in variable is only emitted for 5.4 and 5.5. So any script using that feature died on 5.5 with an internal compiler error. It now takes its target from teal.runtime_target(), like tl.load already does.

Tests pass on 5.5.0 and 5.4.8. Macro bodies still generate for 5.1 and skip the compat pass, so that path is still broken.