### PR TITLE
Always shadow for-loop control variables in macro bodies

### DIFF
--- a/spec/lang/macro/for_control_var_spec.lua
+++ b/spec/lang/macro/for_control_var_spec.lua
@@ -63,4 +63,26 @@ describe('macro body for-loop control variables', function()
       out = out:gsub("^%s+", ""):gsub("%s+$", "")
       assert.same("print('hi'); print('hi')", out)
    end)
+   it('handles a generic for with multiple control variables', function()
+      local code = [[
+         local macro pairs2!(x: Expression)
+            local out = block('statements')
+            for k, v in pairs({ a = 1, b = 2 }) do
+               k = k .. '!'
+               v = v + 10
+               table.insert(out, `$x`)
+            end
+            return out
+         end
+
+         pairs2!(print('hi'))
+      ]]
+      local ast, errs = tl.parse(code)
+      assert.same({}, errs)
+      local out, err = lua_generator.generate(ast, '5.4')
+      assert.is_nil(err)
+      out = out:gsub("^%s+", ""):gsub("%s+$", "")
+      assert.same("print('hi'); print('hi')", out)
+   end)
+
 end)

--- a/spec/lang/macro/for_control_var_spec.lua
+++ b/spec/lang/macro/for_control_var_spec.lua
@@ -1,0 +1,66 @@
+local tl = require('tl')
+local lua_generator = require('teal.gen.lua_generator')
+
+describe('macro body for-loop control variables', function()
+   it('allows a numeric for body to write to the control variable', function()
+      local code = [[
+         local macro thrice!(x: Expression)
+            local out = block('statements')
+            for i = 1, 3 do
+               i = i + 10
+               table.insert(out, `$x`)
+            end
+            return out
+         end
+
+         thrice!(print('hi'))
+      ]]
+      local ast, errs = tl.parse(code)
+      assert.same({}, errs)
+      local out, err = lua_generator.generate(ast, '5.4')
+      assert.is_nil(err)
+      out = out:gsub("^%s+", ""):gsub("%s+$", "")
+      assert.same("print('hi'); print('hi'); print('hi')", out)
+   end)
+
+   it('allows a generic for body to write to the control variable', function()
+      local code = [[
+         local macro each!(x: Expression)
+            local out = block('statements')
+            for word in ('a b'):gmatch('%a+') do
+               word = word .. '!'
+               table.insert(out, `$x`)
+            end
+            return out
+         end
+
+         each!(print('hi'))
+      ]]
+      local ast, errs = tl.parse(code)
+      assert.same({}, errs)
+      local out, err = lua_generator.generate(ast, '5.4')
+      assert.is_nil(err)
+      out = out:gsub("^%s+", ""):gsub("%s+$", "")
+      assert.same("print('hi'); print('hi')", out)
+   end)
+
+   it('does not disturb loops that never write the control variable', function()
+      local code = [[
+         local macro twice!(x: Expression)
+            local out = block('statements')
+            for _ = 1, 2 do
+               table.insert(out, `$x`)
+            end
+            return out
+         end
+
+         twice!(print('hi'))
+      ]]
+      local ast, errs = tl.parse(code)
+      assert.same({}, errs)
+      local out, err = lua_generator.generate(ast, '5.4')
+      assert.is_nil(err)
+      out = out:gsub("^%s+", ""):gsub("%s+$", "")
+      assert.same("print('hi'); print('hi')", out)
+   end)
+end)

--- a/teal.lua
+++ b/teal.lua
@@ -13760,6 +13760,40 @@ local function is_statement_kind(k)
    k == "record_function" or k == "newtype" or k == "pragma"
 end
 
+
+local function add_for_shadows(b)
+   if b.kind == "forin" or b.kind == "fornum" then
+      local map = BLOCK_INDEXES[b.kind:upper()]
+      local body = b[map.BODY]
+
+      local var = b[1]
+      if b.kind == "forin" then
+         var = var and var[1]
+      end
+
+      if body and var and var.kind == "identifier" then
+         local name = var.tk
+
+         local function at(kind)
+            return { kind = kind, tk = name, f = b.f, y = b.y, x = b.x, yend = b.y, xend = b.x }
+         end
+
+         local LD = BLOCK_INDEXES.LOCAL_DECLARATION
+         local stmt = at("local_declaration")
+         stmt[LD.VARS] = at("variable_list")
+         stmt[LD.VARS][1] = at("identifier")
+         stmt[LD.EXPS] = at("expression_list")
+         stmt[LD.EXPS][1] = at("identifier")
+
+         table.insert(body, 1, stmt)
+      end
+   end
+
+   for _, child in children(b) do
+      add_for_shadows(child)
+   end
+end
+
 local function compile_local_macro(mb, filename, read_lang, env, errs)
    local name_block = mb[BLOCK_INDEXES.LOCAL_MACRO.NAME]
    if not name_block or name_block.kind ~= "identifier" then
