### PR TITLE
ci: add Lua 5.5 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   Test:
     strategy:
       matrix:
-        lua-version: ["5.4", "5.3", "5.2", "5.1", "luajit"]
+        lua-version: [ "5.5", "5.4", "5.3", "5.2", "5.1", "luajit"]
         os: ["ubuntu-latest"]
         include:
         - os: "macos-latest"

--- a/luarocks.lock
+++ b/luarocks.lock
@@ -1,8 +1,8 @@
 return {
    dependencies = {
-      argparse = "0.7.1-1",
-      compat53 = "0.14.4-1",
-      luafilesystem = "1.8.0-1"
+      argparse = "0.7.2-1",
+      compat53 = "0.15.1-1",
+      luafilesystem = "1.9.0-1"
    },
    test_dependencies = {
       luasystem = "0.2.1"


### PR DESCRIPTION
Lua 5.5 has been out since December, and it is the one version CI does not
build. All four 5.5 issues so far surfaced from user reports rather than from a
failing build.

Teal already passes on it. On Lua 5.5.1 with LuaRocks 3.13.0:

```
make selfbuild                        clean, no diff between stages
busted --suppress-pending spec/       1939 successes / 0 failures / 0 errors
```

Every rock dependency installs, including the C ones (`luafilesystem`,
`luasystem`), and `luarocks.org` serves `manifest-5.5`.

So this is not a fix — it just makes CI check what already works, so the next
regression is caught before a release instead of after one.