### PR TITLE
Fix: reject built-in simple type with a trailing dotted name (e.g. number.x.y.z)

### DIFF
--- a/spec/lang/declaration/local_type_spec.lua
+++ b/spec/lang/declaration/local_type_spec.lua
@@ -231,4 +231,16 @@ describe("local type", function()
    ]], {
       { y = 14, msg = 'in record field: Data: string "invalid" is not a member of MyEnum' }
    }))
+
+   it("does not accept a built-in simple type followed by a dotted name (regression test for #1136)", util.check_type_error([[
+      local a: number.x.y.z = 1
+      local b: string.a.b = "x"
+      local c: integer.foo = 1
+      local d: boolean.foo = true
+   ]], {
+      { y = 1, msg = "unknown type number.x.y.z" },
+      { y = 2, msg = "unknown type string.a.b" },
+      { y = 3, msg = "unknown type integer.foo" },
+      { y = 4, msg = "unknown type boolean.foo" },
+   }))
 end)

--- a/teal.lua
+++ b/teal.lua
@@ -1971,7 +1971,8 @@ end
 parse_simple_type_or_nominal = function(state, block)
    local tk = block.tk
    local st = simple_types[tk]
-   if st then
+   local rest = block[reader.BLOCK_INDEXES.NOMINAL_TYPE.NAME + 1]
+   if st and not (rest and rest.kind == "identifier") then
       return new_type(state, block, tk)
    elseif tk == "table" and block.kind ~= "nominal_type" then
       local typ = new_type(state, block, "map")

--- a/teal/ast.lua
+++ b/teal/ast.lua
@@ -1969,7 +1969,8 @@ end
 parse_simple_type_or_nominal = function(state, block)
    local tk = block.tk
    local st = simple_types[tk]
-   if st then
+   local rest = block[reader.BLOCK_INDEXES.NOMINAL_TYPE.NAME + 1]
+   if st and not (rest and rest.kind == "identifier") then
       return new_type(state, block, tk)
    elseif tk == "table" and block.kind ~= "nominal_type" then
       local typ = new_type(state, block, "map")

--- a/teal/ast.tl
+++ b/teal/ast.tl
@@ -1969,7 +1969,8 @@ end
 parse_simple_type_or_nominal = function(state: ParseState, block: Block): FirstOrderType
    local tk = block.tk
    local st = simple_types[tk as TypeName]
-   if st then
+   local rest = block[reader.BLOCK_INDEXES.NOMINAL_TYPE.NAME + 1]
+   if st and not (rest and rest.kind == "identifier") then
       return new_type(state, block, tk as TypeName) as StructuralType
    elseif tk == "table" and block.kind ~= "nominal_type" then -- reader already turns plain `table` into map_type
       local typ = new_type(state, block, "map") as MapType

--- a/tl.lua
+++ b/tl.lua
@@ -2225,7 +2225,8 @@ end
 parse_simple_type_or_nominal = function(state, block)
    local tk = block.tk
    local st = simple_types[tk]
-   if st then
+   local rest = block[reader.BLOCK_INDEXES.NOMINAL_TYPE.NAME + 1]
+   if st and not (rest and rest.kind == "identifier") then
       return new_type(state, block, tk)
    elseif tk == "table" and block.kind ~= "nominal_type" then
       local typ = new_type(state, block, "map")


### PR DESCRIPTION
Fixes #1136.

## Root cause
`parse_simple_type_or_nominal` in `teal/ast.tl` short-circuits on a built-in simple type (number/string/integer/boolean/thread/any/self) and discards any trailing dotted name parts. As a result an invalid annotation like `local x: number.x.y.z = 1` is accepted as `number` and type-checks with no errors, while `table.x.y.z` (which is not a simple type and takes the nominal path) correctly reports `unknown type table.x.y.z`.

## Fix
Only take the simple-type short-circuit when there is no dotted continuation (`block[NOMINAL_TYPE.NAME + 1]` is not an `identifier`). Otherwise fall through to the existing nominal path, which reports the unknown type. Ran `make` to regenerate the `.lua` artifacts (`teal/ast.lua`, `tl.lua`, `teal.lua`) from the `.tl` source per the repo's codegen convention.

## Tests
Added a regression test in `spec/lang/declaration/local_type_spec.lua` asserting that `number.x.y.z`, `string.a.b`, `integer.foo`, and `boolean.foo` each report `unknown type ...` (4 type errors, 0 syntax errors).

Verified red/green with busted (test fails before the fix, passes after) and the full suite passes (1928 successes / 0 failures). Plain `number`/`string`/`integer`/`boolean` still type-check; `nil.x`/`any.x`/`self.x`/`thread.x` still error cleanly with no crash; a real dotted record type and `string.format` are unaffected.

Thanks to @purplesyringa for the clear report.

---
This change was prepared with AI assistance and reviewed by me before submission.