### PR TITLE
fix: resolve type aliases when lowering 'is' to Lua (#1149)

### DIFF
--- a/spec/lang/operator/is_spec.lua
+++ b/spec/lang/operator/is_spec.lua
@@ -452,6 +452,23 @@ if not (r == nil) then
    r.f()
 end]]))
 
+      it("lowers 'is' on a type alias like its underlying type (regression test for #1149)", util.gen([[
+         local x: any = nil
+         local type MyInt = integer
+         local type MyNil = nil
+         print(x is MyInt)
+         print(x is MyNil)
+         print(x is integer)
+         print(x is nil)
+      ]], [[
+local x = nil
+
+
+print(math.type(x) == "integer")
+print(x == nil)
+print(math.type(x) == "integer")
+print(x == nil)]], "5.4"))
+
    end)
 
    describe("on while", function()

--- a/teal.lua
+++ b/teal.lua
@@ -11067,6 +11067,9 @@ local traverse_nodes = traversal.traverse_nodes
 local util = require("teal.util")
 local sorted_keys = util.sorted_keys
 
+local types = require("teal.types")
+
+
 local lua_compat = {}
 
 
@@ -11262,9 +11265,13 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
       visit_node.cbs["op"] = {
          after = function(_, node, _children)
             if node.op.op == "is" then
-               if node.e2.casttype.typename == "integer" then
+               local ct = node.e2.casttype
+               while ct.typename == "nominal" and ct.resolved do
+                  ct = ct.resolved
+               end
+               if ct.typename == "integer" then
                   needs_compat["math"] = true
-               elseif node.e2.casttype.typename ~= "nil" then
+               elseif ct.typename ~= "nil" then
                   needs_compat["type"] = true
                end
             elseif node.op.op == "." then
@@ -11985,11 +11992,15 @@ function lua_generator.generate(ast, gen_target, opts)
             elseif node.op.op == "as" then
                add_child(out, children[1], "", indent)
             elseif node.op.op == "is" then
-               if node.e2.casttype.typename == "integer" then
+               local ct = node.e2.casttype
+               while ct.typename == "nominal" and ct.resolved do
+                  ct = ct.resolved
+               end
+               if ct.typename == "integer" then
                   table.insert(out, "math.type(")
                   add_child(out, children[1], "", indent)
                   table.insert(out, ") == \"integer\"")
-               elseif node.e2.casttype.typename == "nil" then
+               elseif ct.typename == "nil" then
                   add_child(out, children[1], "", indent)
                   table.insert(out, " == nil")
                else

--- a/teal/gen/lua_compat.lua
+++ b/teal/gen/lua_compat.lua
@@ -21,6 +21,9 @@ local traverse_nodes = traversal.traverse_nodes
 local util = require("teal.util")
 local sorted_keys = util.sorted_keys
 
+local types = require("teal.types")
+
+
 local lua_compat = {}
 
 
@@ -216,9 +219,13 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
       visit_node.cbs["op"] = {
          after = function(_, node, _children)
             if node.op.op == "is" then
-               if node.e2.casttype.typename == "integer" then
+               local ct = node.e2.casttype
+               while ct.typename == "nominal" and ct.resolved do
+                  ct = ct.resolved
+               end
+               if ct.typename == "integer" then
                   needs_compat["math"] = true
-               elseif node.e2.casttype.typename ~= "nil" then
+               elseif ct.typename ~= "nil" then
                   needs_compat["type"] = true
                end
             elseif node.op.op == "." then

--- a/teal/gen/lua_compat.tl
+++ b/teal/gen/lua_compat.tl
@@ -21,6 +21,9 @@ local traverse_nodes = traversal.traverse_nodes
 local util = require("teal.util")
 local sorted_keys = util.sorted_keys
 
+local types = require("teal.types")
+local type NominalType = types.NominalType
+
 local record lua_compat
 end
 
@@ -216,9 +219,13 @@ local function adjust_code(ast: Node, needs_compat: {string:boolean}, gen_compat
       visit_node.cbs["op"] = {
          after = function(_: nil, node: Node, _children: {nil}): nil
             if node.op.op == "is" then
-               if node.e2.casttype.typename == "integer" then
+               local ct = node.e2.casttype
+               while ct is NominalType and ct.resolved do
+                  ct = ct.resolved
+               end
+               if ct.typename == "integer" then
                   needs_compat["math"] = true
-               elseif node.e2.casttype.typename ~= "nil" then
+               elseif ct.typename ~= "nil" then
                   needs_compat["type"] = true
                end
             elseif node.op.op == "." then

--- a/teal/gen/lua_generator.lua
+++ b/teal/gen/lua_generator.lua
@@ -626,11 +626,15 @@ function lua_generator.generate(ast, gen_target, opts)
             elseif node.op.op == "as" then
                add_child(out, children[1], "", indent)
             elseif node.op.op == "is" then
-               if node.e2.casttype.typename == "integer" then
+               local ct = node.e2.casttype
+               while ct.typename == "nominal" and ct.resolved do
+                  ct = ct.resolved
+               end
+               if ct.typename == "integer" then
                   table.insert(out, "math.type(")
                   add_child(out, children[1], "", indent)
                   table.insert(out, ") == \"integer\"")
-               elseif node.e2.casttype.typename == "nil" then
+               elseif ct.typename == "nil" then
                   add_child(out, children[1], "", indent)
                   table.insert(out, " == nil")
                else

--- a/teal/gen/lua_generator.tl
+++ b/teal/gen/lua_generator.tl
@@ -626,11 +626,15 @@ function lua_generator.generate(ast: Node, gen_target: GenTarget, opts?: Options
             elseif node.op.op == "as" then
                add_child(out, children[1], "", indent)
             elseif node.op.op == "is" then
-               if node.e2.casttype.typename == "integer" then
+               local ct = node.e2.casttype
+               while ct is NominalType and ct.resolved do
+                  ct = ct.resolved
+               end
+               if ct.typename == "integer" then
                   table.insert(out, "math.type(")
                   add_child(out, children[1], "", indent)
                   table.insert(out, ") == \"integer\"")
-               elseif node.e2.casttype.typename == "nil" then
+               elseif ct.typename == "nil" then
                   add_child(out, children[1], "", indent)
                   table.insert(out, " == nil")
                else

--- a/tl.lua
+++ b/tl.lua
@@ -11321,6 +11321,9 @@ local traverse_nodes = traversal.traverse_nodes
 local util = require("teal.util")
 local sorted_keys = util.sorted_keys
 
+local types = require("teal.types")
+
+
 local lua_compat = {}
 
 
@@ -11516,9 +11519,13 @@ local function adjust_code(ast, needs_compat, gen_compat, gen_target)
       visit_node.cbs["op"] = {
          after = function(_, node, _children)
             if node.op.op == "is" then
-               if node.e2.casttype.typename == "integer" then
+               local ct = node.e2.casttype
+               while ct.typename == "nominal" and ct.resolved do
+                  ct = ct.resolved
+               end
+               if ct.typename == "integer" then
                   needs_compat["math"] = true
-               elseif node.e2.casttype.typename ~= "nil" then
+               elseif ct.typename ~= "nil" then
                   needs_compat["type"] = true
                end
             elseif node.op.op == "." then
@@ -12239,11 +12246,15 @@ function lua_generator.generate(ast, gen_target, opts)
             elseif node.op.op == "as" then
                add_child(out, children[1], "", indent)
             elseif node.op.op == "is" then
-               if node.e2.casttype.typename == "integer" then
+               local ct = node.e2.casttype
+               while ct.typename == "nominal" and ct.resolved do
+                  ct = ct.resolved
+               end
+               if ct.typename == "integer" then
                   table.insert(out, "math.type(")
                   add_child(out, children[1], "", indent)
                   table.insert(out, ") == \"integer\"")
-               elseif node.e2.casttype.typename == "nil" then
+               elseif ct.typename == "nil" then
                   add_child(out, children[1], "", indent)
                   table.insert(out, " == nil")
                else


### PR DESCRIPTION
## What

Closes #1149.

`x is SomeType` compiles to a runtime type check. When the tested type is a **type alias**, the code generator inspected the nominal type's own `typename` (`"nominal"`) instead of the type it resolves to, so `integer` and `nil` aliases were lowered like a generic `type(x) == "..."` check.

```lua
local x: any = nil
local type A = integer
print(x is A)   -- was: type(x) == "number"   (wrong)
local type B = nil
print(x is B)   -- was: type(x) == "nil"      (wrong)
```

`x is A` should lower to `math.type(x) == "integer"` (a `number` may be a float, not an integer), and `x is B` to `x == nil` — exactly what `x is integer` / `x is nil` already produce.

## Fix

In both `is`-lowering sites (`teal/gen/lua_generator.tl` and the 5.1/5.3 compat header selection in `teal/gen/lua_compat.tl`), resolve the cast type through its nominal chain before discriminating on `integer` / `nil`. Chained aliases (`local type C = A`) resolve too.

## Tests

Added a `util.gen` regression test in `spec/lang/operator/is_spec.lua` asserting alias and direct forms lower identically.

Verified genuine RED→GREEN: reverting the source fix (keeping the test) makes it fail with `type(x) == "number"` vs the expected `math.type(x) == "integer"`; restoring it passes.

## Validation

```
make selfbuild            # two-stage bootstrap diff clean
busted spec/lang          # 1733 successes / 0 failures
busted spec/api           # 96 successes / 0 failures
busted spec/cli           # 112 successes / 0 failures
```

Regenerated `.lua` artifacts via `make selfbuild` so the committed build matches the `.tl` sources. Happy to adjust.