@@ -13802,6 +13836,9 @@ local function compile_local_macro(mb, filename, read_lang, env, errs)
    local lua_generator = require("teal.gen.lua_generator")
    local single = { kind = "statements", y = mb.y, x = mb.x, tk = mb.tk, yend = mb.yend, xend = mb.xend }
    single[1] = mb
+
+   add_for_shadows(single)
+
    local mast, perrs = ast.parse_blocks(single, filename, read_lang)
    if #perrs > 0 then
       for _, e in ipairs(perrs) do table.insert(errs, e) end

--- a/teal/macro_eval.lua
+++ b/teal/macro_eval.lua
@@ -178,6 +178,40 @@ local function is_statement_kind(k)
    k == "record_function" or k == "newtype" or k == "pragma"
 end
 
+
+local function add_for_shadows(b)
+   if b.kind == "forin" or b.kind == "fornum" then
+      local map = BLOCK_INDEXES[b.kind:upper()]
+      local body = b[map.BODY]
+
+      local var = b[1]
+      if b.kind == "forin" then
+         var = var and var[1]
+      end
+
+      if body and var and var.kind == "identifier" then
+         local name = var.tk
+
+         local function at(kind)
+            return { kind = kind, tk = name, f = b.f, y = b.y, x = b.x, yend = b.y, xend = b.x }
+         end
+
+         local LD = BLOCK_INDEXES.LOCAL_DECLARATION
+         local stmt = at("local_declaration")
+         stmt[LD.VARS] = at("variable_list")
+         stmt[LD.VARS][1] = at("identifier")
+         stmt[LD.EXPS] = at("expression_list")
+         stmt[LD.EXPS][1] = at("identifier")
+
+         table.insert(body, 1, stmt)
+      end
+   end
+
+   for _, child in children(b) do
+      add_for_shadows(child)
+   end
+end
+
 local function compile_local_macro(mb, filename, read_lang, env, errs)
    local name_block = mb[BLOCK_INDEXES.LOCAL_MACRO.NAME]
    if not name_block or name_block.kind ~= "identifier" then
@@ -220,6 +254,9 @@ local function compile_local_macro(mb, filename, read_lang, env, errs)
    local lua_generator = require("teal.gen.lua_generator")
    local single = { kind = "statements", y = mb.y, x = mb.x, tk = mb.tk, yend = mb.yend, xend = mb.xend }
    single[1] = mb
+
+   add_for_shadows(single)
+
    local mast, perrs = ast.parse_blocks(single, filename, read_lang)
    if #perrs > 0 then
       for _, e in ipairs(perrs) do table.insert(errs, e) end

--- a/teal/macro_eval.tl
+++ b/teal/macro_eval.tl
@@ -178,6 +178,40 @@ local function is_statement_kind(k: block.BlockKind): boolean
           k == "record_function" or k == "newtype" or k == "pragma"
 end
 
+-- 5.5 makes `for` control variables const; shadowing is a no-op in older targets.
+local function add_for_shadows(b: Block)
+   if b.kind == "forin" or b.kind == "fornum" then
+      local map = BLOCK_INDEXES[b.kind:upper()]
+      local body = b[map.BODY]
+
+      local var = b[1]
+      if b.kind == "forin" then
+         var = var and var[1]
+      end
+
+      if body and var and var.kind == "identifier" then
+         local name = var.tk
+         
+         local function at(kind : block.BlockKind) : Block
+            return { kind = kind, tk = name, f = b.f, y = b.y, x = b.x, yend = b.y, xend = b.x }
+         end
+
+         local LD = BLOCK_INDEXES.LOCAL_DECLARATION
+         local stmt = at("local_declaration")
+         stmt[LD.VARS] = at("variable_list")
+         stmt[LD.VARS][1] = at("identifier")
+         stmt[LD.EXPS] = at("expression_list") 
+         stmt[LD.EXPS][1] = at("identifier")
+
+         table.insert(body, 1, stmt)
+      end
+   end
+
+   for _, child in children(b) do
+      add_for_shadows(child)
+   end
+end
+
 local function compile_local_macro(mb: Block, filename: string, read_lang: BlockLang, env: MacroEnv, errs: {Error})
    local name_block = mb[BLOCK_INDEXES.LOCAL_MACRO.NAME]
    if not name_block or name_block.kind ~= "identifier" then
