### PR TITLE
fix: emit bxor, not bnot, for binary '~' with --gen-target 5.1

### DIFF
--- a/spec/lang/compat/lua_versions_spec.lua
+++ b/spec/lang/compat/lua_versions_spec.lua
@@ -30,6 +30,20 @@ describe("Lua version compatibility", function()
       local x = bit32.band(2, (bit32.bor(bit32.rshift(c, bit32.bnot(4)), 0xff)))
    ]], "5.1"))
 
+   it("distinguishes unary and binary '~' operators", util.gen([[
+
+
+      local c = 0xcafebabe
+      local x = c ~ 0xff
+      local y = ~c ~ c
+   ]], [[
+      local bit32 = bit32; if not bit32 then local p, m = pcall(require, 'bit32'); if p then bit32 = m end end
+
+      local c = 0xcafebabe
+      local x = bit32.bxor(c, 0xff)
+      local y = bit32.bxor(bit32.bnot(c), c)
+   ]], "5.1"))
+
    it("generates compat code for bitwise unary operator metamethods", util.gen([[
 
       local type Rec = record
@@ -98,6 +112,42 @@ describe("Lua version compatibility", function()
       local s = setmetatable({}, rec_mt)
 
       print(_tl_mt("__shl", 1, r, s))
+   ]], "5.1"))
+
+   it("generates compat code for the binary '~' operator metamethod", util.gen([[
+
+      local type Rec = record
+         x: number
+         metamethod __bxor: function(Rec, Rec): number
+      end
+
+      local rec_mt: metatable<Rec> = {
+         __bxor = function(a: Rec, b: Rec): number
+            return a.x + b.x
+         end
+      }
+
+      local r = setmetatable({} as Rec, rec_mt)
+      local s = setmetatable({} as Rec, rec_mt)
+
+      print(r ~ s)
+   ]], [[
+      local _tl_mt = function(m, s, a, b) return (getmetatable(s == 1 and a or b)[m](a, b)) end
+
+
+
+
+
+      local rec_mt = {
+         __bxor = function(a, b)
+            return a.x + b.x
+         end,
+      }
+
+      local r = setmetatable({}, rec_mt)
+      local s = setmetatable({}, rec_mt)
+
+      print(_tl_mt("__bxor", 1, r, s))
    ]], "5.1"))
 
    -- varargs

--- a/spec/util.lua
+++ b/spec/util.lua
@@ -743,12 +743,12 @@ local function gen(lax, code, expected, gen_target, type_errors)
          local expected_code = util.dedent(expected):match("^(.-)%s*$")
 
          local expected_lines = {}
-         for line in expected_code:gmatch("([^\n]*)\n") do
+         for line in expected_code:gmatch("([^\n]*)\n?") do
            table.insert(expected_lines, line)
          end
 
          local output_lines = {}
-         for line in output_code:gmatch("([^\n]*)\n") do
+         for line in output_code:gmatch("([^\n]*)\n?") do
            table.insert(output_lines, line)
          end
 

--- a/teal.lua
+++ b/teal.lua
@@ -11277,7 +11277,8 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
                      needs_compat[key] = true
                   end
                end
-            elseif node.op.op == "~" and gen_target == "5.1" then
+
+            elseif node.op.op == "~" and node.op.arity == 1 and gen_target == "5.1" then
                if node.op.meta_on_operand then
                   needs_compat["mt"] = true
                   convert_node_to_compat_mt_call(node, unop_to_metamethod[node.op.op], 1, node.e1)

--- a/teal/gen/lua_compat.lua
+++ b/teal/gen/lua_compat.lua
@@ -231,7 +231,8 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
                      needs_compat[key] = true
                   end
                end
-            elseif node.op.op == "~" and gen_target == "5.1" then
+
+            elseif node.op.op == "~" and node.op.arity == 1 and gen_target == "5.1" then
                if node.op.meta_on_operand then
                   needs_compat["mt"] = true
                   convert_node_to_compat_mt_call(node, unop_to_metamethod[node.op.op], 1, node.e1)

--- a/teal/gen/lua_compat.tl
+++ b/teal/gen/lua_compat.tl
@@ -231,7 +231,8 @@ local function adjust_code(ast: Node, needs_compat: {string:boolean}, gen_compat
                      needs_compat[key] = true
                   end
                end
-            elseif node.op.op == "~" and gen_target == "5.1" then
+            -- unary '~' only; binary '~' is bxor, handled below
+            elseif node.op.op == "~" and node.op.arity == 1 and gen_target == "5.1" then
                if node.op.meta_on_operand then
                   needs_compat["mt"] = true
                   convert_node_to_compat_mt_call(node, unop_to_metamethod[node.op.op], 1, node.e1)

--- a/tl.lua
+++ b/tl.lua
@@ -11531,7 +11531,8 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
                      needs_compat[key] = true
                   end
                end
-            elseif node.op.op == "~" and gen_target == "5.1" then
+
+            elseif node.op.op == "~" and node.op.arity == 1 and gen_target == "5.1" then
                if node.op.meta_on_operand then
                   needs_compat["mt"] = true
                   convert_node_to_compat_mt_call(node, unop_to_metamethod[node.op.op], 1, node.e1)


### PR DESCRIPTION
`~` is both unary bitwise NOT and binary bitwise XOR, but the 5.1 compat pass in `teal/gen/lua_compat.tl` matches on the operator token alone, so the unary branch swallows the binary one.

```lua
local function f(a: integer, b: integer): integer
   return a ~ b
end
```

`tl gen --gen-target 5.1` before / after:

```lua
   return bit32.bnot(a)     -- before
   return bit32.bxor(a, b)  -- after
```

The right operand is dropped and the operation changes, silently: the checker accepts it as `integer` and the output is still valid Lua. `&`, `|`, `<<` and `>>` are all correct; `~` is the only one of the five with a same-token unary form. The metamethod path splits the same way, sending `a ~ b` on a record with `__bxor` to `__bnot` with one argument.

The fix is an arity check, so binary `~` falls through to the existing `bit_operators` branch, which already maps `~` to `bxor` and `__bxor`.

Also `spec/util.lua`: `gen()` built its line arrays with `gmatch("([^\n]*)\n")`, which drops the final line, so a `util.gen` mismatch confined to the last line of the output was never reported. That is why the metamethod half stayed invisible, and why the existing `__bnot` metamethod test cannot catch a regression either. With `\n?` the suite is unchanged at 1941 passing, but both halves of this bug now fail it.

Regenerated the `.lua` artifacts with `make`.

Drafted with AI assistance (Claude Opus 5).
