### PR TITLE
compat: shadow numeric for control variables on 5.4+

### DIFF
--- a/spec/lang/code_gen/fornum_spec.lua
+++ b/spec/lang/code_gen/fornum_spec.lua
@@ -1,0 +1,97 @@
+local util = require("spec.util")
+
+describe("fornum", function()
+   it("5.3: doesn't generate control variable that is local to the iteration", util.gen([[
+      local t: {string} = { "a", "b", "c" }
+
+      for i = 1, #t do
+         i = i + 1
+         print(t[i])
+      end
+   ]], [[
+      local t = { "a", "b", "c" }
+
+      for i = 1, #t do
+         i = i + 1
+         print(t[i])
+      end
+   ]], "5.3"))
+
+   it("5.4: generates control variable that is local to the iteration", util.gen([[
+      local t: {string} = { "a", "b", "c" }
+
+      for i = 1, #t do
+         i = i + 1
+         print(t[i])
+      end
+   ]], [[
+      local t = { "a", "b", "c" }
+
+      for i = 1, #t do local i = i
+         i = i + 1
+         print(t[i])
+      end
+   ]], "5.4"))
+
+   it("5.4: does not generate control variable if not assigned to", util.gen([[
+      local t: {string} = { "a", "b", "c" }
+
+      for i = 1, #t do
+         local j = i + 1
+         print(t[j])
+      end
+   ]], [[
+      local t = { "a", "b", "c" }
+
+      for i = 1, #t do
+         local j = i + 1
+         print(t[j])
+      end
+   ]], "5.4"))
+
+   it("5.4: generates control variable for a loop with a step", util.gen([[
+      for i = 10, 1, -2 do
+         i = i // 2
+         print(i)
+      end
+   ]], [[
+      for i = 10, 1, -2 do local i = i
+         i = i // 2
+         print(i)
+      end
+   ]], "5.4"))
+
+   it("5.4: detects an assignment made from a nested function", util.gen([[
+      for i = 1, 3 do
+         local function bump()
+            i = i + 1
+         end
+         bump()
+         print(i)
+      end
+   ]], [[
+      for i = 1, 3 do local i = i
+         local function bump()
+            i = i + 1
+         end
+         bump()
+         print(i)
+      end
+   ]], "5.4"))
+
+   it("5.4: only shadows the loops that are assigned to", util.gen([[
+      for i = 1, 3 do
+         for j = 1, 3 do
+            j = j + 1
+            print(i, j)
+         end
+      end
+   ]], [[
+      for i = 1, 3 do
+         for j = 1, 3 do local j = j
+            j = j + 1
+            print(i, j)
+         end
+      end
+   ]], "5.4"))
+end)

--- a/teal.lua
+++ b/teal.lua
@@ -238,6 +238,7 @@ local parse_typeargs_if_any
 
 
 
+
 local ast = {}
 
 