@@ -220,6 +254,9 @@ local function compile_local_macro(mb: Block, filename: string, read_lang: Block
    local lua_generator = require("teal.gen.lua_generator")
    local single: Block = { kind = "statements", y = mb.y, x = mb.x, tk = mb.tk, yend = mb.yend, xend = mb.xend }
    single[1] = mb
+
+   add_for_shadows(single)
+
    local mast, perrs = ast.parse_blocks(single, filename, read_lang)
    if #perrs > 0 then
       for _, e in ipairs(perrs) do table.insert(errs, e) end

--- a/tl.lua
+++ b/tl.lua
@@ -13604,6 +13604,40 @@ local function is_statement_kind(k)
    k == "record_function" or k == "newtype" or k == "pragma"
 end
 
+
+local function add_for_shadows(b)
+   if b.kind == "forin" or b.kind == "fornum" then
+      local map = BLOCK_INDEXES[b.kind:upper()]
+      local body = b[map.BODY]
+
+      local var = b[1]
+      if b.kind == "forin" then
+         var = var and var[1]
+      end
+
+      if body and var and var.kind == "identifier" then
+         local name = var.tk
+
+         local function at(kind)
+            return { kind = kind, tk = name, f = b.f, y = b.y, x = b.x, yend = b.y, xend = b.x }
+         end
+
+         local LD = BLOCK_INDEXES.LOCAL_DECLARATION
+         local stmt = at("local_declaration")
+         stmt[LD.VARS] = at("variable_list")
+         stmt[LD.VARS][1] = at("identifier")
+         stmt[LD.EXPS] = at("expression_list")
+         stmt[LD.EXPS][1] = at("identifier")
+
+         table.insert(body, 1, stmt)
+      end
+   end
+
+   for _, child in children(b) do
+      add_for_shadows(child)
+   end
+end
+
 local function compile_local_macro(mb, filename, read_lang, env, errs)
    local name_block = mb[BLOCK_INDEXES.LOCAL_MACRO.NAME]
    if not name_block or name_block.kind ~= "identifier" then
@@ -13646,6 +13680,9 @@ local function compile_local_macro(mb, filename, read_lang, env, errs)
    local lua_generator = require("teal.gen.lua_generator")
    local single = { kind = "statements", y = mb.y, x = mb.x, tk = mb.tk, yend = mb.yend, xend = mb.xend }
    single[1] = mb
+
+   add_for_shadows(single)
+
    local mast, perrs = ast.parse_blocks(single, filename, read_lang)
    if #perrs > 0 then
       for _, e in ipairs(perrs) do table.insert(errs, e) end


### PR DESCRIPTION
## Problem

A macro whose body writes to the control variable of a `for` loop fails to
compile when the compiler itself runs on Lua 5.5:

```lua
local macro shout!(x: Expression)
   local out = block('statements')
   for entry in ("a;b"):gmatch("[^;]+") do
      entry = entry .. "!"
   end
   table.insert(out, `$x`)
   return out
end

shout!(print('hi'))
```

```
$ lua5.5 ./tl run macro_bug.tl
[string "shout"]:3: attempt to assign to const variable 'entry'
```

Numeric `for` in a macro body fails the same way. The file works on 5.1, 5.3
and 5.4 — 5.5 is the first version to make the control variable a constant.

## Fix

Macro bodies keep targeting the 5.1 subset, as discussed. Instead of detecting
whether a body writes to a control variable, `macro_eval` now inserts the
shadowing local into every `for` in the macro body before parsing. `local x = x`
is valid in every supported target and is a no-op when nothing writes to it, so
no detection is needed and the traversal from the previous revision is gone.

Both `forin` and `fornum` are covered. 39 lines in `teal/macro_eval.tl`; no
other source file is touched.

## Tests

`spec/lang/macro/for_control_var_spec.lua` adds three cases: a numeric `for`
body that writes its control variable, a generic `for` body that writes its
control variable, and a loop that never writes one. Each asserts the expanded
output rather than just that parsing succeeded, so the number of iterations the
macro body actually performed is encoded in the result.

Two of the three fail on Lua 5.5 without this change. On 5.1–5.4 they pass
either way, since those versions allow the assignment — which is also why CI
does not catch this today (`lua-version: ["5.4", "5.3", "5.2", "5.1", "luajit"]`).

`make selfbuild` is clean and `busted --suppress-pending spec/` passes.

## Related

Numeric `for` has the same problem outside macros: `lua_compat.adjust_code` has
no `fornum` case, so ordinary Teal code that writes to a numeric loop variable
type checks and then emits invalid Lua on 5.5. That is the issue @bjornbm ran
into in #1159; it reproduces on master without this change and needs
`lua_compat` and `visitors` changes, so it is out of scope here. Happy to take
it separately if nobody else is on it.