@@ -8486,7 +8487,14 @@ visit_node.cbs = {
          "number"
          self:add_var(node.var, node.var.tk, a_type(node.var, typename, {}))
       end,
-      after = end_scope_and_none_type,
+      after = function(self, node, _children)
+         local var = self:find_var(node.var.tk)
+         if var and var.has_been_written_to then
+            node.fornum_modifies_control_var = true
+         end
+         self:end_scope(node)
+         return NONE
+      end,
    },
    ["return"] = {
       before = function(self, node)
@@ -11154,6 +11162,25 @@ local bit_operators = {
    ["<<"] = "lshift",
 }
 
+
+local function shadow_control_var(node, control_var)
+   if #node.body == 0 then
+      return
+   end
+   local stmt = node_at(node, {
+      kind = "local_declaration",
+      vars = node_at(node, {
+         kind = "variable_list",
+         node_at(node, { kind = "variable", is_lvalue = true, tk = control_var }),
+      }),
+      exps = node_at(node, {
+         kind = "expression_list",
+         node_at(node, { kind = "variable", tk = control_var }),
+      }),
+   })
+   table.insert(node.body, 1, stmt)
+end
+
 local function adjust_code(ast, needs_compat, gen_compat, gen_target)
    local visit = false
 
@@ -11283,24 +11310,15 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
       visit = true
       visit_node.cbs["forin"] = {
          after = function(_, node, _children)
-            if #node.body == 0 then
-               return
-            end
             if node.forin_modifies_control_var then
-               local control_var = node.vars[1].tk
-               local loc_at = node
-               local stmt = node_at(loc_at, {
-                  kind = "local_declaration",
-                  vars = node_at(loc_at, {
-                     kind = "variable_list",
-                     node_at(loc_at, { kind = "variable", is_lvalue = true, tk = control_var }),
-                  }),
-                  exps = node_at(loc_at, {
-                     kind = "expression_list",
-                     node_at(loc_at, { kind = "variable", tk = control_var }),
-                  }),
-               })
-               table.insert(node.body, 1, stmt)
+               shadow_control_var(node, node.vars[1].tk)
+            end
+         end,
+      }
+      visit_node.cbs["fornum"] = {
+         after = function(_, node, _children)
+            if node.fornum_modifies_control_var then
+               shadow_control_var(node, node.var.tk)
             end
          end,
       }

--- a/teal/ast.lua
+++ b/teal/ast.lua
@@ -236,6 +236,7 @@ local parse_typeargs_if_any
 
 
 
+
 local ast = {}
 
 

--- a/teal/ast.tl
+++ b/teal/ast.tl
@@ -162,6 +162,7 @@ local record Node
    from: Node
    to: Node
    step: Node
+   fornum_modifies_control_var: boolean
 
    -- forin
    vars: Node

--- a/teal/check/visitors.lua
+++ b/teal/check/visitors.lua
@@ -1217,7 +1217,14 @@ visit_node.cbs = {
          "number"
          self:add_var(node.var, node.var.tk, a_type(node.var, typename, {}))
       end,
-      after = end_scope_and_none_type,
+      after = function(self, node, _children)
+         local var = self:find_var(node.var.tk)
+         if var and var.has_been_written_to then
+            node.fornum_modifies_control_var = true
+         end
+         self:end_scope(node)
+         return NONE
+      end,
    },
    ["return"] = {
       before = function(self, node)

--- a/teal/check/visitors.tl
+++ b/teal/check/visitors.tl
@@ -1217,7 +1217,14 @@ visit_node.cbs = {
                                     or  "number"
          self:add_var(node.var, node.var.tk, a_type(node.var, typename, {}))
       end,
-      after = end_scope_and_none_type,
+      after = function(self: Context, node: Node, _children: {Type}): Type
+         local var = self:find_var(node.var.tk)
+         if var and var.has_been_written_to then
+            node.fornum_modifies_control_var = true
+         end
+         self:end_scope(node)
+         return NONE
+      end,
    },
    ["return"] = {
       before = function(self: Context, node: Node)

--- a/teal/gen/lua_compat.lua
+++ b/teal/gen/lua_compat.lua
@@ -117,6 +117,25 @@ local bit_operators = {
    ["<<"] = "lshift",
 }
 
+
+local function shadow_control_var(node, control_var)
+   if #node.body == 0 then
+      return
+   end
+   local stmt = node_at(node, {
+      kind = "local_declaration",
+      vars = node_at(node, {
+         kind = "variable_list",
+         node_at(node, { kind = "variable", is_lvalue = true, tk = control_var }),
+      }),
+      exps = node_at(node, {
+         kind = "expression_list",
+         node_at(node, { kind = "variable", tk = control_var }),
+      }),
+   })
+   table.insert(node.body, 1, stmt)
+end
+
 local function adjust_code(ast, needs_compat, gen_compat, gen_target)
    local visit = false
 
@@ -246,24 +265,15 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
       visit = true
       visit_node.cbs["forin"] = {
          after = function(_, node, _children)
-            if #node.body == 0 then
-               return
-            end
             if node.forin_modifies_control_var then
-               local control_var = node.vars[1].tk
-               local loc_at = node
-               local stmt = node_at(loc_at, {
-                  kind = "local_declaration",
-                  vars = node_at(loc_at, {
-                     kind = "variable_list",
-                     node_at(loc_at, { kind = "variable", is_lvalue = true, tk = control_var }),
-                  }),
-                  exps = node_at(loc_at, {
-                     kind = "expression_list",
-                     node_at(loc_at, { kind = "variable", tk = control_var }),
-                  }),
-               })
-               table.insert(node.body, 1, stmt)
+               shadow_control_var(node, node.vars[1].tk)
+            end
+         end,
+      }
+      visit_node.cbs["fornum"] = {
+         after = function(_, node, _children)
+            if node.fornum_modifies_control_var then
+               shadow_control_var(node, node.var.tk)
             end
          end,
       }

--- a/teal/gen/lua_compat.tl
+++ b/teal/gen/lua_compat.tl
@@ -117,6 +117,25 @@ local bit_operators: {string:string} = {
    ["<<"] = "lshift",
 }
 
+-- shadow var function
+local function shadow_control_var(node: Node, control_var: string)
+   if #node.body == 0 then
+      return
+   end
+   local stmt = node_at(node, {
+      kind = "local_declaration",
+      vars = node_at(node, {
+         kind = "variable_list",
+         node_at(node, { kind = "variable", is_lvalue = true, tk = control_var }),
+      }),
+      exps = node_at(node, {
+         kind = "expression_list",
+         node_at(node, { kind = "variable", tk = control_var }),
+      }),
+   })
+   table.insert(node.body, 1, stmt)
+end
+
 local function adjust_code(ast: Node, needs_compat: {string:boolean}, gen_compat: GenCompat, gen_target: string)
    local visit = false
 
@@ -246,24 +265,15 @@ local function adjust_code(ast: Node, needs_compat: {string:boolean}, gen_compat
       visit = true
       visit_node.cbs["forin"] = {
          after = function(_: nil, node: Node, _children: {nil}): nil
-            if #node.body == 0 then
-               return
-            end
             if node.forin_modifies_control_var then
-               local control_var = node.vars[1].tk
-               local loc_at = node
-               local stmt = node_at(loc_at, {
-                  kind = "local_declaration",
-                  vars = node_at(loc_at, {
-                     kind = "variable_list",
-                     node_at(loc_at, { kind = "variable", is_lvalue = true, tk = control_var }),
-                  }),
-                  exps = node_at(loc_at, {
-                     kind = "expression_list",
-                     node_at(loc_at, { kind = "variable", tk = control_var }),
-                  }),
-               })
-               table.insert(node.body, 1, stmt)
+               shadow_control_var(node, node.vars[1].tk)
+            end
+         end,
+      }
+      visit_node.cbs["fornum"] = {
+         after = function(_: nil, node: Node, _children: {nil}): nil
+            if node.fornum_modifies_control_var then
+               shadow_control_var(node, node.var.tk)
             end
          end,
       }

--- a/tl.lua
+++ b/tl.lua
@@ -492,6 +492,7 @@ local parse_typeargs_if_any
 
 
 
+
 local ast = {}
 
 
@@ -8740,7 +8741,14 @@ visit_node.cbs = {
          "number"
          self:add_var(node.var, node.var.tk, a_type(node.var, typename, {}))
       end,
-      after = end_scope_and_none_type,
+      after = function(self, node, _children)
+         local var = self:find_var(node.var.tk)
+         if var and var.has_been_written_to then
+            node.fornum_modifies_control_var = true
+         end
+         self:end_scope(node)
+         return NONE
+      end,
    },
    ["return"] = {
       before = function(self, node)
@@ -11408,6 +11416,25 @@ local bit_operators = {
    ["<<"] = "lshift",
 }
 
+
+local function shadow_control_var(node, control_var)
+   if #node.body == 0 then
+      return
+   end
+   local stmt = node_at(node, {
+      kind = "local_declaration",
+      vars = node_at(node, {
+         kind = "variable_list",
+         node_at(node, { kind = "variable", is_lvalue = true, tk = control_var }),
+      }),
+      exps = node_at(node, {
+         kind = "expression_list",
+         node_at(node, { kind = "variable", tk = control_var }),
+      }),
+   })
+   table.insert(node.body, 1, stmt)
+end
+
 local function adjust_code(ast, needs_compat, gen_compat, gen_target)
    local visit = false
 
@@ -11537,24 +11564,15 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
       visit = true
       visit_node.cbs["forin"] = {
          after = function(_, node, _children)
-            if #node.body == 0 then
-               return
-            end
             if node.forin_modifies_control_var then
-               local control_var = node.vars[1].tk
-               local loc_at = node
-               local stmt = node_at(loc_at, {
-                  kind = "local_declaration",
-                  vars = node_at(loc_at, {
-                     kind = "variable_list",
-                     node_at(loc_at, { kind = "variable", is_lvalue = true, tk = control_var }),
-                  }),
-                  exps = node_at(loc_at, {
-                     kind = "expression_list",
-                     node_at(loc_at, { kind = "variable", tk = control_var }),
-                  }),
-               })
-               table.insert(node.body, 1, stmt)
+               shadow_control_var(node, node.vars[1].tk)
+            end
+         end,
+      }
+      visit_node.cbs["fornum"] = {
+         after = function(_, node, _children)
+            if node.fornum_modifies_control_var then
+               shadow_control_var(node, node.var.tk)
             end
          end,
       }


### PR DESCRIPTION
Closes #1164. Option 1, as decided in the issue: mirror the `forin` shadow
rather than making numeric control variables const in all targets.

## Problem

`lua_compat.adjust_code` only had a `forin` case, so plain (non-macro) code that
writes to a numeric `for` variable type checks and then generates invalid Lua:

```lua
local t: {string} = { "a", "b", "c" }

for i = 1, #t do
   i = i + 0
   print(t[i])
end
```

```
$ lua5.5 ./tl run fornum.tl
Internal Compiler Error: Teal generator produced invalid Lua. Please report a bug at https://github.com/teal-language/tl

fornum.tl:3: attempt to assign to const variable 'i'
```

## Change

- `teal/ast.tl` — `fornum_modifies_control_var` on `Node`.
- `teal/check/visitors.tl` — the `fornum` visitor sets it from
  `has_been_written_to`, the same way `forin` does, so writes from nested
  functions are covered too.
- `teal/gen/lua_compat.tl` — a `fornum` case. The shadow construction that was
  inlined in the `forin` case is factored out into `shadow_control_var()` and
  shared; the new case is six lines.

The shadow is a no-op in every target, since writing to a numeric `for` variable
has never affected the iteration:

```
$ lua5.1 -e 'for i=1,3 do i = i + 100; io.write(i," ") end'
101 102 103
```

## Tests

`spec/lang/code_gen/fornum_spec.lua`, deliberately parallel to `forin_spec.lua`:
no shadow on 5.3, a shadow on 5.4 when the body assigns, none when it does not,
a loop with an explicit step, an assignment made from a nested function, and
nested loops where only the inner one is written to.

`make selfbuild` clean, `busted --suppress-pending spec/` 1932 → 1938. The
reproduction above was verified end to end on Lua 5.5.1.